### PR TITLE
Convert deck_spi to use DMA

### DIFF
--- a/src/deck/api/deck_spi.c
+++ b/src/deck/api/deck_spi.c
@@ -26,10 +26,6 @@
 
 #include "deck.h"
 
-#include "stm32fxxx.h"
-
-#include <string.h>
-
 /*ST includes */
 #include "stm32fxxx.h"
 #include "config.h"
@@ -47,6 +43,22 @@
 #define SPI_IRQ_HANDLER               SPI1_IRQHandler
 #define SPI_IRQn                      SPI1_IRQn
 
+#define SPI_DMA_IRQ_PRIO        (NVIC_HIGH_PRI)
+#define SPI_DMA                 DMA2
+#define SPI_DMA_CLK             RCC_AHB1Periph_DMA2
+#define SPI_DMA_CLK_INIT        RCC_AHB1PeriphClockCmd
+
+#define SPI_TX_DMA_STREAM       DMA2_Stream5
+#define SPI_TX_DMA_IRQ          DMA2_Stream5_IRQn
+#define SPI_TX_DMA_IRQHandler   DMA2_Stream5_IRQHandler
+#define SPI_TX_DMA_CHANNEL      DMA_Channel_3
+#define SPI_TX_DMA_FLAG_TCIF    DMA_FLAG_TCIF5
+
+#define SPI_RX_DMA_STREAM       DMA2_Stream0
+#define SPI_RX_DMA_IRQ          DMA2_Stream0_IRQn
+#define SPI_RX_DMA_IRQHandler   DMA2_Stream0_IRQHandler
+#define SPI_RX_DMA_CHANNEL      DMA_Channel_3
+#define SPI_RX_DMA_FLAG_TCIF    DMA_FLAG_TCIF0
 
 #define SPI_SCK_PIN                   GPIO_Pin_5
 #define SPI_SCK_GPIO_PORT             GPIOA
@@ -70,17 +82,19 @@
 
 static bool isInit = false;
 
-static xSemaphoreHandle xferComplete;
+static SemaphoreHandle_t txComplete;
+static SemaphoreHandle_t rxComplete;
+
+static void spiDMAInit();
 
 void spiBegin(void)
 {
-
   GPIO_InitTypeDef GPIO_InitStructure;
-  SPI_InitTypeDef  SPI_InitStructure;
-  NVIC_InitTypeDef NVIC_InitStructure;
 
-  vSemaphoreCreateBinary(xferComplete);
-  xSemaphoreTake(xferComplete, portMAX_DELAY);
+  // binary semaphores created using xSemaphoreCreateBinary() are created in a state
+  // such that the the semaphore must first be 'given' before it can be 'taken'
+  txComplete = xSemaphoreCreateBinary();
+  rxComplete = xSemaphoreCreateBinary();
 
   /*!< Enable the SPI clock */
   SPI_CLK_INIT(SPI_CLK, ENABLE);
@@ -88,6 +102,9 @@ void spiBegin(void)
   /*!< Enable GPIO clocks */
   RCC_AHB1PeriphClockCmd(SPI_SCK_GPIO_CLK | SPI_MISO_GPIO_CLK |
                          SPI_MOSI_GPIO_CLK, ENABLE);
+
+  /*!< Enable DMA Clocks */
+  SPI_DMA_CLK_INIT(SPI_DMA_CLK, ENABLE);
 
   /*!< SPI pins configuration *************************************************/
 
@@ -113,37 +130,64 @@ void spiBegin(void)
   GPIO_InitStructure.GPIO_Pin =  SPI_MISO_PIN;
   GPIO_Init(SPI_MISO_GPIO_PORT, &GPIO_InitStructure);
 
+  /*!< SPI DMA Initialization */
+  spiDMAInit();
+
   /*!< SPI configuration */
-  SPI_InitStructure.SPI_Direction = SPI_Direction_2Lines_FullDuplex;
-  SPI_InitStructure.SPI_Mode = SPI_Mode_Master;
-  SPI_InitStructure.SPI_DataSize = SPI_DataSize_8b;
-  SPI_InitStructure.SPI_CPOL = SPI_CPOL_Low;
-  SPI_InitStructure.SPI_CPHA = SPI_CPHA_1Edge;
-  SPI_InitStructure.SPI_NSS = SPI_NSS_Soft;
-  SPI_InitStructure.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_32; //~2.6 MHz
-
-  SPI_InitStructure.SPI_FirstBit = SPI_FirstBit_MSB;
-
-  SPI_InitStructure.SPI_CRCPolynomial = 0; // Not used
-  SPI_Init(SPI, &SPI_InitStructure);
-
-  /*!< Enable the SPI  */
-  SPI_Cmd(SPI, ENABLE);
-
-  /* Enable SPI Interrupt */
-  NVIC_InitStructure.NVIC_IRQChannel = SPI_IRQn;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_HIGH_PRI;
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-  NVIC_Init(&NVIC_InitStructure);
-  //NVIC_EnableIRQ(SPI_IRQn);
+  spiConfigureSlow();
 
   isInit = true;
 }
 
-void spiFast()
+void spiDMAInit()
+{
+  DMA_InitTypeDef  DMA_InitStructure;
+  NVIC_InitTypeDef NVIC_InitStructure;
+
+  /* Configure DMA Initialization Structure */
+  DMA_InitStructure.DMA_FIFOMode = DMA_FIFOMode_Disable ;
+  DMA_InitStructure.DMA_FIFOThreshold = DMA_FIFOThreshold_1QuarterFull ;
+  DMA_InitStructure.DMA_MemoryBurst = DMA_MemoryBurst_Single ;
+  DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
+  DMA_InitStructure.DMA_MemoryInc = DMA_MemoryInc_Enable;
+  DMA_InitStructure.DMA_Mode = DMA_Mode_Normal;
+  DMA_InitStructure.DMA_PeripheralBaseAddr =(uint32_t) (&(SPI->DR)) ;
+  DMA_InitStructure.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
+  DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
+  DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
+  DMA_InitStructure.DMA_Priority = DMA_Priority_High;
+  DMA_InitStructure.DMA_BufferSize = 0; // set later
+  DMA_InitStructure.DMA_Memory0BaseAddr = 0; // set later
+
+  // Configure TX DMA
+  DMA_InitStructure.DMA_Channel = SPI_TX_DMA_CHANNEL;
+  DMA_InitStructure.DMA_DIR = DMA_DIR_MemoryToPeripheral;
+  DMA_Cmd(SPI_TX_DMA_STREAM,DISABLE);
+  DMA_Init(SPI_TX_DMA_STREAM, &DMA_InitStructure);
+
+  // Configure RX DMA
+  DMA_InitStructure.DMA_Channel = SPI_RX_DMA_CHANNEL;
+  DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
+  DMA_Cmd(SPI_RX_DMA_STREAM,DISABLE);
+  DMA_Init(SPI_RX_DMA_STREAM, &DMA_InitStructure);
+
+  // Configure interrupts
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_HIGH_PRI;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+
+  NVIC_InitStructure.NVIC_IRQChannel = SPI_TX_DMA_IRQ;
+  NVIC_Init(&NVIC_InitStructure);
+
+  NVIC_InitStructure.NVIC_IRQChannel = SPI_RX_DMA_IRQ;
+  NVIC_Init(&NVIC_InitStructure);
+}
+
+void spiConfigureSlow()
 {
   SPI_InitTypeDef  SPI_InitStructure;
+
+  SPI_I2S_DeInit(SPI);
 
   SPI_InitStructure.SPI_Direction = SPI_Direction_2Lines_FullDuplex;
   SPI_InitStructure.SPI_Mode = SPI_Mode_Master;
@@ -151,11 +195,29 @@ void spiFast()
   SPI_InitStructure.SPI_CPOL = SPI_CPOL_Low;
   SPI_InitStructure.SPI_CPHA = SPI_CPHA_1Edge;
   SPI_InitStructure.SPI_NSS = SPI_NSS_Soft;
-  SPI_InitStructure.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_8; //~10 MHz
-
   SPI_InitStructure.SPI_FirstBit = SPI_FirstBit_MSB;
-
   SPI_InitStructure.SPI_CRCPolynomial = 0; // Not used
+
+  SPI_InitStructure.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_32; //~2.7 MHz
+  SPI_Init(SPI, &SPI_InitStructure);
+}
+
+void spiConfigureFast()
+{
+  SPI_InitTypeDef  SPI_InitStructure;
+
+  SPI_I2S_DeInit(SPI);
+
+  SPI_InitStructure.SPI_Direction = SPI_Direction_2Lines_FullDuplex;
+  SPI_InitStructure.SPI_Mode = SPI_Mode_Master;
+  SPI_InitStructure.SPI_DataSize = SPI_DataSize_8b;
+  SPI_InitStructure.SPI_CPOL = SPI_CPOL_Low;
+  SPI_InitStructure.SPI_CPHA = SPI_CPHA_1Edge;
+  SPI_InitStructure.SPI_NSS = SPI_NSS_Soft;
+  SPI_InitStructure.SPI_FirstBit = SPI_FirstBit_MSB;
+  SPI_InitStructure.SPI_CRCPolynomial = 0; // Not used
+
+  SPI_InitStructure.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_4; //~21 MHz
   SPI_Init(SPI, &SPI_InitStructure);
 }
 
@@ -164,89 +226,91 @@ bool spiTest(void)
   return isInit;
 }
 
-static const uint8_t * txBuffer;
-static uint8_t * rxBuffer;
-static volatile int nextTxByte;
-static volatile int byteTxLeft;
-static volatile int nextRxByte;
-static volatile int byteRxLeft;
-
-void SPI_IRQ_HANDLER()
+bool spiExchange(size_t length, const uint8_t * data_tx, uint8_t * data_rx)
 {
-  volatile int dummy;
+  // DMA already configured, just need to set memory addresses
+  SPI_TX_DMA_STREAM->M0AR = (uint32_t)data_tx;
+  SPI_TX_DMA_STREAM->NDTR = length;
 
-  if (SPI_I2S_GetITStatus(SPI, SPI_I2S_IT_RXNE) == SET) {
-    if (rxBuffer) {
-      rxBuffer[nextRxByte] = SPI_I2S_ReceiveData(SPI);
-    } else {
-      dummy = SPI_I2S_ReceiveData(SPI);
-      dummy;  // To avoid GCC Warning
-    }
+  SPI_RX_DMA_STREAM->M0AR = (uint32_t)data_rx;
+  SPI_RX_DMA_STREAM->NDTR = length;
 
-    if (byteRxLeft > 1) {
-      if (txBuffer) {
-        SPI_I2S_SendData(SPI, txBuffer[nextTxByte]);
-      } else {
-        SPI_I2S_SendData(SPI, DUMMY_BYTE);
-      }
-    }
+  // Enable SPI DMA Interrupts
+  DMA_ITConfig(SPI_TX_DMA_STREAM, DMA_IT_TC, ENABLE);
+  DMA_ITConfig(SPI_RX_DMA_STREAM, DMA_IT_TC, ENABLE);
 
-    byteRxLeft--;
-    nextRxByte++;
-    nextTxByte++;
+  // Clear DMA Flags
+  DMA_ClearFlag(SPI_TX_DMA_STREAM, DMA_FLAG_FEIF5|DMA_FLAG_DMEIF5|DMA_FLAG_TEIF5|DMA_FLAG_HTIF5|DMA_FLAG_TCIF5);
+  DMA_ClearFlag(SPI_RX_DMA_STREAM, DMA_FLAG_FEIF0|DMA_FLAG_DMEIF0|DMA_FLAG_TEIF0|DMA_FLAG_HTIF0|DMA_FLAG_TCIF0);
 
-    if (byteRxLeft == 0) {
-      portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
+  // Enable DMA Streams
+  DMA_Cmd(SPI_TX_DMA_STREAM,ENABLE);
+  DMA_Cmd(SPI_RX_DMA_STREAM,ENABLE);
 
-      SPI_I2S_ITConfig(SPI, SPI_I2S_IT_RXNE, DISABLE);
+  // Enable SPI DMA requests
+  SPI_I2S_DMACmd(SPI, SPI_I2S_DMAReq_Tx, ENABLE);
+  SPI_I2S_DMACmd(SPI, SPI_I2S_DMAReq_Rx, ENABLE);
 
-      xSemaphoreGiveFromISR(xferComplete, &xHigherPriorityTaskWoken);
+  // Enable peripheral
+  SPI_Cmd(SPI, ENABLE);
 
-      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-    }
+  // Wait for completion
+  bool result = (xSemaphoreTake(txComplete, portMAX_DELAY) == pdTRUE)
+             && (xSemaphoreTake(rxComplete, portMAX_DELAY) == pdTRUE);
+
+  // Disable peripheral
+  SPI_Cmd(SPI, DISABLE);
+  return result;
+}
+
+void __attribute__((used)) SPI_TX_DMA_IRQHandler(void)
+{
+  portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+
+  // Stop and cleanup DMA stream
+  DMA_ITConfig(SPI_TX_DMA_STREAM, DMA_IT_TC, DISABLE);
+  DMA_ClearITPendingBit(SPI_TX_DMA_STREAM, SPI_TX_DMA_FLAG_TCIF);
+
+  // Clear stream flags
+  DMA_ClearFlag(SPI_TX_DMA_STREAM,SPI_TX_DMA_FLAG_TCIF);
+
+  // Disable SPI DMA requests
+  SPI_I2S_DMACmd(SPI, SPI_I2S_DMAReq_Tx, DISABLE);
+
+  // Disable streams
+  DMA_Cmd(SPI_TX_DMA_STREAM,DISABLE);
+
+  // Give the semaphore, allowing the SPI transaction to complete
+  xSemaphoreGiveFromISR(txComplete, &xHigherPriorityTaskWoken);
+
+  if (xHigherPriorityTaskWoken)
+  {
+    portYIELD();
   }
 }
 
-
-bool spiXfer(uint32_t length, const uint8_t * data_tx, uint8_t * data_rx)
+void __attribute__((used)) SPI_RX_DMA_IRQHandler(void)
 {
-  volatile int dummy;
+  portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 
-  if (length < 1) {
-    return true;
+  // Stop and cleanup DMA stream
+  DMA_ITConfig(SPI_RX_DMA_STREAM, DMA_IT_TC, DISABLE);
+  DMA_ClearITPendingBit(SPI_RX_DMA_STREAM, SPI_RX_DMA_FLAG_TCIF);
+
+  // Clear stream flags
+  DMA_ClearFlag(SPI_RX_DMA_STREAM,SPI_RX_DMA_FLAG_TCIF);
+
+  // Disable SPI DMA requests
+  SPI_I2S_DMACmd(SPI, SPI_I2S_DMAReq_Rx, DISABLE);
+
+  // Disable streams
+  DMA_Cmd(SPI_RX_DMA_STREAM,DISABLE);
+
+  // Give the semaphore, allowing the SPI transaction to complete
+  xSemaphoreGiveFromISR(rxComplete, &xHigherPriorityTaskWoken);
+
+  if (xHigherPriorityTaskWoken)
+  {
+    portYIELD();
   }
-
-  // Clear possible overrun error
-  dummy = SPI->DR;
-  dummy = SPI->SR;
-  dummy;
-
-  txBuffer = data_tx;
-  rxBuffer = data_rx;
-
-  SPI_I2S_SendData(SPI, txBuffer[0]);
-
-  nextTxByte = 1;
-  nextRxByte = 0;
-  byteRxLeft = length;
-
-  SPI_I2S_ITConfig(SPI, SPI_I2S_IT_RXNE, ENABLE);
-
-  xSemaphoreTake(xferComplete, portMAX_DELAY);
-
-  return true;
-}
-
-void spiTransfer(void *buffer, int length) {
-  spiXfer(length, buffer, buffer);
-}
-
-bool spiWrite(uint32_t length, const uint8_t * data)
-{
-  return spiXfer(length, data, NULL);
-}
-
-bool spiRead(uint32_t length, uint8_t * data)
-{
-  return spiXfer(length, NULL, data);
 }

--- a/src/deck/interface/deck_spi.h
+++ b/src/deck/interface/deck_spi.h
@@ -28,14 +28,16 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "eprintf.h"
+#include <string.h>
 
 /**
  * Initialize the SPI.
  */
 void spiBegin(void);
+void spiConfigureSlow(void);
+void spiConfigureFast(void);
 
-/* Send the buffer and write the byte received in the same buffer */
-void spiTransfer(void *buffer, int length);
+/* Send the data_tx buffer and receive into the data_rx buffer */
+bool spiExchange(size_t length, const uint8_t *data_tx, uint8_t *data_rx);
 
 #endif /* SPI_H_ */


### PR DESCRIPTION
This pull request converts the deck_spi to use DMA. This has been developed and tested with the DW1000 UWB module, and hence slow mode is hard-coded to ~2.7MHz, and fast mode to ~21MHz.

This pull request significantly reduces the load on the CPU (since it is not interrupted for every SPI byte), and is particularly useful for applications requiring a high number of frequently occurring SPI transactions (eg. UWB localization). 

In addition, this pull request enables SPI speed switching for the dw1000 deck driver.

Signed-off-by: Mike Hamer <mike@mikehamer.info>