### PR TITLE
Fix Eskylink compilation option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ PROJ_OBJ_CF2 += platform_cf2.o
 PROJ_OBJ += exti.o nvic.o motors.o
 PROJ_OBJ_CF1 += led_f103.o i2cdev_f103.o i2croutines.o adc_f103.o mpu6050.o
 PROJ_OBJ_CF1 += hmc5883l.o ms5611.o nrf24l01.o eeprom.o watchdog.o
+PROJ_OBJ_CF1 += eskylink.o
 PROJ_OBJ_CF2 += led_f405.o mpu6500.o i2cdev_f405.o ws2812_cf2.o lps25h.o
 PROJ_OBJ_CF2 += ak8963.o eeprom.o maxsonar.o piezo.o
 PROJ_OBJ_CF2 += uart_syslink.o swd.o uart1.o uart2.o watchdog.o

--- a/hal/src/eskylink.c
+++ b/hal/src/eskylink.c
@@ -35,6 +35,7 @@
 
 #include <stdbool.h>
 #include <string.h>
+#include <errno.h>
 
 #include "FreeRTOS.h"
 #include "task.h"


### PR DESCRIPTION
Added Eskylink.o to list of files to be compiled, included errno.h in
eskylink.c

Addresses #80 