### PR TITLE
Assorted FPU fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,8 @@ INCLUDES_CF2 += -I$(STLIB)/STM32_USB_OTG_Driver/inc
 INCLUDES_CF2 += -Ideck/interface
 
 ifeq ($(USE_FPU), 1)
-PROCESSOR = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
+	PROCESSOR = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
+	CFLAGS += -fno-math-errno
 else
 	ifeq ($(PLATFORM), CF1)
 		PROCESSOR = -mcpu=cortex-m3 -mthumb

--- a/config/FreeRTOSConfig.h
+++ b/config/FreeRTOSConfig.h
@@ -114,8 +114,8 @@ to exclude the API function. */
 #define vPortSVCHandler SVC_Handler
 
 //Milliseconds to OS Ticks
-#define M2T(X) ((unsigned int)(X*(configTICK_RATE_HZ/1000.0)))
-#define F2T(X) ((unsigned int)((configTICK_RATE_HZ/X)))
+#define M2T(X) ((unsigned int)((X)*(configTICK_RATE_HZ/1000.0)))
+#define F2T(X) ((unsigned int)((configTICK_RATE_HZ/(X))))
 
 // DEBUG SECTION
 #define configUSE_APPLICATION_TASK_TAG  1

--- a/drivers/src/lps25h.c
+++ b/drivers/src/lps25h.c
@@ -236,7 +236,7 @@ bool lps25hGetData(float* pressure, float* temperature, float* asl)
 #include "math.h"
 // Constants used to determine altitude from pressure
 #define CONST_SEA_PRESSURE 102610.f //1026.1f //http://www.meteo.physik.uni-muenchen.de/dokuwiki/doku.php?id=wetter:stadt:messung
-#define CONST_PF 0.1902630958 //(1/5.25588f) Pressure factor
+#define CONST_PF 0.1902630958f //(1/5.25588f) Pressure factor
 #define CONST_PF2 44330.0f
 #define FIX_TEMP 25         // Fixed Temperature. ASL is a function of pressure and temperature, but as the temperature changes so much (blow a little towards the flie and watch it drop 5 degrees) it corrupts the ASL estimates.
                             // TLDR: Adjusting for temp changes does more harm than good.
@@ -251,7 +251,7 @@ float lps25hPressureToAltitude(float* pressure/*, float* ground_pressure, float*
     {
         //return (1.f - pow(*pressure / CONST_SEA_PRESSURE, CONST_PF)) * CONST_PF2;
         //return ((pow((1015.7 / *pressure), CONST_PF) - 1.0) * (25. + 273.15)) / 0.0065;
-        return ((pow((1015.7 / *pressure), CONST_PF) - 1.0) * (FIX_TEMP + 273.15)) / 0.0065;
+        return ((powf((1015.7f / *pressure), CONST_PF) - 1.0f) * (FIX_TEMP + 273.15f)) / 0.0065f;
     }
     else
     {

--- a/drivers/src/motors_f405.c
+++ b/drivers/src/motors_f405.c
@@ -305,10 +305,10 @@ bool motorsTest(void)
 void motorsSetRatio(int id, uint16_t ithrust)
 {
   float thrust = ((float)ithrust / 65536.0f) * 60;
-  float volts = -0.0006239 * thrust * thrust + 0.088 * thrust + 0.069;
+  float volts = -0.0006239f * thrust * thrust + 0.088f * thrust + 0.069f;
   float supply_voltage = pmGetBatteryVoltage();
   float percentage = volts / supply_voltage;
-  percentage = percentage > 1.0 ? 1.0 : percentage;
+  percentage = percentage > 1.0f ? 1.0f : percentage;
   uint16_t ratio = percentage * UINT16_MAX;
 
   switch(id)

--- a/drivers/src/mpu6500.c
+++ b/drivers/src/mpu6500.c
@@ -219,8 +219,8 @@ bool mpu6500SelfTest()
   // To get percent, must multiply by 100
   for (i = 0; i < 3; i++)
   {
-   aDiff[i] = 100.0*((float)((aSTAvg[i] - aAvg[i]) - factoryTrim[i]))/factoryTrim[i]; // Report percent differences
-   gDiff[i] = 100.0*((float)((gSTAvg[i] - gAvg[i]) - factoryTrim[i+3]))/factoryTrim[i+3]; // Report percent differences
+   aDiff[i] = 100.0f*((float)((aSTAvg[i] - aAvg[i]) - factoryTrim[i]))/factoryTrim[i]; // Report percent differences
+   gDiff[i] = 100.0f*((float)((gSTAvg[i] - gAvg[i]) - factoryTrim[i+3]))/factoryTrim[i+3]; // Report percent differences
 //   DEBUG_PRINT("a[%d] Avg:%d, StAvg:%d, Shift:%d, FT:%d, Diff:%0.2f\n", i, aAvg[i], aSTAvg[i], aSTAvg[i] - aAvg[i], factoryTrim[i], aDiff[i]);
 //   DEBUG_PRINT("g[%d] Avg:%d, StAvg:%d, Shift:%d, FT:%d, Diff:%0.2f\n", i, gAvg[i], gSTAvg[i], gSTAvg[i] - gAvg[i], factoryTrim[i+3], gDiff[i]);
   }

--- a/hal/interface/pm.h
+++ b/hal/interface/pm.h
@@ -31,7 +31,7 @@
 #include "syslink.h"
 
 #ifndef CRITICAL_LOW_VOLTAGE
-  #define PM_BAT_CRITICAL_LOW_VOLTAGE   3.0
+  #define PM_BAT_CRITICAL_LOW_VOLTAGE   3.0f
 #else
   #define PM_BAT_CRITICAL_LOW_VOLTAGE   CRITICAL_LOW_VOLTAGE
 #endif
@@ -42,7 +42,7 @@
 #endif
 
 #ifndef LOW_VOLTAGE
-  #define PM_BAT_LOW_VOLTAGE   3.2
+  #define PM_BAT_LOW_VOLTAGE   3.2f
 #else
   #define PM_BAT_LOW_VOLTAGE   LOW_VOLTAGE
 #endif
@@ -58,9 +58,9 @@
   #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * SYSTEM_SHUTDOWN_TIMEOUT)
 #endif
 
-#define PM_BAT_DIVIDER                (float)(3.0)
-#define PM_BAT_ADC_FOR_3_VOLT         (int32_t)(((3.0 / PM_BAT_DIVIDER) / 2.8) * 4096)
-#define PM_BAT_ADC_FOR_1p2_VOLT       (int32_t)(((1.2 / PM_BAT_DIVIDER) / 2.8) * 4096)
+#define PM_BAT_DIVIDER                3.0f
+#define PM_BAT_ADC_FOR_3_VOLT         (int32_t)(((3.0f / PM_BAT_DIVIDER) / 2.8f) * 4096)
+#define PM_BAT_ADC_FOR_1p2_VOLT       (int32_t)(((1.2f / PM_BAT_DIVIDER) / 2.8f) * 4096)
 
 #define PM_BAT_IIR_SHIFT     8
 /**
@@ -74,7 +74,7 @@
  * f0 = fs / 2*pi*attenuation.
  * attenuation = fs / 2*pi*f0
  */
-#define PM_BAT_IIR_LPF_ATTENUATION (int)(ADC_SAMPLING_FREQ / (int)(2 * 3.1415 * PM_BAT_WANTED_LPF_CUTOFF_HZ))
+#define PM_BAT_IIR_LPF_ATTENUATION (int)(ADC_SAMPLING_FREQ / (int)(2 * 3.1415f * PM_BAT_WANTED_LPF_CUTOFF_HZ))
 #define PM_BAT_IIR_LPF_ATT_FACTOR  (int)((1<<PM_BAT_IIR_SHIFT) / PM_BAT_IIR_LPF_ATTENUATION)
 
 typedef enum

--- a/hal/src/eskylink.c
+++ b/hal/src/eskylink.c
@@ -34,7 +34,6 @@
  */
 
 #include <stdbool.h>
-#include <errno.h>
 #include <string.h>
 
 #include "FreeRTOS.h"

--- a/hal/src/imu_cf1.c
+++ b/hal/src/imu_cf1.c
@@ -120,9 +120,6 @@ static void imuAccIIRLPFilter(Axis3i16* in, Axis3i16* out,
                               Axis3i32* storedValues, int32_t attenuation);
 static void imuAccAlignToGravity(Axis3i16* in, Axis3i16* out);
 
-// TODO: Fix __errno linker error with math lib
-int __attribute__((used)) __errno;
-
 static bool isInit;
 
 void imu6Init(void)

--- a/hal/src/imu_cf2.c
+++ b/hal/src/imu_cf2.c
@@ -54,12 +54,12 @@
 #define IMU_DEG_PER_LSB_CFG   MPU6500_DEG_PER_LSB_2000
 #define IMU_ACCEL_FS_CFG      MPU6500_ACCEL_FS_8
 #define IMU_G_PER_LSB_CFG     MPU6500_G_PER_LSB_8
-#define IMU_1G_RAW            (int16_t)(1.0 / MPU6500_G_PER_LSB_8)
+#define IMU_1G_RAW            (int16_t)(1.0f / MPU6500_G_PER_LSB_8)
 
 #define IMU_VARIANCE_MAN_TEST_TIMEOUT M2T(1000) // Timeout in ms
-#define IMU_MAN_TEST_LEVEL_MAX        5.0      // Max degrees off
+#define IMU_MAN_TEST_LEVEL_MAX        5.0f      // Max degrees off
 
-#define MAG_GAUSS_PER_LSB     666.7
+#define MAG_GAUSS_PER_LSB     666.7f
 
 #define IMU_STARTUP_TIME_MS   1000
 
@@ -225,10 +225,10 @@ void imu6Init(void)
   varianceSampleTime = -GYRO_MIN_BIAS_TIMEOUT_MS + 1;
   imuAccLpfAttFactor = IMU_ACC_IIR_LPF_ATT_FACTOR;
 
-  cosPitch = cos(configblockGetCalibPitch() * M_PI/180);
-  sinPitch = sin(configblockGetCalibPitch() * M_PI/180);
-  cosRoll = cos(configblockGetCalibRoll() * M_PI/180);
-  sinRoll = sin(configblockGetCalibRoll() * M_PI/180);
+  cosPitch = cosf(configblockGetCalibPitch() * (float) M_PI/180);
+  sinPitch = sinf(configblockGetCalibPitch() * (float) M_PI/180);
+  cosRoll = cosf(configblockGetCalibRoll() * (float) M_PI/180);
+  sinRoll = sinf(configblockGetCalibRoll() * (float) M_PI/180);
 
   isInit = true;
 }
@@ -289,10 +289,10 @@ bool imu6ManufacturingTest(void)
     if (gyroBias.isBiasValueFound)
     {
       // Calculate pitch and roll based on accelerometer. Board must be level
-      pitch = tan(-acc.x/(sqrt(acc.y*acc.y + acc.z*acc.z))) * 180/M_PI;
-      roll = tan(acc.y/acc.z) * 180/M_PI;
+      pitch = tanf(-acc.x/(sqrtf(acc.y*acc.y + acc.z*acc.z))) * 180/(float) M_PI;
+      roll = tanf(acc.y/acc.z) * 180/(float) M_PI;
 
-      if ((fabs(roll) < IMU_MAN_TEST_LEVEL_MAX) && (fabs(pitch) < IMU_MAN_TEST_LEVEL_MAX))
+      if ((fabsf(roll) < IMU_MAN_TEST_LEVEL_MAX) && (fabsf(pitch) < IMU_MAN_TEST_LEVEL_MAX))
       {
         DEBUG_PRINT("Acc level test [OK]\n");
         testStatus = true;

--- a/hal/src/imu_cf2.c
+++ b/hal/src/imu_cf2.c
@@ -129,9 +129,6 @@ static void imuAccIIRLPFilter(Axis3i16* in, Axis3i16* out,
                               Axis3i32* storedValues, int32_t attenuation);
 static void imuAccAlignToGravity(Axis3i16* in, Axis3i16* out);
 
-// TODO: Fix __errno linker error with math lib
-int __attribute__((used)) __errno;
-
 static bool isInit;
 
 void imu6Init(void)

--- a/hal/src/nrf24link.c
+++ b/hal/src/nrf24link.c
@@ -25,7 +25,6 @@
  */
 
 #include <stdbool.h>
-#include <errno.h>
 
 #include "config.h"
 #include "nrf24l01.h"

--- a/hal/src/syslink.c
+++ b/hal/src/syslink.c
@@ -26,7 +26,6 @@
 #define DEBUG_MODULE "SL"
 
 #include <stdbool.h>
-#include <errno.h>
 #include <string.h>
 #include <stdint.h>
 

--- a/hal/src/usblink.c
+++ b/hal/src/usblink.c
@@ -25,7 +25,6 @@
  */
 
 #include <stdbool.h>
-#include <errno.h>
 #include <string.h>
 
 #include "config.h"

--- a/modules/src/commander.c
+++ b/modules/src/commander.c
@@ -136,7 +136,7 @@ void commanderGetAltHold(bool* altHold, bool* setAltHold, float* altHoldChange)
 {
   *altHold = altHoldMode; // Still in altitude hold mode
   *setAltHold = !altHoldModeOld && altHoldMode; // Hover just activated
-  *altHoldChange = altHoldMode ? ((float) targetVal[side].thrust - 32767.) / 32767. : 0.0; // Amount to change altitude hold target
+  *altHoldChange = altHoldMode ? ((float) targetVal[side].thrust - 32767.f) / 32767.f : 0.0; // Amount to change altitude hold target
   altHoldModeOld = altHoldMode;
 }
 

--- a/modules/src/neopixelring.c
+++ b/modules/src/neopixelring.c
@@ -154,7 +154,7 @@ static void solidColorEffect(uint8_t buffer[][3], bool reset)
 
   if (reset) brightness = 0;
 
-  if (brightness<1) brightness += 0.05;
+  if (brightness<1) brightness += 0.05f;
   else brightness = 1;
 
   for (i=0; i<NBR_LEDS; i++)
@@ -345,8 +345,8 @@ static void gravityLight(uint8_t buffer[][3], bool reset)
   float roll = logGetFloat(rollid); // -180 to 180
 
   float angle = gravityLightCalculateAngle(pitch, roll);
-  float led_index = NBR_LEDS * angle / (2 * M_PI);
-  int intensity = LIMIT(sqrt(pitch * pitch + roll * roll));
+  float led_index = NBR_LEDS * angle / (2 * (float) M_PI);
+  int intensity = LIMIT(sqrtf(pitch * pitch + roll * roll));
   gravityLightRender(buffer, led_index, intensity);
 }
 
@@ -354,10 +354,10 @@ static float gravityLightCalculateAngle(float pitch, float roll) {
   float angle = 0.0;
 
   if (roll != 0) {
-    angle = atan(pitch / roll) + M_PI_2;
+    angle = atanf(pitch / roll) + (float) M_PI_2;
 
     if (roll < 0.0) {
-      angle += M_PI;
+      angle += (float) M_PI;
     }
   }
 
@@ -454,7 +454,7 @@ static void ledTestEffect(uint8_t buffer[][3], bool reset)
 
   if (reset) brightness = 0;
 
-  if (brightness<1) brightness += 0.05;
+  if (brightness<1) brightness += 0.05f;
   else brightness = 1;
 
   for (i=0; i<NBR_LEDS; i++)

--- a/modules/src/sensfusion6.c
+++ b/modules/src/sensfusion6.c
@@ -29,6 +29,8 @@
 #include "imu.h"
 #include "param.h"
 
+#define M_PI_F ((float) M_PI)
+
 //#define MADWICK_QUATERNION_IMU
 
 #ifdef MADWICK_QUATERNION_IMU
@@ -161,9 +163,9 @@ void sensfusion6UpdateQ(float gx, float gy, float gz, float ax, float ay, float 
   float halfex, halfey, halfez;
   float qa, qb, qc;
 
-  gx = gx * M_PI / 180;
-  gy = gy * M_PI / 180;
-  gz = gz * M_PI / 180;
+  gx = gx * M_PI_F / 180;
+  gy = gy * M_PI_F / 180;
+  gz = gz * M_PI_F / 180;
 
   // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
   if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
@@ -239,9 +241,9 @@ void sensfusion6GetEulerRPY(float* roll, float* pitch, float* yaw)
   if (gx>1) gx=1;
   if (gx<-1) gx=-1;
 
-  *yaw = atan2(2*(q0*q3 + q1*q2), q0*q0 + q1*q1 - q2*q2 - q3*q3) * 180 / M_PI;
-  *pitch = asin(gx) * 180 / M_PI; //Pitch seems to be inverted
-  *roll = atan2(gy, gz) * 180 / M_PI;
+  *yaw = atan2f(2*(q0*q3 + q1*q2), q0*q0 + q1*q1 - q2*q2 - q3*q3) * 180 / M_PI_F;
+  *pitch = asinf(gx) * 180 / M_PI_F; //Pitch seems to be inverted
+  *roll = atan2f(gy, gz) * 180 / M_PI_F;
 }
 
 float sensfusion6GetAccZWithoutGravity(const float ax, const float ay, const float az)


### PR DESCRIPTION
These commits...

- Make the `M2T`/`F2T` macros safer.
- Reduce image size by ~8%.
- Remove uses of `errno` and the associated `TODO`s.
- Should significantly increase math performance, though I haven't quantified that.

I've allowed a few lines over 80 characters in these commits, because I couldn't figure out what margin the existing code was using (some files have lines well over 100 characters).  I'm happy to wrap the lines to the margin of your choice.