### PR TITLE
radiolink: create queue before starting syslink.

### DIFF
--- a/hal/src/radiolink.c
+++ b/hal/src/radiolink.c
@@ -68,15 +68,12 @@ void radiolinkInit(void)
   if (isInit)
     return;
 
-  syslinkInit();
-
   txQueue = xQueueCreate(RADIOLINK_TX_QUEUE_SIZE, sizeof(SyslinkPacket));
   crtpPacketDelivery = xQueueCreate(5, sizeof(CRTPPacket));
 
-  if (crtpPacketDelivery == 0)
-  {
-    return;
-  }
+  ASSERT(crtpPacketDelivery);
+
+  syslinkInit();
 
   radiolinkSetChannel(configblockGetRadioChannel());
   radiolinkSetDatarate(configblockGetRadioSpeed());


### PR DESCRIPTION
This is a mitigation measure working around issue #63.

A more systematic fix might be to disable context switches during initialization, but I don't have the sort of global understanding of this codebase to do that.