### PR TITLE
Deck analog API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ PROJ_OBJ_CF2 += neopixelring.o expbrd.o platformservice.o
 
 # Expansion boards
 PROJ_OBJ_CF2 += exptest.o
+PROJ_OBJ_CF2 += deck_constants.o
 PROJ_OBJ_CF2 += deck_digital.o
 PROJ_OBJ_CF2 += deck_analog.o
 

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ PROJ_OBJ_CF2 += neopixelring.o expbrd.o platformservice.o
 # Expansion boards
 PROJ_OBJ_CF2 += exptest.o
 PROJ_OBJ_CF2 += deck_digital.o
+PROJ_OBJ_CF2 += deck_analog.o
 
 # Utilities
 PROJ_OBJ += filter.o cpuid.o cfassert.o  eprintf.o crc.o fp16.o debug.o

--- a/deck/api/deck_analog.c
+++ b/deck/api/deck_analog.c
@@ -1,0 +1,159 @@
+/*
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2015 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * deck_analog.c - Arduino-compatible analog input implementation
+ */
+
+#include "deck.h"
+
+#include "stm32fxxx.h"
+
+// Mapping between Pin number and real GPIO
+// TODO: Copy of identical struct in deck_digital.c - should be shared
+const struct {
+  uint32_t periph;
+  GPIO_TypeDef* port;
+  uint16_t pin;
+} gpioMapping2[13] = {
+  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_11},
+  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_10},
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_7},
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_6},
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_8},
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_5},
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_4},
+  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_12},
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_2},
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_3},
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_5},
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_6},
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_7},
+};
+
+/* TODO: Merged as extra column into the gpioMapping struct? */
+const struct {
+    int8_t adcCh; /* -1 means no ADC available for this pin. */
+} adcMapping[13] = {
+    {.adcCh=-1},            /* RX1 */
+    {.adcCh=-1},            /* TX1 */
+    {.adcCh=-1},            /* SDA */
+    {.adcCh=-1},            /* SCL */
+    {.adcCh=-1},            /* IO1 */
+    {.adcCh=-1},            /* IO2 */
+    {.adcCh=-1},            /* IO3 */
+    {.adcCh=-1},            /* IO4 */
+    {.adcCh=ADC_Channel_2}, /* TX2 */
+    {.adcCh=ADC_Channel_3}, /* RX2 */
+    {.adcCh=ADC_Channel_5}, /* SCK */
+    {.adcCh=ADC_Channel_6}, /* MISO */
+    {.adcCh=ADC_Channel_7}, /* MOSI */
+};
+
+void adcInit(void)
+{
+  /*
+   * Note: This function initializes only ADC1, and only for single channel, single conversion mode. No DMA, no interrupts, no bells or whistles.
+   */
+
+  /* Note that this de-initializes registers for all ADCs (ADCx) */
+  // ADC_DeInit();
+
+  /* Define ADC init structures */
+  ADC_InitTypeDef       ADC_InitStructure;
+  ADC_CommonInitTypeDef ADC_CommonInitStructure;
+
+  /* IMPORTANT: populates structures with reset values */
+  ADC_StructInit(&ADC_InitStructure);
+  ADC_CommonStructInit(&ADC_CommonInitStructure);
+
+  /* enable ADC clock */
+  RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
+
+  /* init ADCs in independent mode, div clock by two */
+  ADC_CommonInitStructure.ADC_Mode = ADC_Mode_Independent;
+  ADC_CommonInitStructure.ADC_Prescaler = ADC_Prescaler_Div2;
+  ADC_CommonInitStructure.ADC_DMAAccessMode = ADC_DMAAccessMode_Disabled;
+  ADC_CommonInitStructure.ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_5Cycles;
+  ADC_CommonInit(&ADC_CommonInitStructure);
+
+  /* init ADC1: 10bit, single-conversion for Arduino compatibility */
+  ADC_InitStructure.ADC_Resolution = ADC_Resolution_10b;
+  ADC_InitStructure.ADC_ScanConvMode = DISABLE;
+  ADC_InitStructure.ADC_ContinuousConvMode = DISABLE;
+  ADC_InitStructure.ADC_ExternalTrigConvEdge = 0;
+  ADC_InitStructure.ADC_ExternalTrigConv = 0;
+  ADC_InitStructure.ADC_DataAlign = ADC_DataAlign_Right;
+  ADC_InitStructure.ADC_NbrOfConversion = 1;
+  ADC_Init(ADC1, &ADC_InitStructure);
+
+  /* Enable ADC1 */
+  ADC_Cmd(ADC1, ENABLE);
+}
+
+static uint16_t analogReadChannel(uint8_t channel)
+{
+  ADC_RegularChannelConfig(ADC1, channel, 1, ADC_SampleTime_480Cycles);
+
+  /* Start the conversion */
+  ADC_SoftwareStartConv(ADC1);
+
+  /* Wait until conversion completion */
+  while(ADC_GetFlagStatus(ADC1, ADC_FLAG_EOC) == RESET);
+
+  /* Get the conversion value */
+  return ADC_GetConversionValue(ADC1);
+}
+
+uint16_t analogRead(uint32_t pin)
+{
+  assert_param((pin >= 1) && (pin <= 13));
+  assert_param(adcMapping[pin-1].adcCh > -1);
+
+  /* Now set the GPIO pin to analog mode. */
+
+  /* Enable clock for the peripheral of the pin.*/
+  RCC_AHB1PeriphClockCmd(gpioMapping2[pin-1].periph, ENABLE);
+
+  /* Populate structure with RESET values. */
+  GPIO_InitTypeDef GPIO_InitStructure;
+  GPIO_StructInit(&GPIO_InitStructure);
+
+  /* Initialise the GPIO pin to analog mode. According to the datasheet, only the analog mode needs to be set. */
+  GPIO_InitStructure.GPIO_Pin = gpioMapping2[pin-1].pin;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AN;
+
+  /* TODO: Any settling time before we can do ADC after init on the GPIO pin? */
+  GPIO_Init(gpioMapping2[pin-1].port, &GPIO_InitStructure);
+
+  /* Read the appropriate ADC channel. */
+  return analogReadChannel((uint8_t)adcMapping[pin-1].adcCh);
+}
+
+void analogReference(uint8_t type)
+{
+  /*
+   * TODO: We should probably support the Arduino EXTERNAL type here.
+   * TODO: Figure out which voltage reference to compensate with.
+   */
+  assert_param(type == 0 /* DEFAULT */);
+}

--- a/deck/api/deck_constants.c
+++ b/deck/api/deck_constants.c
@@ -1,0 +1,44 @@
+/*
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2015 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * deck_constants.c - Constants for the Deck API
+ */
+
+#include "deck.h"
+
+/* Mapping between Deck Pin number, real GPIO and ADC channel */
+deckGPIOMapping_t deckGPIOMapping[13] = {
+  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_11, .adcCh=-1},            /* RX1 */
+  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_10, .adcCh=-1},            /* TX1 */
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_7,  .adcCh=-1},            /* SDA */
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_6,  .adcCh=-1},            /* SCL */
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_8,  .adcCh=-1},            /* IO1 */
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_5,  .adcCh=-1},            /* IO2 */
+  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_4,  .adcCh=-1},            /* IO3 */
+  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_12, .adcCh=-1},            /* IO4 */
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_2,  .adcCh=ADC_Channel_2}, /* TX2 */
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_3,  .adcCh=ADC_Channel_3}, /* RX2 */
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_5,  .adcCh=ADC_Channel_5}, /* SCK */
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_6,  .adcCh=ADC_Channel_6}, /* MISO */
+  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_7,  .adcCh=ADC_Channel_7}, /* MOSI */
+};

--- a/deck/api/deck_digital.c
+++ b/deck/api/deck_digital.c
@@ -28,43 +28,22 @@
 
 #include "stm32fxxx.h"
 
-// Mapping between Pin number and real GPIO
-const struct {
-  uint32_t periph;
-  GPIO_TypeDef* port;
-  uint16_t pin;
-} gpioMapping[13] = {
-  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_11},
-  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_10},
-  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_7},
-  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_6},
-  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_8},
-  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_5},
-  {.periph= RCC_AHB1Periph_GPIOB, .port= GPIOB, .pin=GPIO_Pin_4},
-  {.periph= RCC_AHB1Periph_GPIOC, .port= GPIOC, .pin=GPIO_Pin_12},
-  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_2},
-  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_3},
-  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_5},
-  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_6},
-  {.periph= RCC_AHB1Periph_GPIOA, .port= GPIOA, .pin=GPIO_Pin_7},
-};
-
 void pinMode(uint32_t pin, uint32_t mode)
 {
   if (pin > 13) {
     return;
   }
 
-  RCC_AHB1PeriphClockCmd(gpioMapping[pin-1].periph, ENABLE);
+  RCC_AHB1PeriphClockCmd(deckGPIOMapping[pin-1].periph, ENABLE);
 
   GPIO_InitTypeDef GPIO_InitStructure = {0};
 
-  GPIO_InitStructure.GPIO_Pin = gpioMapping[pin-1].pin;
+  GPIO_InitStructure.GPIO_Pin = deckGPIOMapping[pin-1].pin;
   GPIO_InitStructure.GPIO_Mode = (mode == OUTPUT)?GPIO_Mode_OUT:GPIO_Mode_IN;
   if (mode == OUTPUT) GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
   if (mode == INPUT_PULLUP) GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
   GPIO_InitStructure.GPIO_Speed = GPIO_Speed_25MHz;
-  GPIO_Init(gpioMapping[pin-1].port, &GPIO_InitStructure);
+  GPIO_Init(deckGPIOMapping[pin-1].port, &GPIO_InitStructure);
 }
 
 void digitalWrite(uint32_t pin, uint32_t val)
@@ -75,7 +54,7 @@ void digitalWrite(uint32_t pin, uint32_t val)
 
   if (val) val = Bit_SET;
 
-  GPIO_WriteBit(gpioMapping[pin-1].port, gpioMapping[pin-1].pin, val);
+  GPIO_WriteBit(deckGPIOMapping[pin-1].port, deckGPIOMapping[pin-1].pin, val);
 }
 
 int digitalRead(uint32_t pin)
@@ -84,6 +63,6 @@ int digitalRead(uint32_t pin)
     return LOW;
   }
 
-  int val = GPIO_ReadInputDataBit(gpioMapping[pin-1].port, gpioMapping[pin-1].pin);
+  int val = GPIO_ReadInputDataBit(deckGPIOMapping[pin-1].port, deckGPIOMapping[pin-1].pin);
   return (val==Bit_SET)?HIGH:LOW;
 }

--- a/deck/interface/deck.h
+++ b/deck/interface/deck.h
@@ -5,5 +5,6 @@
 
 #include "deck_contants.h"
 #include "deck_digital.h"
+#include "deck_analog.h"
 
 #endif

--- a/deck/interface/deck_analog.h
+++ b/deck/interface/deck_analog.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 
 /* Voltage reference types for the analogReference() function. */
-#define DEFAULT ((uint8_t)00)
+#define DEFAULT 0
 
 void adcInit(void);
 

--- a/deck/interface/deck_analog.h
+++ b/deck/interface/deck_analog.h
@@ -1,0 +1,61 @@
+/*
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2015 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * deck_analog.h - Arduino-compatible analog input API
+ */
+
+#ifndef __DECK_ANALOG_H__
+#define __DECK_ANALOG_H__
+
+#include <stdint.h>
+
+/*
+ * The Deck port GPIO pins, as named by the deck port / expansion port / expansion breakout documentation on bitcraze.io.
+ * Sequenced according to the gpioMapping struct in deck_analog.c, so that these can be used for lookup in the struct.
+ *
+ * TODO: Should be shared across the deck API.
+ */
+#define DECK_PIN_RX1   1
+#define DECK_PIN_TX1   2
+#define DECK_PIN_SDA   3
+#define DECK_PIN_SCL   4
+#define DECK_PIN_IO1   5
+#define DECK_PIN_IO2   6
+#define DECK_PIN_IO3   7
+#define DECK_PIN_IO4   8
+#define DECK_PIN_TX2   9
+#define DECK_PIN_RX2  10
+#define DECK_PIN_SCK  11
+#define DECK_PIN_MISO 12
+#define DECK_PIN_MOSI 13
+
+/* Voltage reference types for the analogReference() function. */
+#define DEFAULT ((uint8_t)00)
+
+void adcInit(void);
+
+uint16_t analogRead(uint32_t pin);
+
+void analogReference(uint8_t type);
+
+#endif

--- a/deck/interface/deck_analog.h
+++ b/deck/interface/deck_analog.h
@@ -29,26 +29,6 @@
 
 #include <stdint.h>
 
-/*
- * The Deck port GPIO pins, as named by the deck port / expansion port / expansion breakout documentation on bitcraze.io.
- * Sequenced according to the gpioMapping struct in deck_analog.c, so that these can be used for lookup in the struct.
- *
- * TODO: Should be shared across the deck API.
- */
-#define DECK_PIN_RX1   1
-#define DECK_PIN_TX1   2
-#define DECK_PIN_SDA   3
-#define DECK_PIN_SCL   4
-#define DECK_PIN_IO1   5
-#define DECK_PIN_IO2   6
-#define DECK_PIN_IO3   7
-#define DECK_PIN_IO4   8
-#define DECK_PIN_TX2   9
-#define DECK_PIN_RX2  10
-#define DECK_PIN_SCK  11
-#define DECK_PIN_MISO 12
-#define DECK_PIN_MOSI 13
-
 /* Voltage reference types for the analogReference() function. */
 #define DEFAULT ((uint8_t)00)
 

--- a/deck/interface/deck_contants.h
+++ b/deck/interface/deck_contants.h
@@ -30,11 +30,40 @@
 // For true and false
 #include <stdbool.h>
 
+#include "stm32fxxx.h"
+
 #define LOW 0x0
 #define HIGH 0x1
 
 #define INPUT 0x0
 #define OUTPUT 0x1
 #define INPUT_PULLUP 0x2
+
+/*
+ * The Deck port GPIO pins, as named by the deck port / expansion port / expansion breakout documentation on bitcraze.io.
+ * Sequenced according to the deckGPIOMapping struct, so that these can be used for lookup in the struct.
+ */
+#define DECK_GPIO_RX1   1
+#define DECK_GPIO_TX1   2
+#define DECK_GPIO_SDA   3
+#define DECK_GPIO_SCL   4
+#define DECK_GPIO_IO1   5
+#define DECK_GPIO_IO2   6
+#define DECK_GPIO_IO3   7
+#define DECK_GPIO_IO4   8
+#define DECK_GPIO_TX2   9
+#define DECK_GPIO_RX2  10
+#define DECK_GPIO_SCK  11
+#define DECK_GPIO_MISO 12
+#define DECK_GPIO_MOSI 13
+
+typedef const struct {
+  uint32_t periph;
+  GPIO_TypeDef* port;
+  uint16_t pin;
+  int8_t adcCh; /* -1 means no ADC available for this pin. */
+} deckGPIOMapping_t;
+
+extern deckGPIOMapping_t deckGPIOMapping[];
 
 #endif

--- a/modules/src/system.c
+++ b/modules/src/system.c
@@ -88,9 +88,7 @@ void systemInit(void)
 
   configblockInit();
   workerInit();
-#ifdef PLATFORM_CF1
   adcInit();
-#endif
   ledseqInit();
   pmInit();
     


### PR DESCRIPTION
New deck_analog.[hc] API as discussed in thread https://forum.bitcraze.io/viewtopic.php?p=8305#p8305

Most notably (not yet discussed), is that the API is now using ADC2 instead of ADC1. This since there are internal temp and vref connected to ADC1, and ADC1 should perhaps thus be used in a different way at a later stage.

Also, some changes/cleanups since last posts, please see if these are acceptable.
