### PR TITLE
Debug newlines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/*
 config.mk
 cflie.*
 version.c
+*.swp

--- a/hal/src/imu_cf1.c
+++ b/hal/src/imu_cf1.c
@@ -223,7 +223,7 @@ bool imu6Test(void)
 
   if (!isInit)
   {
-    DEBUG_PRINT("Uninitialized");
+    DEBUG_PRINT("Uninitialized\n");
     testStatus = false;
   }
 #if defined (IMU_ENABLE_MAG_HMC5883) && defined (IMU_ENABLE_PRESSURE_MS5611)
@@ -231,7 +231,7 @@ bool imu6Test(void)
   if((isHmc5883lPresent && !isMs5611Present) ||
      (!isHmc5883lPresent && isMs5611Present))
   {
-    DEBUG_PRINT("HMC5883L or MS5611 is not responding");
+    DEBUG_PRINT("HMC5883L or MS5611 is not responding\n");
     testStatus = false;
   }
 #endif

--- a/hal/src/imu_cf2.c
+++ b/hal/src/imu_cf2.c
@@ -239,7 +239,7 @@ bool imu6Test(void)
 
   if (!isInit)
   {
-    DEBUG_PRINT("Uninitialized");
+    DEBUG_PRINT("Uninitialized\n");
     testStatus = false;
   }
 


### PR DESCRIPTION
Some newlines were missing in debug output, making a mess out of it.

Btw, some of the files (like `hal/src/imu_cf*`) have DOS line endings. Is that on purpose? If not, a conversion of all files would make sense. Right now git diff looks a bit messy with all those `^M` in them.