### PR TITLE
correct maximum payload for logging size

### DIFF
--- a/src/modules/src/log.c
+++ b/src/modules/src/log.c
@@ -68,8 +68,8 @@ static const uint8_t typeLength[] = {
   [LOG_FP16]   = 2,
 };
 
-// Maximum log payload length
-#define LOG_MAX_LEN 30
+// Maximum log payload length (4 bytes are used for block id and timestamp)
+#define LOG_MAX_LEN 26
 
 /* Log packet parameters storage */
 #define LOG_MAX_OPS 64


### PR DESCRIPTION
The logging packet first sends block id (1 byte) and timestamp (3 bytes) followed by the actual values. Hence, only 26 (out of the 30 CRTP payload) can be used.