### PR TITLE
Avoid smashing the stack when generating log packets

### DIFF
--- a/modules/src/crtp.c
+++ b/modules/src/crtp.c
@@ -173,6 +173,7 @@ void crtpRegisterPortCB(int port, CrtpCallback cb)
 int crtpSendPacket(CRTPPacket *p)
 {
   ASSERT(p); 
+  ASSERT(p->size <= CRTP_MAX_DATA_SIZE);
 
   return xQueueSend(txQueue, p, 0);
 }
@@ -180,6 +181,7 @@ int crtpSendPacket(CRTPPacket *p)
 int crtpSendPacketBlock(CRTPPacket *p)
 {
   ASSERT(p); 
+  ASSERT(p->size <= CRTP_MAX_DATA_SIZE);
 
   return xQueueSend(txQueue, p, portMAX_DELAY);
 }


### PR DESCRIPTION
This is one possible approach to fixing #61.  This branch includes two commits; the first is a diagnostic aid to make it easier to identify who's generating bogus CRTP packets.