### PR TITLE
Add measurement update with elevation laser ranging in the EKF

### DIFF
--- a/src/deck/drivers/src/vl53l0x.c
+++ b/src/deck/drivers/src/vl53l0x.c
@@ -43,6 +43,8 @@
 #include "arm_math.h"
 #endif
 
+//#define UPDATE_KALMAN_WITH_RANGING
+
 static uint8_t devAddr;
 static I2C_Dev *I2Cx;
 static bool isInit;
@@ -51,7 +53,7 @@ static uint16_t io_timeout = 0;
 static bool did_timeout;
 static uint16_t timeout_start_ms;
 
-static uint16_t range_last = 10;
+static uint16_t range_last = 0;
 
 // Record the current time to check an upcoming timeout against
 #define startTimeout() (timeout_start_ms = xTaskGetTickCount())
@@ -163,7 +165,7 @@ void vl53l0xTask(void* arg)
   while (1) {
     xLastWakeTime = xTaskGetTickCount();
     range_last = vl53l0xReadRangeContinuousMillimeters();
-#if defined(ESTIMATOR_TYPE_kalman)
+#if defined(ESTIMATOR_TYPE_kalman) && defined(UPDATE_KALMAN_WITH_RANGING)
     // check if range is feasible and push into the kalman filter
     float distance = (float)range_last;
     if (distance < 2.0f){

--- a/src/deck/drivers/src/vl53l0x.c
+++ b/src/deck/drivers/src/vl53l0x.c
@@ -44,6 +44,7 @@
 #include "arm_math.h"
 
 //#define UPDATE_KALMAN_WITH_RANGING // uncomment to push into the kalman
+#ifdef UPDATE_KALMAN_WITH_RANGING
 #define RANGE_OUTLIER_LIMIT 1500 // the measured range is in [mm]
 // Measurement noise model
 static float expPointA = 1.0f;
@@ -51,8 +52,8 @@ static float expStdA = 0.0025f; // STD at elevation expPointA [m]
 static float expPointB = 1.3f;
 static float expStdB = 0.2f;    // STD at elevation expPointB [m]
 static float expCoeff;
-
-#endif
+#endif // UPDATE_KALMAN_WITH_RANGING
+#endif // ESTIMATOR_TYPE_kalman
 
 static uint8_t devAddr;
 static I2C_Dev *I2Cx;

--- a/src/deck/drivers/src/vl53l0x.c
+++ b/src/deck/drivers/src/vl53l0x.c
@@ -37,13 +37,13 @@
 #include "i2cdev.h"
 #include "vl53l0x.h"
 
-#define UPDATE_KALMAN_WITH_RANGING
-
 #include "stabilizer_types.h"
 #ifdef ESTIMATOR_TYPE_kalman
+
 #include "estimator_kalman.h"
 #include "arm_math.h"
 
+//#define UPDATE_KALMAN_WITH_RANGING // uncomment to push into the kalman
 #define RANGE_OUTLIER_LIMIT 1500 // the measured range is in [mm]
 // Measurement noise model
 static float expPointA = 1.0f;
@@ -147,8 +147,10 @@ void vl53l0xInit(DeckInfo* info)
   devAddr = VL53L0X_DEFAULT_ADDRESS;
   xTaskCreate(vl53l0xTask, "vl53l0x", 2*configMINIMAL_STACK_SIZE, NULL, 3, NULL);
   
-  // Compute constant in the measurement noise mdoel
+#if defined(ESTIMATOR_TYPE_kalman) && defined(UPDATE_KALMAN_WITH_RANGING)
+  // pre-compute constant in the measurement noise mdoel
   expCoeff = logf(expStdB / expStdA) / (expPointB - expPointA);
+#endif
   
   isInit = true;
 }

--- a/src/modules/interface/estimator_kalman.h
+++ b/src/modules/interface/estimator_kalman.h
@@ -67,3 +67,4 @@ bool stateEstimatorTest(void);
 bool stateEstimatorEnqueueTDOA(tdoaMeasurement_t *uwb);
 bool stateEstimatorEnqueuePosition(positionMeasurement_t *pos);
 bool stateEstimatorEnqueueDistance(distanceMeasurement_t *dist);
+bool stateEstimatorEnqueueTOF(tofMeasurement_t *tof);

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -173,6 +173,13 @@ typedef struct setpointZ_s {
   bool isUpdate; // True = small update of setpoint, false = completely new
 } setpointZ_t;
 
+/** TOF measurement**/
+typedef struct tofMeasurement_s {
+  uint32_t timestamp;
+  float distance;
+  float stdDev;
+} tofMeasurement_t;
+
 // Frequencies to bo used with the RATE_DO_EXECUTE_HZ macro. Do NOT use an arbitrary number.
 #define RATE_1000_HZ 1000
 #define RATE_500_HZ 500


### PR DESCRIPTION
Added support for laser ranging in the EKF such that measurements are taken every 10 [ms] and ququed in the EKF, where they enter the filter by means of a scalar update. The standard deviation of the measurements are set low, and should be made a function of the distance - but this version of the code is stable and has been used to fly with the LPS system.

Edited with a second commit so as not to make pushing into the Kalman filter the default setting.