### PR TITLE
Make the LED-ring deck white spin effect really white, not green

### DIFF
--- a/modules/src/neopixelring.c
+++ b/modules/src/neopixelring.c
@@ -134,7 +134,7 @@ static void whiteSpinEffect(uint8_t buffer[][3], bool reset)
   if (reset)
   {
     for (i=0; i<NBR_LEDS; i++) {
-      COPY_COLOR(buffer[i], greenRing[i]);
+      COPY_COLOR(buffer[i], whiteRing[i]);
     }
   }
 


### PR DESCRIPTION
In both crazyflie firmware and python client this effect is named "white", while it actually uses green color. So I changed it to refer the whiteRing intead of greenRing color array.