### PR TITLE
Fixed I2C delay bug

### DIFF
--- a/src/drivers/interface/i2cdev.h
+++ b/src/drivers/interface/i2cdev.h
@@ -33,9 +33,17 @@
 
 #include "cpal.h"
 
+#ifdef PLATFORM_CF1
 // Delay is approx 0.2us per loop @64Mhz
 #define I2CDEV_LOOPS_PER_US  5
 #define I2CDEV_LOOPS_PER_MS  (1000 * I2CDEV_LOOPS_PER_US)
+#endif
+
+#ifdef PLATFORM_CF2
+// Delay is approx 0.06us per loop @168Mhz
+#define I2CDEV_LOOPS_PER_US  17
+#define I2CDEV_LOOPS_PER_MS  (16789) // measured
+#endif
 
 #define I2CDEV_I2C1_PIN_SDA GPIO_Pin_7
 #define I2CDEV_I2C1_PIN_SCL GPIO_Pin_6

--- a/src/drivers/src/i2cdev_f103.c
+++ b/src/drivers/src/i2cdev_f103.c
@@ -70,7 +70,7 @@ __IO uint32_t I2CDirection;
 
 static void i2cdevResetAndLowLevelInitBusI2c1(void);
 static void i2cdevResetAndLowLevelInitBusI2c2(void);
-static inline void i2cdevRuffLoopDelay(uint32_t us);
+static inline void i2cdevRoughLoopDelay(uint32_t us);
 
 
 int i2cdevInit(I2C_Dev *I2Cx)
@@ -269,7 +269,7 @@ bool i2cdevWrite(I2C_Dev *I2Cx, uint8_t devAddress, uint8_t memAddress,
   return status;
 }
 
-static inline void i2cdevRuffLoopDelay(uint32_t us)
+static inline void i2cdevRoughLoopDelay(uint32_t us)
 {
   volatile uint32_t delay;
 
@@ -303,22 +303,22 @@ static void i2cdevResetAndLowLevelInitBusI2c1(void)
     GPIO_SetBits(GPIOB, I2CDEV_I2C1_PIN_SCL);
     /* Wait for any clock stretching to finish. */
     GPIO_WAIT_LOW(GPIOB, I2CDEV_I2C1_PIN_SCL, 10 * I2CDEV_LOOPS_PER_MS);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
 
     /* Generate a clock cycle */
     GPIO_ResetBits(GPIOB, I2CDEV_I2C1_PIN_SCL);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
     GPIO_SetBits(GPIOB, I2CDEV_I2C1_PIN_SCL);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   }
 
   /* Generate a start then stop condition */
   GPIO_SetBits(GPIOB, I2CDEV_I2C1_PIN_SCL);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   GPIO_ResetBits(GPIOB, I2CDEV_I2C1_PIN_SDA);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   GPIO_ResetBits(GPIOB, I2CDEV_I2C1_PIN_SDA);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
 
   /* Set data and clock high and wait for any clock stretching to finish. */
   GPIO_SetBits(GPIOB, I2CDEV_I2C1_PIN_SDA);
@@ -366,22 +366,22 @@ static void i2cdevResetAndLowLevelInitBusI2c2(void)
     GPIO_SetBits(GPIOB, I2CDEV_I2C2_PIN_SCL);
     /* Wait for any clock stretching to finish. */
     GPIO_WAIT_LOW(GPIOB, I2CDEV_I2C2_PIN_SCL, 10 * I2CDEV_LOOPS_PER_MS);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
 
     /* Generate a clock cycle */
     GPIO_ResetBits(GPIOB, I2CDEV_I2C2_PIN_SCL);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
     GPIO_SetBits(GPIOB, I2CDEV_I2C2_PIN_SCL);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   }
 
   /* Generate a start then stop condition */
   GPIO_SetBits(GPIOB, I2CDEV_I2C2_PIN_SCL);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   GPIO_ResetBits(GPIOB, I2CDEV_I2C2_PIN_SDA);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   GPIO_ResetBits(GPIOB, I2CDEV_I2C2_PIN_SDA);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
 
   /* Set data and clock high and wait for any clock stretching to finish. */
   GPIO_SetBits(GPIOB, I2CDEV_I2C2_PIN_SDA);

--- a/src/drivers/src/i2cdev_f405.c
+++ b/src/drivers/src/i2cdev_f405.c
@@ -67,7 +67,7 @@ xSemaphoreHandle i2cdevDmaEventI2c3;
 /* Private functions */
 static bool i2cdevWriteTransfer(I2C_Dev *dev);
 static bool i2cdevReadTransfer(I2C_Dev *dev);
-static inline void i2cdevRuffLoopDelay(uint32_t us) __attribute__((optimize("O2")));
+static inline void i2cdevRoughLoopDelay(uint32_t us) __attribute__((optimize("O2")));
 
 #define SEMAPHORE_TIMEOUT M2T(30)
 static void semaphoreGiveFromISR(xSemaphoreHandle semaphore);
@@ -277,7 +277,7 @@ static bool i2cdevWriteTransfer(I2C_Dev *dev)
   return false;
 }
 
-static inline void i2cdevRuffLoopDelay(uint32_t us)
+static inline void i2cdevRoughLoopDelay(uint32_t us)
 {
   volatile uint32_t delay = 0;
   for(delay = 0; delay < I2CDEV_LOOPS_PER_US * us; ++delay) { };
@@ -293,22 +293,22 @@ void i2cdevUnlockBus(GPIO_TypeDef* portSCL, GPIO_TypeDef* portSDA, uint16_t pinS
     GPIO_SetBits(portSCL, pinSCL);
     /* Wait for any clock stretching to finish. */
     GPIO_WAIT_FOR_HIGH(portSCL, pinSCL, 10 * I2CDEV_LOOPS_PER_MS);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
 
     /* Generate a clock cycle */
     GPIO_ResetBits(portSCL, pinSCL);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
     GPIO_SetBits(portSCL, pinSCL);
-    i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+    i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   }
 
   /* Generate a start then stop condition */
   GPIO_SetBits(portSCL, pinSCL);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   GPIO_ResetBits(portSDA, pinSDA);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
   GPIO_ResetBits(portSDA, pinSDA);
-  i2cdevRuffLoopDelay(I2CDEV_CLK_TS);
+  i2cdevRoughLoopDelay(I2CDEV_CLK_TS);
 
   /* Set data and clock high and wait for any clock stretching to finish. */
   GPIO_SetBits(portSDA, pinSDA);

--- a/src/drivers/src/i2cdev_f405.c
+++ b/src/drivers/src/i2cdev_f405.c
@@ -67,7 +67,7 @@ xSemaphoreHandle i2cdevDmaEventI2c3;
 /* Private functions */
 static bool i2cdevWriteTransfer(I2C_Dev *dev);
 static bool i2cdevReadTransfer(I2C_Dev *dev);
-static inline void i2cdevRuffLoopDelay(uint32_t us);
+static inline void i2cdevRuffLoopDelay(uint32_t us) __attribute__((optimize("O2")));
 
 #define SEMAPHORE_TIMEOUT M2T(30)
 static void semaphoreGiveFromISR(xSemaphoreHandle semaphore);
@@ -279,9 +279,8 @@ static bool i2cdevWriteTransfer(I2C_Dev *dev)
 
 static inline void i2cdevRuffLoopDelay(uint32_t us)
 {
-  volatile uint32_t delay;
-
-  for(delay = I2CDEV_LOOPS_PER_US * us; delay > 0; delay--);
+  volatile uint32_t delay = 0;
+  for(delay = 0; delay < I2CDEV_LOOPS_PER_US * us; ++delay) { };
 }
 
 void i2cdevUnlockBus(GPIO_TypeDef* portSCL, GPIO_TypeDef* portSDA, uint16_t pinSCL, uint16_t pinSDA)


### PR DESCRIPTION
This delay bug was two-fold:

1. Wrong loop delay
 - The loop delay was (I assume, based on a comment in `i2cdev.h`) set for the CF1, and not updated for the CF2. The CF2 runs these loops ~3.5x faster, so the delays were much shorter than expected. I'm not sure if this was a problem, but things seem to be more robust after this change.
 - The new loop speeds were timed using the DWT->CYCCNT to count clock cycles.

2. Overflow caused hangs
 - For some reason, it occasionally occurred that the delay variable would (due to it being a uint32_t and being decremented) underflow, wrapping to the maximum value.
 - The loop was changed to increment the value and terminate on all values greater than the target, rather than only on 0.

Signed-off-by: Mike Hamer <mike@mikehamer.info>