### PR TITLE
This commit adds support for logging RSSI samples

### DIFF
--- a/hal/interface/syslink.h
+++ b/hal/interface/syslink.h
@@ -44,6 +44,7 @@
 #define SYSLINK_RADIO_CHANNEL  0x01
 #define SYSLINK_RADIO_DATARATE 0x02
 #define SYSLINK_RADIO_CONTWAVE 0x03
+#define SYSLINK_RADIO_RSSI     0x04
 
 #define SYSLINK_PM_GROUP              0x10
 #define SYSLINK_PM_SOURCE             0x10

--- a/hal/src/radiolink.c
+++ b/hal/src/radiolink.c
@@ -48,7 +48,7 @@ static int radiolinkSetEnable(bool enable);
 static int radiolinkReceiveCRTPPacket(CRTPPacket *p);
 
 //Local RSSI variable used to enable logging of RSSI values from Radio
-static uint32_t rssi;
+static uint8_t rssi;
 
 static struct crtpLinkOperations radiolinkOp =
 {
@@ -111,7 +111,7 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
   } else if (slp->type == SYSLINK_RADIO_RSSI)
 	{
 		//Extract RSSI sample sent from radio
-		memcpy(&rssi, slp->data, sizeof(uint32_t));
+		memcpy(&rssi, slp->data, sizeof(uint8_t));
 	}
 }
 
@@ -149,5 +149,5 @@ static int radiolinkSetEnable(bool enable)
 }
 
 LOG_GROUP_START(radio)
-LOG_ADD(LOG_UINT32, rssi, &rssi)
+LOG_ADD(LOG_UINT8, rssi, &rssi)
 LOG_GROUP_STOP(radio)

--- a/hal/src/radiolink.c
+++ b/hal/src/radiolink.c
@@ -37,6 +37,7 @@
 #include "syslink.h"
 #include "crtp.h"
 #include "configblock.h"
+#include "log.h"
 
 static xQueueHandle crtpPacketDelivery;
 
@@ -45,6 +46,9 @@ static bool isInit;
 static int radiolinkSendCRTPPacket(CRTPPacket *p);
 static int radiolinkSetEnable(bool enable);
 static int radiolinkReceiveCRTPPacket(CRTPPacket *p);
+
+//Local RSSI variable used to enable logging of RSSI values from Radio
+static uint32_t rssi;
 
 static struct crtpLinkOperations radiolinkOp =
 {
@@ -104,7 +108,11 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
   {
     slp->length--; // Decrease to get CRTP size.
     xQueueSend(crtpPacketDelivery, &slp->length, 0);
-  }
+  } else if (slp->type == SYSLINK_RADIO_RSSI)
+	{
+		//Extract RSSI sample sent from radio
+		memcpy(&rssi, slp->data, sizeof(uint32_t));
+	}
 }
 
 static int radiolinkReceiveCRTPPacket(CRTPPacket *p)
@@ -139,3 +147,7 @@ static int radiolinkSetEnable(bool enable)
 {
   return 0;
 }
+
+LOG_GROUP_START(radio)
+LOG_ADD(LOG_UINT32, rssi, &rssi)
+LOG_GROUP_STOP(radio)


### PR DESCRIPTION
After updating the firmware on the radio this commit adds support for
those messages to the STM32. The only things this commit does is add a
new constant to match what is sent from the radio and logging of those
samples.

Note: This pull request is intended to work with https://github.com/bitcraze/crazyflie2-nrf-firmware/pull/1