### PR TITLE
revive microsecond timer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ PROJ_OBJ_CF2 += usb_bsp.o usblink.o usbd_desc.o usb.o
 # Hal
 PROJ_OBJ += crtp.o ledseq.o freeRTOSdebug.o buzzer.o
 PROJ_OBJ_CF1 += imu_cf1.o pm_f103.o nrf24link.o ow_none.o uart.o
-PROJ_OBJ_CF2 += imu_cf2.o pm_f405.o syslink.o radiolink.o ow_syslink.o proximity.o
+PROJ_OBJ_CF2 += imu_cf2.o pm_f405.o syslink.o radiolink.o ow_syslink.o proximity.o usec_time.o
 
 # libdw
 PROJ_OBJ_CF2 += libdw1000.o libdw1000Spi.o

--- a/src/hal/interface/usec_time.h
+++ b/src/hal/interface/usec_time.h
@@ -26,6 +26,8 @@
 #ifndef USEC_TIME_H_
 #define USEC_TIME_H_
 
+#include <stdint.h>
+
 /**
  * Initialize microsecond-resolution timer (TIM1).
  */

--- a/src/hal/src/usec_time.c
+++ b/src/hal/src/usec_time.c
@@ -40,32 +40,34 @@ void initUsecTimer(void)
   NVIC_InitTypeDef NVIC_InitStructure;
 
   //Enable the Timer
-  RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM1, ENABLE);
+  RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM7, ENABLE);
 
   //Timer configuration
   TIM_TimeBaseStructure.TIM_Period = 0xFFFF;
-  TIM_TimeBaseStructure.TIM_Prescaler = 72;
+  // APB1 clock is /4, but APB clock inputs to timers are doubled when
+  // the APB clock runs slower than /1, so APB1 timers see a /2 clock
+  TIM_TimeBaseStructure.TIM_Prescaler = SystemCoreClock / (1000 * 1000) / 2;
   TIM_TimeBaseStructure.TIM_ClockDivision = TIM_CKD_DIV1;
   TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
   TIM_TimeBaseStructure.TIM_RepetitionCounter = 0;
-  TIM_TimeBaseInit(TIM1, &TIM_TimeBaseStructure);
+  TIM_TimeBaseInit(TIM7, &TIM_TimeBaseStructure);
 
-  NVIC_InitStructure.NVIC_IRQChannel = TIM1_UP_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannel = TIM7_IRQn;
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_TRACE_TIM_PRI;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
 
-  DBGMCU_Config(DBGMCU_TIM1_STOP, ENABLE);
-  TIM_ITConfig(TIM1, TIM_IT_Update, ENABLE);
-  TIM_Cmd(TIM1, ENABLE);
+  DBGMCU_Config(DBGMCU_TIM7_STOP, ENABLE);
+  TIM_ITConfig(TIM7, TIM_IT_Update, ENABLE);
+  TIM_Cmd(TIM7, ENABLE);
 }
 
 uint64_t usecTimestamp(void)
 {
   uint32_t high0;
   __atomic_load(&usecTimerHighCount, &high0, __ATOMIC_SEQ_CST);
-  uint32_t low = TIM1->CNT;
+  uint32_t low = TIM7->CNT;
   uint32_t high;
   __atomic_load(&usecTimerHighCount, &high, __ATOMIC_SEQ_CST);
 
@@ -75,12 +77,12 @@ uint64_t usecTimestamp(void)
     return (((uint64_t)high) << 16) + low;
   }
   // There was an increment, but we don't expect another one soon
-  return (((uint64_t)high) << 16) + TIM1->CNT;
+  return (((uint64_t)high) << 16) + TIM7->CNT;
 }
 
-void __attribute__((used)) TIM1_UP_IRQHandler(void)
+void __attribute__((used)) TIM7_IRQHandler(void)
 {
-  TIM_ClearITPendingBit(TIM1, TIM_IT_Update);
+  TIM_ClearITPendingBit(TIM7, TIM_IT_Update);
 
   __sync_fetch_and_add(&usecTimerHighCount, 1);
 }


### PR DESCRIPTION
This change re-enables the microsecond timer function `uint64_t usecTimestamp()` for CF2. The the timer is changed from TIM1 to TIM7 which is the most minimal-featured timer on the STM32. The  prescaler is now determined from the `SystemCoreClock` variable instead of a hard-coded constant.