### PR TITLE
Adding automatic take-off function based on the sitaw framework

### DIFF
--- a/modules/interface/sitaw.h
+++ b/modules/interface/sitaw.h
@@ -46,7 +46,7 @@ void sitAwInit(void);
 #define SITAW_FF_TRIGGER_COUNT 15  /* The number of consecutive tests for Free Fall to be detected. Configured for 250Hz testing. */
 
 /* Configuration options for the 'At Rest' detection. */
-#define SITAW_AR_THRESHOLD 0.02    /* The default tolerance for AccZ deviations from 1 and AccX, AccY deviations from 0, indicating At Rest. */
+#define SITAW_AR_THRESHOLD 0.05    /* The default tolerance for AccZ deviations from 1 and AccX, AccY deviations from 0, indicating At Rest. */
 #define SITAW_AR_TRIGGER_COUNT 500 /* The number of consecutive tests for At Rest to be detected. Configured for 250Hz testing. */
 
 /* Configuration options for the 'Tumbled' detection. */


### PR DESCRIPTION
This pull request adds an automatic take-off function based on the situation awareness framework. If pressing the altHold button while the crazyflie is at rest (and not tumbled), the automatic take-off function will activate.

The function deactivates automatically once the take-off has been conducted, and remains in altHold mode thereafter (as long as the user keeps the altHold button pressed).

Note: This function is disabled by default. Uncomment the #define SITAW_ENABLED in sitaw.h to enable this feature.

