### PR TITLE
Run dfu-convert.py with Python 2

### DIFF
--- a/scripts/targets.mk
+++ b/scripts/targets.mk
@@ -44,7 +44,7 @@ $(PROG).bin: $(PROG).elf
 	@$(if $(QUIET), ,echo $(BIN_COMMAND$(VERBOSE)) )
 	@$(BIN_COMMAND)
 
-DFU_COMMAND=python scripts/dfu-convert.py -b $(LOAD_ADDRESS):$< $@
+DFU_COMMAND=$(PYTHON2) scripts/dfu-convert.py -b $(LOAD_ADDRESS):$< $@
 DFU_COMMAND_SILENT="  DFUse $@"
 $(PROG).dfu: $(PROG).bin
 	@$(if $(QUIET), ,echo $(DFU_COMMAND$(VERBOSE)) )


### PR DESCRIPTION
On Arch Linux, Python 3 is default.

An even better solution would be to support both Python 2 and 3 with the script. Maye I'll port it sometime (although there are probably quite some other scripts that are also Py2 only).