### PR TITLE
Enables all EXTI handlers to use callbacks

### DIFF
--- a/src/config/nvicconf.h
+++ b/src/config/nvicconf.h
@@ -84,5 +84,15 @@
 #define NVIC_RADIO_PRI        11
 #define NVIC_ADC_PRI          12
 #define NVIC_CPPM_PRI         14
+#define NVIC_SYSLINK_PRI      5
+
+// Priorities for external interrupts
+#define EXTI0_PRI NVIC_LOW_PRI
+#define EXTI1_PRI NVIC_LOW_PRI
+#define EXTI2_PRI NVIC_LOW_PRI
+#define EXTI3_PRI NVIC_LOW_PRI
+#define EXTI4_PRI NVIC_SYSLINK_PRI // this serves the syslink UART
+#define EXTI9_5_PRI NVIC_LOW_PRI
+#define EXTI15_10_PRI NVIC_MID_PRI // this serves the decks and sensors
 
 #endif /* NVIC_CONF_H_ */

--- a/src/deck/drivers/src/dwm1000.c
+++ b/src/deck/drivers/src/dwm1000.c
@@ -380,7 +380,7 @@ static void spiRead(dwDevice_t* dev, const void *header, size_t headerLength,
   xSemaphoreGive(spiSemaphore);
 }
 
-void __attribute__((used)) EXTI15_10_IRQHandler(void)
+void __attribute__((used)) EXTI11_Callback(void)
 {
   portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
 

--- a/src/drivers/interface/exti.h
+++ b/src/drivers/interface/exti.h
@@ -31,7 +31,22 @@
 void extiInit();
 bool extiTest();
 
-inline void extiInterruptHandler(void);
+void EXTI0_Callback(void);
+void EXTI1_Callback(void);
+void EXTI2_Callback(void);
+void EXTI3_Callback(void);
+void EXTI4_Callback(void);
+void EXTI5_Callback(void);
+void EXTI6_Callback(void);
+void EXTI7_Callback(void);
+void EXTI8_Callback(void);
+void EXTI9_Callback(void);
+void EXTI10_Callback(void);
+void EXTI11_Callback(void);
+void EXTI12_Callback(void);
+void EXTI13_Callback(void);
+void EXTI14_Callback(void);
+void EXTI15_Callback(void);
 
 #endif /* __EXTI_H__ */
 

--- a/src/drivers/src/exti.c
+++ b/src/drivers/src/exti.c
@@ -27,6 +27,7 @@
 
 #include "stm32fxxx.h"
 
+#include "exti.h"
 #include "nvicconf.h"
 #include "nrf24l01.h"
 
@@ -46,12 +47,44 @@ void extiInit()
   if (isInit)
     return;
 
+  // required for the EXTI interrupt configuration
+  RCC_AHB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE); 
+
   NVIC_InitTypeDef NVIC_InitStructure;
 
-  NVIC_InitStructure.NVIC_IRQChannel = RADIO_IRQ_CHANNEL;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_RADIO_PRI;
+  // Here we enable all EXTI interrupt handlers to save conflicting
+  // reinitialization code for the 9_5 and 15_10 handlers. Note that
+  // the individual EXTI interrupts still need to be enabled.
+
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI0_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI0_IRQn;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI1_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI1_IRQn;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI2_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI2_IRQn;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI3_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI3_IRQn;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI4_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI4_IRQn;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI9_5_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI9_5_IRQn;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = EXTI15_10_PRI;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI15_10_IRQn;
   NVIC_Init(&NVIC_InitStructure);
 
   isInit = true;
@@ -62,13 +95,116 @@ bool extiTest(void)
   return isInit;
 }
 
-#ifdef PLATFORM_CF1
+void __attribute__((used)) EXTI0_IRQHandler(void)
+{
+  EXTI_ClearITPendingBit(EXTI_Line0);
+  EXTI0_Callback();
+}
+
+void __attribute__((used)) EXTI1_IRQHandler(void)
+{
+  EXTI_ClearITPendingBit(EXTI_Line1);
+  EXTI1_Callback();
+}
+
+void __attribute__((used)) EXTI2_IRQHandler(void)
+{
+  EXTI_ClearITPendingBit(EXTI_Line2);
+  EXTI2_Callback();
+}
+
+void __attribute__((used)) EXTI3_IRQHandler(void)
+{
+  EXTI_ClearITPendingBit(EXTI_Line3);
+  EXTI3_Callback();
+}
+
+void __attribute__((used)) EXTI4_IRQHandler(void)
+{
+  EXTI_ClearITPendingBit(EXTI_Line4);
+  EXTI4_Callback();
+}
+
 void __attribute__((used)) EXTI9_5_IRQHandler(void)
 {
-  if (EXTI_GetITStatus(RADIO_GPIO_IRQ_LINE) == SET)
-  {
-    EXTI_ClearITPendingBit(RADIO_GPIO_IRQ_LINE);
-    nrfIsr();
+  if (EXTI_GetITStatus(EXTI_Line5) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line5);
+    EXTI5_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line6) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line6);
+    EXTI6_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line7) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line7);
+    EXTI7_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line8) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line8);
+    EXTI8_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line9) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line9);
+    EXTI9_Callback();
   }
 }
+
+void __attribute__((used)) EXTI15_10_IRQHandler(void)
+{
+  if (EXTI_GetITStatus(EXTI_Line10) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line10);
+    EXTI10_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line11) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line11);
+    EXTI11_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line12) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line12);
+    EXTI12_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line13) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line13);
+    EXTI13_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line14) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line14);
+    EXTI14_Callback();
+  }
+
+  if (EXTI_GetITStatus(EXTI_Line15) == SET) {
+    EXTI_ClearITPendingBit(EXTI_Line15);
+    EXTI15_Callback();
+  }
+}
+
+void __attribute__((weak)) EXTI0_Callback(void) { }
+void __attribute__((weak)) EXTI1_Callback(void) { }
+void __attribute__((weak)) EXTI2_Callback(void) { }
+void __attribute__((weak)) EXTI3_Callback(void) { }
+void __attribute__((weak)) EXTI4_Callback(void) { }
+void __attribute__((weak)) EXTI5_Callback(void) { }
+void __attribute__((weak)) EXTI6_Callback(void) { }
+void __attribute__((weak)) EXTI7_Callback(void) { }
+void __attribute__((weak)) EXTI8_Callback(void) { }
+
+#ifndef PLATFORM_CF1
+void __attribute__((weak)) EXTI9_Callback(void) { }
+#else
+void __attribute__((used)) EXTI9_Callback(void) { nrfIsr(); }
 #endif
+
+void __attribute__((weak)) EXTI10_Callback(void) { }
+void __attribute__((weak)) EXTI11_Callback(void) { }
+void __attribute__((weak)) EXTI12_Callback(void) { }
+void __attribute__((weak)) EXTI13_Callback(void) { }
+void __attribute__((weak)) EXTI14_Callback(void) { }
+void __attribute__((weak)) EXTI15_Callback(void) { }

--- a/src/drivers/src/exti.c
+++ b/src/drivers/src/exti.c
@@ -31,26 +31,27 @@
 #include "nvicconf.h"
 #include "nrf24l01.h"
 
-#ifdef PLATFORM_CF1
-  #define RADIO_GPIO_IRQ_LINE   EXTI_Line9
-  #define RADIO_IRQ_CHANNEL     EXTI9_5_IRQn
-#else
-  #define RADIO_GPIO_IRQ_LINE   EXTI_Line10
-  #define RADIO_IRQ_CHANNEL     EXTI15_10_IRQn
-#endif
-
 static bool isInit;
 
 /* Interruption initialisation */
 void extiInit()
 {
+  static NVIC_InitTypeDef NVIC_InitStructure;
+
   if (isInit)
     return;
 
-  // required for the EXTI interrupt configuration
-  RCC_AHB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE); 
+#ifdef PLATFORM_CF2 
+  // This is required for the EXTI interrupt configuration since EXTI
+  // lines are set via the SYSCFG peripheral; eg.
+  // SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource13);
 
-  NVIC_InitTypeDef NVIC_InitStructure;
+  // On the CF1, the equivalent command is:
+  // GPIO_EXTILineConfig(GPIO_PortSourceGPIOC, GPIO_PinSource9);
+  // which only requires the relevant GPIO clock to be enabled.
+
+  RCC_AHB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE); 
+#endif
 
   // Here we enable all EXTI interrupt handlers to save conflicting
   // reinitialization code for the 9_5 and 15_10 handlers. Note that
@@ -195,13 +196,7 @@ void __attribute__((weak)) EXTI5_Callback(void) { }
 void __attribute__((weak)) EXTI6_Callback(void) { }
 void __attribute__((weak)) EXTI7_Callback(void) { }
 void __attribute__((weak)) EXTI8_Callback(void) { }
-
-#ifndef PLATFORM_CF1
 void __attribute__((weak)) EXTI9_Callback(void) { }
-#else
-void __attribute__((used)) EXTI9_Callback(void) { nrfIsr(); }
-#endif
-
 void __attribute__((weak)) EXTI10_Callback(void) { }
 void __attribute__((weak)) EXTI11_Callback(void) { }
 void __attribute__((weak)) EXTI12_Callback(void) { }

--- a/src/drivers/src/nrf24l01.c
+++ b/src/drivers/src/nrf24l01.c
@@ -355,9 +355,6 @@ void nrfInit(void)
   if (isInit)
     return;
 
-  /* Enable the EXTI interrupt router */
-  extiInit();
-
   /* Enable SPI and GPIO clocks */
   RCC_APB2PeriphClockCmd(RADIO_GPIO_SPI_CLK | RADIO_GPIO_CS_PERIF | 
                          RADIO_GPIO_CE_PERIF | RADIO_GPIO_IRQ_PERIF, ENABLE);

--- a/src/drivers/src/nrf24l01.c
+++ b/src/drivers/src/nrf24l01.c
@@ -279,14 +279,13 @@ unsigned char nrfReadRX(char *buffer, int len)
   return status;
 }
 
-/* Interrupt service routine, call the interrupt callback
- */
-void nrfIsr()
+/* Interrupt service routine, call the interrupt callback */
+void __attribute__((used)) EXTI9_Callback(void)
 {
   if (interruptCb)
+  {
     interruptCb();
-
-  return;
+  }
 }
 
 void nrfSetInterruptCallback(void (*cb)(void))

--- a/src/drivers/src/uart_syslink.c
+++ b/src/drivers/src/uart_syslink.c
@@ -147,7 +147,7 @@ void uartslkInit(void)
 
   // Configure Rx buffer not empty interrupt
   NVIC_InitStructure.NVIC_IRQChannel = UARTSLK_IRQ;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_HIGH_PRI;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_SYSLINK_PRI;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
@@ -347,7 +347,7 @@ void uartslkTxenFlowctrlIsr()
   }
 }
 
-void __attribute__((used)) EXTI4_IRQHandler(void)
+void __attribute__((used)) EXTI4_Callback(void)
 {
   uartslkTxenFlowctrlIsr();
 }

--- a/src/platform/cf1/platform_cf1.c
+++ b/src/platform/cf1/platform_cf1.c
@@ -25,6 +25,7 @@
  */
 
 /* Project includes */
+#include "exti.h"
 #include "nvic.h"
 
 // TODO: Implement!
@@ -32,6 +33,9 @@ int platformInit(void)
 {
   //Low level init: Clock and Interrupt controller
   nvicInit();
+
+  //EXTI interrupts
+  extiInit();
 
   return 0;
 }

--- a/src/platform/cf2/platform_cf2.c
+++ b/src/platform/cf2/platform_cf2.c
@@ -26,6 +26,7 @@
 
 /* Personal configs */
 /* Project includes */
+#include "exti.h"
 #include "nvic.h"
 
 // TODO: Implement!
@@ -33,6 +34,9 @@ int platformInit(void)
 {
   //Low level init: Clock and Interrupt controller
   nvicInit();
+
+  //EXTI interrupts
+  extiInit();
 
   return 0;
 }


### PR DESCRIPTION
This commit centrally enables all EXTI interrupts on the NVIC. Note that the individual EXTI line interrupts still need to be enabled for interrupts to be generated.

This fixes issues related to EXTI9_5 and EXTI15_10 handlers being initialized and defined multiple times.

This affects, primarily, the IMU interrupt (EXTI13) and interrupts on some of the deck pins (eg. dw1000 on EXTI11). The solution was therefore made global, and existing interrupts updated to use callbacks, rather than the handlers directly.

Signed-off-by: Mike Hamer <mike@mikehamer.info>