### PR TITLE
Setting sampling time to minimum for 10-bit conversion

### DIFF
--- a/deck/api/deck_analog.c
+++ b/deck/api/deck_analog.c
@@ -71,8 +71,8 @@ void adcInit(void)
 
 static uint16_t analogReadChannel(uint8_t channel)
 {
-  /* At 42MHz ADC clock, 480+15 cycles is slightly above 10us sampling time. */
-  ADC_RegularChannelConfig(ADC2, channel, 1, ADC_SampleTime_480Cycles);
+  /* According to datasheet, minimum sampling time for 10-bit conversion is almost 15 cycles. */
+  ADC_RegularChannelConfig(ADC2, channel, 1, ADC_SampleTime_15Cycles);
 
   /* Start the conversion */
   ADC_SoftwareStartConv(ADC2);


### PR DESCRIPTION
The deck_analog.c file currently uses an ADC conversion time of 480 cycles, which causes occasional problems with the transfer of log variables to the cfclient.

Some testing over the past couple of days indicate that setting the conversion time to 15 cycles fixes the problem. As far as I can read from the datasheet, this should also be the minimum value for 10-bit conversion (used for Arduino compatibility)
