### PR TITLE
Fixed crtpRxTask bug on nopLink

### DIFF
--- a/src/modules/src/crtp.c
+++ b/src/modules/src/crtp.c
@@ -158,8 +158,8 @@ void crtpRxTask(void *param)
     {
       if(queues[p.port])
       {
-        // TODO: If full, remove one packet and then send
-        xQueueSend(queues[p.port], &p, 0);
+        // The queue is only 1 long, so if the last packet hasn't been processed, we just replace it
+        xQueueOverwrite(queues[p.port], &p); 
       } else {
         droppedPacket++;
       }

--- a/src/modules/src/crtp.c
+++ b/src/modules/src/crtp.c
@@ -154,18 +154,27 @@ void crtpRxTask(void *param)
 
   while (true)
   {
-    if (!link->receivePacket(&p))
+    if (link != &nopLink)
     {
-      if(queues[p.port])
+      if (!link->receivePacket(&p))
       {
-        // The queue is only 1 long, so if the last packet hasn't been processed, we just replace it
-        xQueueOverwrite(queues[p.port], &p); 
-      } else {
-        droppedPacket++;
-      }
+        if (queues[p.port])
+        {
+          // The queue is only 1 long, so if the last packet hasn't been processed, we just replace it
+          xQueueOverwrite(queues[p.port], &p); 
+        }
+        else
+        {
+          droppedPacket++;
+        }
 
-      if(callbacks[p.port])
-        callbacks[p.port](&p);  //Dangerous?
+        if (callbacks[p.port])
+          callbacks[p.port](&p);  //Dangerous?
+      }
+    }
+    else
+    {
+      vTaskDelay(M2T(10));
     }
   }
 }


### PR DESCRIPTION
This pull request fixes a bug, whereby the crtpRxTask would loop infinitely (and without delay) if a communication link had not been established (ie, link == nopLink).

Signed-off-by: Mike Hamer <mike@mikehamer.info>