### PR TITLE
Add option to set device address.

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -109,6 +109,7 @@
 //The radio channel. From 0 to 125
 #define RADIO_CHANNEL 80
 #define RADIO_DATARATE RADIO_RATE_250K
+#define RADIO_ADDRESS 0xE7E7E7E7E7ULL
 
 // Define to force initialization of expansion board drivers. For test-rig and programming.
 //#define FORCE_EXP_DETECT

--- a/hal/interface/radiolink.h
+++ b/hal/interface/radiolink.h
@@ -35,6 +35,7 @@ void radioInit(void);
 bool radioTest(void);
 void radiolinkSetChannel(uint8_t channel);
 void radiolinkSetDatarate(uint8_t datarate);
+void radiolinkSetAddress(uint64_t address);
 void radiolinkSyslinkDispatch(SyslinkPacket *slp);
 struct crtpLinkOperations * radiolinkGetLink();
 

--- a/hal/interface/syslink.h
+++ b/hal/interface/syslink.h
@@ -44,6 +44,7 @@
 #define SYSLINK_RADIO_DATARATE 0x02
 #define SYSLINK_RADIO_CONTWAVE 0x03
 #define SYSLINK_RADIO_RSSI     0x04
+#define SYSLINK_RADIO_ADDRESS  0x05
 
 #define SYSLINK_PM_GROUP              0x10
 #define SYSLINK_PM_SOURCE             0x10

--- a/hal/src/radiolink.c
+++ b/hal/src/radiolink.c
@@ -80,6 +80,7 @@ void radiolinkInit(void)
 
   radiolinkSetChannel(configblockGetRadioChannel());
   radiolinkSetDatarate(configblockGetRadioSpeed());
+  radiolinkSetAddress(configblockGetRadioAddress());
 
   isInit = true;
 }
@@ -108,6 +109,17 @@ void radiolinkSetDatarate(uint8_t datarate)
   slp.data[0] = datarate;
   syslinkSendPacket(&slp);
 }
+
+void radiolinkSetAddress(uint64_t address)
+{
+  SyslinkPacket slp;
+
+  slp.type = SYSLINK_RADIO_ADDRESS;
+  slp.length = 5;
+  memcpy(&slp.data[0], &address, 5);
+  syslinkSendPacket(&slp);
+}
+
 
 void radiolinkSyslinkDispatch(SyslinkPacket *slp)
 {

--- a/utils/interface/configblock.h
+++ b/utils/interface/configblock.h
@@ -35,6 +35,7 @@ bool configblockTest(void);
 /* Static accessors */
 int configblockGetRadioChannel(void);
 int configblockGetRadioSpeed(void);
+uint64_t configblockGetRadioAddress(void);
 
 float configblockGetCalibPitch(void);
 float configblockGetCalibRoll(void);

--- a/utils/src/configblockeeprom.c
+++ b/utils/src/configblockeeprom.c
@@ -38,7 +38,7 @@
 
 /* Internal format of the config block */
 #define MAGIC 0x43427830
-#define VERSION 0
+#define VERSION 1
 struct configblock_s {
   /* header */
   uint32_t magic;
@@ -48,6 +48,8 @@ struct configblock_s {
   uint8_t radioSpeed;
   float calibPitch;
   float calibRoll;
+  uint8_t radioAddress_upper;
+  uint32_t radioAddress_lower;
   /* Simple modulo 256 checksum */
   uint8_t cksum;
 } __attribute__((__packed__));
@@ -57,10 +59,12 @@ static struct configblock_s configblockDefault =
 {
     .magic = MAGIC,
     .version = VERSION,
-    .radioChannel = 80,
-    .radioSpeed = 0,
+    .radioChannel = RADIO_CHANNEL,
+    .radioSpeed = RADIO_DATARATE,
     .calibPitch = 0.0,
     .calibRoll = 0.0,
+    .radioAddress_upper = ((uint64_t)RADIO_ADDRESS >> 32),
+    .radioAddress_lower = (RADIO_ADDRESS & 0xFFFFFFFFULL),
 };
 
 static bool isInit = false;
@@ -133,6 +137,14 @@ int configblockGetRadioSpeed(void)
     return configblock.radioSpeed;
   else
     return RADIO_DATARATE;
+}
+
+uint64_t configblockGetRadioAddress(void)
+{
+  if (cb_ok)
+    return ((uint64_t)configblock.radioAddress_upper << 32) | (uint64_t)configblock.radioAddress_lower;
+  else
+    return RADIO_ADDRESS;
 }
 
 float configblockGetCalibPitch(void)


### PR DESCRIPTION
This is part 3 of the effort of improving the multi-flie support by allowing custom device addresses.
Please see https://github.com/bitcraze/crazyflie-clients-python/pull/161 for the matching UI changes.
Please see https://github.com/bitcraze/crazyflie2-nrf-firmware/pull/2 for the matching NRF changes.

The changes include:
* Update eeprom configurationblock to include 5 additional bytes for the device address
* communicate the device address to NRF51 via syslink interface (requires updated nrf firmware)