### PR TITLE
Broadcast support

### DIFF
--- a/src/hal/interface/syslink.h
+++ b/src/hal/interface/syslink.h
@@ -38,13 +38,14 @@
 // Defined packet types
 #define SYSLINK_GROUP_MASK    0xF0
 
-#define SYSLINK_RADIO_GROUP    0x00
-#define SYSLINK_RADIO_RAW      0x00
-#define SYSLINK_RADIO_CHANNEL  0x01
-#define SYSLINK_RADIO_DATARATE 0x02
-#define SYSLINK_RADIO_CONTWAVE 0x03
-#define SYSLINK_RADIO_RSSI     0x04
-#define SYSLINK_RADIO_ADDRESS  0x05
+#define SYSLINK_RADIO_GROUP         0x00
+#define SYSLINK_RADIO_RAW           0x00
+#define SYSLINK_RADIO_CHANNEL       0x01
+#define SYSLINK_RADIO_DATARATE      0x02
+#define SYSLINK_RADIO_CONTWAVE      0x03
+#define SYSLINK_RADIO_RSSI          0x04
+#define SYSLINK_RADIO_ADDRESS       0x05
+#define SYSLINK_RADIO_RAW_BROADCAST 0x06
 
 #define SYSLINK_PM_GROUP              0x10
 #define SYSLINK_PM_SOURCE             0x10

--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -136,6 +136,12 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
       ledseqRun(LINK_DOWN_LED, seq_linkup);
       syslinkSendPacket(&txPacket);
     }
+  } else if (slp->type == SYSLINK_RADIO_RAW_BROADCAST)
+  {
+    slp->length--; // Decrease to get CRTP size.
+    xQueueSend(crtpPacketDelivery, &slp->length, 0);
+    ledseqRun(LINK_LED, seq_linkup);
+    // no ack for broadcasts
   } else if (slp->type == SYSLINK_RADIO_RSSI)
 	{
 		//Extract RSSI sample sent from radio


### PR DESCRIPTION
This change is related to https://github.com/bitcraze/crazyflie2-nrf-firmware/pull/15. It adds the STM32 side of the broadcasting support.