### PR TITLE
Allow custom arguments for the cload script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DFU_UTIL          ?= dfu-util
 CLOAD             ?= 1
 DEBUG             ?= 0
 CLOAD_SCRIPT      ?= ../crazyflie-clients-python/bin/cfloader
+CLOAD_CMDS        ?=
 PLATFORM					?= CF2
 
 ######### Stabilizer configuration ##########
@@ -343,7 +344,7 @@ size: compile
 #Radio bootloader
 cload:
 ifeq ($(CLOAD), 1)
-	$(CLOAD_SCRIPT) flash $(PROG).bin stm32-fw
+	$(CLOAD_SCRIPT) $(CLOAD_CMDS) flash $(PROG).bin stm32-fw
 else
 	@echo "Only cload build can be bootloaded. Launch build and cload with CLOAD=1"
 endif

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -17,3 +17,6 @@
 
 ## Turn on monitoring of queue usages
 # CFLAGS += -DDEBUG_QUEUE_MONITOR
+
+## Automatically reboot to bootloader before flashing
+# CLOAD_CMDS = -w radio://0/100/2M/E7E7E7E7E7


### PR DESCRIPTION
This allows to reflash the Crazyflie without the need to put it manually in bootloader mode.