### PR TITLE
Added Replacement for Deck Driver gtgps.c

### DIFF
--- a/src/deck/drivers/interface/gtgps.h
+++ b/src/deck/drivers/interface/gtgps.h
@@ -1,0 +1,34 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2011-2012 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * gtgps.h - Titan-2 driver for deck port
+ */
+#ifndef GTGPS_H_
+#define GTGPS_H_
+
+/**
+ * Transfer GPS frame data to sensor_stock.c
+ */
+void gtgpsGetFrameData(uint32_t* ts, float* px, float* py, float* pz);
+
+#endif /* GTGPS_H_ */

--- a/src/deck/drivers/src/gtgps.c
+++ b/src/deck/drivers/src/gtgps.c
@@ -21,13 +21,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * exptest.c - Testing of expansion port.
+ * gtgps.c - Titan-2 GNSS Receiver Expansion Deck Driver.
  */
 #define DEBUG_MODULE "GTGPS"
 
 #include <stdint.h>
 #include <string.h>
-#include <stdio.h>
 
 #include "stm32fxxx.h"
 #include "config.h"
@@ -43,235 +42,290 @@
 #include <math.h>
 #include "log.h"
 
-static bool isInit;
+/**
+ * gtgps.h is needed for the Position Hold Mode capability
+ * and when gtgps.c is called by sensors_stock.c to pick up
+ * 3D fix positions
+ */ 
 
-#define LEN_TOKEN 5
-#define MAX_LEN_SENTANCE 100
-char buff[MAX_LEN_SENTANCE];
-uint8_t bi;
+#include "gtgps.h"
 
-typedef bool (*SentanceParser)(char * buff);
+#if defined(COMPASS_ENABLED)
+/**
+ * compass.h is needed for the Position Hold Mode capability
+ * and when gtgps.c calls compass.c to see if is calibrated
+ */  
+
+#include "compass.h"
+#endif
+
+#define ENABLE_GPS_DECK
+
+/**
+ * gtgps.h is needed for the Position Hold Mode capability
+ * and when gtgps.c is called by sensors_stock.c
+ */ 
+
+#include "gtgps.h" 
 
 typedef struct {
-  const char * token;
-  SentanceParser parser;
-} ParserConfig;
-
-typedef enum {
-  FixNone = 1,
-  Fix2D = 2,
-  Fix3D = 3
-} FixQuality;
-
-typedef enum {
-  NoFix = 1,
-  GPSFix = 2
-} FixType;
-
-typedef enum {FIELD_COORD, FIELD_FLOAT, FIELD_INT} FieldType;
-
-typedef struct {
-  FixQuality fix;
-  uint32_t locks[12];
-  float pdop;
-  float hdop;
-  float vdop;
+  uint8_t fix;
+  uint32_t pdop;
 } Basic;
 
 typedef struct {
-  uint32_t fixtime;
+  uint32_t utc;
+  uint32_t date;
   int32_t latitude;
+  uint8_t N_S;
   int32_t longitude;
-  FixType fixtype;
-  uint32_t nsat;
-  float hdop;
-  float alt;
-  float height;
+  uint8_t E_W;
+  uint8_t fixtype;
+  uint32_t alt;
+  uint32_t cog;
+  uint32_t smg;
+  uint8_t sats;
+  uint8_t nsat;
+  uint32_t hdop;
+  uint32_t temp32;
+  uint16_t temp16;
 } MeasData;
+
+struct nav_onesentence {
+    uint32_t utc;            //hhmmss.sss * 10^3
+    uint32_t date;           //ddmmyy
+    uint32_t lat;            //dd.dddddd * 10^6 (deg)
+    uint8_t N_S;             //North = 1, South = 2
+    uint32_t lon;            //ddd.dddddd * 10^6 (deg)
+    uint8_t E_W;             //East = 1, West = 2
+    uint8_t fixquality;      //No GPS = 1, 2D Fix = 2, 3D-GPS = 3
+    uint8_t fixmode;         //No GPS = 0, SPS Fix = 1, DGPS = 2    
+    uint32_t altitude;       //mm.mm * 10^2 (m)
+    uint32_t cog;            //dd.dd * 10^2 (deg)
+    uint32_t smg;            //v.vv * 10^2 (km/hr)
+    uint8_t sats;            //number of satellites in view
+    uint8_t nsat;            //number of satellites in use
+    uint16_t hdop;           //v.vv * 10^2
+    uint16_t epe;            //v.vv * 10^2
+} __attribute__ ((packed));
+
+struct gtbin_message {
+    union {
+    	void * payload;
+    	struct nav_onesentence* nav_onesentence;
+    };
+} __attribute__ ((packed));
+
 
 static Basic b;
 static MeasData m;
 
-// Only use on 0-terminated strings!
-static int skip_to_next(char ** sp, const char ch) {
-  int steps;
-  while (ch != 0 && (**sp) != ch) {
-    (*sp)++;
-    steps++;
+static bool isInit;
+
+static uint8_t  gps_fixType;
+static uint8_t  gps_fixStatus;
+static bool     NewFrame = false;
+static float    gps_hMSL;
+static float    gps_hAcc;
+static float    gps_pAcc;
+static float    gps_scaleLat = 0.011113295f; //degrees * 1e+7 convert to meters
+static float    gps_scaleLon;
+static float    D2R;
+static uint32_t gps_fixTime;
+static bool     gps_setHome = false;
+static int32_t  gps_latHome = 0;
+static int32_t  gps_lonHome = 0;
+
+static uint32_t timestamp;
+static float pos_x;
+static float pos_y;
+static float pos_z;
+
+void gtgpsGetFrameData(uint32_t* ts, float* px, float* py, float* pz)
+{
+  *ts = timestamp;
+  *px = pos_x;
+  *py = pos_y;
+  *pz = pos_z;
+}
+
+static void saveFrameData(void)
+{
+  static float phi;
+    
+//Assume 3D Fix or 3D Fix/DGPS    
+  if ((gps_fixType > 2) && (m.nsat >= 5) && (gps_hAcc <= 2.0f))
+  {
+    if (!gps_setHome)  
+    {
+      gps_latHome = m.latitude;    //deg * 1e+7
+      gps_lonHome = m.longitude;   //deg * 1e+7
+      gps_setHome = true;
+      phi = m.latitude / 10000000.0f * D2R;
+      gps_scaleLon = cosf(phi) * gps_scaleLat;    
+    }
+    
+//Assume right-hand xyz cartesian coordinate system
+//Assume x = latitude pointing to North geographic or plus latitude  
+//Assume y = longitude pointing to West geographic or minus longitude
+//Assume z = vertical pointing downward or minus hMSL
+//Assume yawgeo is +/- 180 degrees and + is counterclockwise
+//Assume yawgeo in degrees is available to map xyz to level cf1/cf2 fwd direction   
+//Preserve 1 cm significance by using Home position offset
+//don't output positions until compass is calibrated
+    
+#if defined(COMPASS_ENABLED)    
+    else if (compassCaled())
+    {
+      timestamp = 1;  
+      pos_x = (m.latitude - gps_latHome) * gps_scaleLat;   //meters
+      pos_y = -(m.longitude - gps_lonHome) * gps_scaleLon; //meters
+      pos_z = -gps_hMSL;                                   //meters
+    }
+#endif    
+  }  
+  else
+  {
+    timestamp = 0;     
+    pos_x = 0.0f;
+    pos_y = 0.0f;
+    pos_z = 0.0f;
   }
-  if (ch != 0)
-    (*sp)++;
-  return (ch != 0 ? steps : -1);
+
+//This code can be found in position_controller_pid.c
+//  In converting position (desired-measured) to roll/pitch
+//  D2R = (float) M_PI/180.0f
+//  cos = cosf(yawgeo * D2R)
+//  sin = sinf(yawgeo * D2R)
+//  pitch = - position.x * cos - position.y * sin
+//  roll  = - position.y * cos + position.x * sin 
+  
 }
 
-static int32_t parse_coordinate(char ** sp) {
-  int32_t dm;
-  int32_t degree;
-  int32_t minute;
-  int32_t second;
-  int32_t ret;
-  char * i;
-  char * j;
-
-  // Format as DDDMM.SSSS converted by long or lat = DDD + MM / 100 + SSSS/3600
-  // To avoid inaccuracy caused by float representation save this value as
-  // a large number * 10 M
-
-  // 32 18.0489 N = 32 degrees + 18.0489 / 60 = 32.300815 N
-  dm = strtol(*sp, &i, 10);
-  degree = (dm / 100) * 10000000;
-  minute = ((dm % 100) * 10000000) / 60;
-  second = (strtol(i+1, &j, 10) * 1000) / 60;
-  ret = degree + minute + second;
-  skip_to_next(sp, ',');
-  if (**sp == 'S' || **sp == 'W')
-    ret *= -1;
-  return ret;
+static char gtgpsGetc()
+{
+  char c;
+  uart1Getchar(&c);
+  return c;
 }
 
-static float parse_float(char * sp) {
-  float ret = 0;
-  int major = 0;
-  int minor = 0;
-  int deci_nbr = 0;
-  char * i;
-  char * j;
+static void gtgpsRead(void *buffer, int length)
+{
+  int i;
 
-  major = strtol(sp, &i, 10);
-  // Do decimals
-  if (strncmp(i, ".", 1) == 0) {
-    minor = strtol(i+1, &j, 10);
-    deci_nbr = j - i - 1;
-  }
-  ret = (major * pow(10, deci_nbr) + minor) / pow(10, deci_nbr);
-  //printf("%i.%i == %f (%i) (%c)\n", major, minor, ret, deci_nbr, (int) *i);
-  return ret;
-}
-
-static void parse_next(char ** sp, FieldType t, void * value) {
-  skip_to_next(sp, ',');
-  //DEBUG_PRINT("[%s]\n", (*sp));
-  switch (t) {
-    case FIELD_INT:
-      *((uint32_t*) value) = strtol(*sp, 0, 10);
-      break;
-    case FIELD_FLOAT:
-      *((float*) value) = parse_float(*sp);
-      break;
-    case FIELD_COORD:
-      *((int32_t*) value) = parse_coordinate(sp);
+  for (i=0; i<length; i++)
+  {
+    ((char*)buffer)[i] = gtgpsGetc();
   }
 }
 
-static bool gpgsaParser(char * buff) {
-  int i = 0;
-  char * sp = buff;
-
-  // Skip leading A/M
-  skip_to_next(&sp, ',');
-
-  parse_next(&sp, FIELD_INT, &b.fix);
-  for (i = 0; i < 12; i++) {
-    parse_next(&sp, FIELD_INT, &b.locks[i]);
+static void gtgpsSwitch(void *buffer_in, void *buffer_out, int length)
+{
+  int i, j;
+  
+  j = length - 1;
+  for (i=0; i<length; i++)
+  {  
+    ((char*)buffer_out)[i] = ((char*)buffer_in)[j--];
   }
-  parse_next(&sp, FIELD_FLOAT, &b.pdop);
-  parse_next(&sp, FIELD_FLOAT, &b.hdop);
-  parse_next(&sp, FIELD_FLOAT, &b.vdop);
-
-  //dbg_print_basic(&b);
-  return false;
 }
 
-static bool gpggaParser(char * buff) {
-  char * sp = buff;
+uint8_t msg_len = 38;
+uint8_t ref_chksum = 0;
+static void gtgpsReceiveBin(struct gtbin_message* msg, int maxPayload)
+{
+  while (!NewFrame)
+  {
+    if ((uint8_t)gtgpsGetc() != 0x04)
+      continue;
+    if ((uint8_t)gtgpsGetc() != 0x24)
+      continue;
+    if ((uint8_t)gtgpsGetc() != 0x02)
+      continue;
+    gtgpsRead(msg->payload, msg_len); 
+    if ((uint8_t)gtgpsGetc() != 0x2A)
+      continue;
+    ref_chksum = gtgpsGetc();
+    if ((uint8_t)gtgpsGetc() != 0x0D)
+      continue;
+    if ((uint8_t)gtgpsGetc() != 0x0A)
+      continue;
 
-  parse_next(&sp, FIELD_INT, &m.fixtime);
-  parse_next(&sp, FIELD_COORD, &m.latitude);
-  parse_next(&sp, FIELD_COORD, &m.longitude);
-  parse_next(&sp, FIELD_INT, &m.fixtype);
-  parse_next(&sp, FIELD_INT, &m.nsat);
-  parse_next(&sp, FIELD_FLOAT, &m.hdop);
-  parse_next(&sp, FIELD_FLOAT, &m.alt);
-  skip_to_next(&sp, ',');
-  // Unit for altitude (not used yet)
-  parse_next(&sp, FIELD_FLOAT, &m.height);
-  skip_to_next(&sp, ',');
-  // Unit for height (not used yet)
-  skip_to_next(&sp, ',');
-  //consolePutchar('.');
-  //consoleFlush();
-  return false;
+    NewFrame = true;;
+  }    
 }
 
-static ParserConfig parsers[] = {
-  {.token = "GPGSA", .parser = gpgsaParser},
-  {.token = "GPGGA", .parser = gpggaParser}
-};
-
-static bool verifyChecksum(const char * buff) {
-  uint8_t test_chksum = 0;
-  uint32_t ref_chksum = 0;
-  uint8_t i = 0;
-  while (buff[i] != '*' && i < MAX_LEN_SENTANCE-3) {
-    test_chksum ^= buff[i++];
-  }
-  ref_chksum = strtol(&buff[i+1], 0, 16);
-
-  return (test_chksum == ref_chksum);
-}
-
-static uint8_t baudcmd[] = "$PMTK251,115200*1F\r\n";
-
-// 5 Hz
-static uint8_t updaterate[] = "$PMTK220,200*2C\r\n";
-static uint8_t updaterate2[] = "$PMTK300,200,0,0,0,0*2F\r\n";
-
-// 10 Hz
-//static uint8_t updaterate3[] = "$PMTK220,100*2F\r\n";
-//static uint8_t updaterate4[] = "$PMTK300,100,0,0,0,0*2C\r\n";
-
+static uint8_t setbinarymodecmd[] = "$PGCMD,21,1*6F\r\n";
 
 void gtgpsTask(void *param)
 {
-  char ch;
-  int j;
-
-  uart1SendData(sizeof(baudcmd), baudcmd);
-
-  vTaskDelay(500);
   uart1Init(115200);
-  vTaskDelay(500);
+  vTaskDelay(2000);
 
-  uart1SendData(sizeof(updaterate), updaterate);
-  uart1SendData(sizeof(updaterate2), updaterate2);
+  uart1SendData(sizeof(setbinarymodecmd), setbinarymodecmd);
+  
+  struct gtbin_message msg;
+  char payload[50];
 
-//  uart1SendData(sizeof(updaterate3), updaterate3);
-//  uart1SendData(sizeof(updaterate4), updaterate4);
-
+  msg.payload = payload;
 
   while(1)
   {
-    uart1Getchar(&ch);
-    //consolePutchar(ch);
+    gtgpsReceiveBin(&msg, 50);
 
-    if (ch == '$') {
-      bi = 0;
-    } else if (ch == '\n') {
-      buff[bi] = 0; // Terminate with null
-      if (verifyChecksum(buff)) {
-        for (j = 0; j < sizeof(parsers)/sizeof(parsers[0]); j++) {
-          if (strncmp(parsers[j].token, buff, LEN_TOKEN) == 0) {
-            parsers[j].parser(&buff[LEN_TOKEN]);
-          }
-        }
+    m.temp32 = msg.nav_onesentence->utc;
+    gtgpsSwitch(&m.temp32, &m.utc, 4);
+    gps_fixTime = m.utc;
+    m.date = msg.nav_onesentence->date;
+    m.temp32 = msg.nav_onesentence->lat;
+    gtgpsSwitch(&m.temp32, &m.latitude, 4);
+    m.N_S = msg.nav_onesentence->N_S;
+    if(m.N_S == 2) m.latitude *= -10; else m.latitude *= 10;
+    m.temp32 = msg.nav_onesentence->lon;
+    gtgpsSwitch(&m.temp32, &m.longitude, 4);
+    m.E_W = msg.nav_onesentence->E_W;
+    if(m.E_W == 2) m.longitude *= -10; else m.longitude *= 10;
+    b.fix = msg.nav_onesentence->fixquality;
+    if(b.fix == 1) b.fix = 0;  
+    m.fixtype = msg.nav_onesentence->fixmode;
+    gps_fixStatus = m.fixtype;
+    if(m.fixtype > 1) m.fixtype = 1; else m.fixtype = 0;   
+    m.temp32 = msg.nav_onesentence->altitude;
+    gtgpsSwitch(&m.temp32, &m.alt, 4); 
+    gps_hMSL = m.alt / 100.0;
+    m.temp32 = msg.nav_onesentence->cog;
+    gtgpsSwitch(&m.temp32, &m.cog, 4); 
+    m.temp32 = msg.nav_onesentence->smg;
+    gtgpsSwitch(&m.temp32, &m.smg, 4);
+    m.sats = msg.nav_onesentence->sats;
+    m.nsat = msg.nav_onesentence->nsat;
+    m.temp16 = msg.nav_onesentence->hdop;
+    gtgpsSwitch(&m.temp16, &m.hdop, 2);
+    gps_hAcc = m.hdop / 100.0; 
+    m.temp16 = msg.nav_onesentence->epe;
+    gtgpsSwitch(&m.temp16, &b.pdop, 2);
+    gps_pAcc = b.pdop / 100.0;
+    if (ref_chksum == 0) ref_chksum = 0;  //dummy until chksum is verified
+    if(m.fixtype == 1)
+    {
+      if(b.fix == 2)
+      {
+        gps_fixType = 6;
       }
-    } else if (bi < MAX_LEN_SENTANCE) {
-      buff[bi++] = ch;
+      else  if(b.fix == 3)
+      {
+        gps_fixType = 7;
+      }
     }
-  }
-}
-
-
+    else
+    {
+      gps_fixType = b.fix;
+    }
+    saveFrameData();
+    NewFrame = false; 
+  } 
+}  
+ 
 static void gtgpsInit(DeckInfo *info)
 {
   if(isInit)
@@ -282,7 +336,7 @@ static void gtgpsInit(DeckInfo *info)
 
   xTaskCreate(gtgpsTask, "GTGPS",
               configMINIMAL_STACK_SIZE, NULL, /*priority*/1, NULL);
-
+  D2R = (float) M_PI/180.0;
   isInit = true;
 }
 
@@ -297,24 +351,37 @@ static bool gtgpsTest()
 }
 
 static const DeckDriver gtgps_deck = {
-  .vid = 0xBC,
-  .pid = 0x07,
+  .vid = 0xBC,             //prototype .vid value selection 
+  .pid = 0x07,             //prototype .pid value selection 
   .name = "bcGTGPS",
 
   .usedPeriph = 0,
-  .usedGpio = 0,               // FIXME: Edit the used GPIOs
+  .usedGpio = DECK_USING_PA2 | DECK_USING_PA3,
 
   .init = gtgpsInit,
   .test = gtgpsTest,
 };
 
+#ifdef ENABLE_GPS_DECK
 DECK_DRIVER(gtgps_deck);
+#endif
 
 LOG_GROUP_START(gps)
-LOG_ADD(LOG_INT32, lat, &m.latitude)
-LOG_ADD(LOG_INT32, lon, &m.longitude)
-LOG_ADD(LOG_FLOAT, hMSL, &m.height)
-LOG_ADD(LOG_FLOAT, hAcc, &b.pdop)
-LOG_ADD(LOG_INT32, nsat, &m.nsat)
-LOG_ADD(LOG_INT32, fix, &b.fix)
+LOG_ADD(LOG_INT32, lat, &m.latitude)         //degrees * 1e+7
+LOG_ADD(LOG_INT32, lon, &m.longitude)        //degrees * 1e+7
+LOG_ADD(LOG_FLOAT, hMSL, &gps_hMSL)          //meters
+LOG_ADD(LOG_FLOAT, hAcc, &gps_hAcc)          //meters
+LOG_ADD(LOG_UINT8, nsat, &m.nsat)
+LOG_ADD(LOG_INT32, fix, &b.fix)              //0-no DGPS, 1-DGPS
+LOG_ADD(LOG_FLOAT, pAcc, &gps_pAcc)          //meters
+LOG_ADD(LOG_UINT8, fixType, &gps_fixType)    //NMEA 0183 Protocol (0,2,3,6,7)
+LOG_ADD(LOG_UINT8, fixStatus, &gps_fixStatus)//0-no, 1-fix, 2-dgps 
+LOG_ADD(LOG_UINT32, fixtime, &gps_fixTime)
 LOG_GROUP_STOP(gps)
+
+LOG_GROUP_START(gps_dpos)
+LOG_ADD(LOG_UINT32, timestamp, &timestamp)
+LOG_ADD(LOG_FLOAT, pos_x, &pos_x)
+LOG_ADD(LOG_FLOAT, pos_y, &pos_y)
+LOG_ADD(LOG_FLOAT, pos_z, &pos_z)
+LOG_GROUP_STOP(gps_dpos)


### PR DESCRIPTION
> > Driver handles custom firmware in GT Titan-2, and only processes
> > one-sentence binary messages. NMEA message parsing has been removed to
> > lessen microprocessor workload and possible timing conflicts.  Driver
> > also corrects coding errors in the baseline gtgps.c.
> > Log_Group(GPS) supports baseline cfclient GpsTab.py
> > (lat,lon,hMSL,nsat) as well as the proposed GpsTab.py update (adds hAcc,
> > fixType) that has previously been submitted in a cfclient pull request.
> > config.mk needs to have CFLAGS += -DDECK_FORCE=bcGTGPS
> > COMPASS_ENABLE is not defined and disables link to compass.c.
> > Driver code includes support for posHoldMode using gps.
> > Proposed modules supporting the compass and compass calibration are
> > not included in this commit.
> > Proposed modules supporting posHoldMode using gps are not included in
> > this commit.
