### PR TITLE
Prevent double promotion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,8 @@ CFLAGS += -Wall -Wmissing-braces -fno-strict-aliasing $(C_PROFILE) -std=gnu11
 CFLAGS += -MD -MP -MF $(BIN)/dep/$(@).d -MQ $(@)
 #Permits to remove un-used functions and global variables from output file
 CFLAGS += -ffunction-sections -fdata-sections
+# Prevent promoting floats to doubles
+CFLAGS += -Wdouble-promotion
 
 # Fail on warnings
 CFLAGS += -Werror

--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -387,7 +387,7 @@ static float gravityLightCalculateAngle(float pitch, float roll) {
   if (roll != 0) {
     angle = atanf(pitch / roll) + (float) M_PI_2;
 
-    if (roll < 0.0) {
+    if (roll < 0.0f) {
       angle += (float) M_PI;
     }
   }

--- a/src/deck/drivers/src/lpsTwrTdmaTag.c
+++ b/src/deck/drivers/src/lpsTwrTdmaTag.c
@@ -48,10 +48,12 @@ bool tdmaSynchronized;
 dwTime_t frameStart;
 
 #ifndef TDMA_NSLOTS_BITS
+#warning "Number of slots for TDMA not defined! Defaulting to 1."
 #define TDMA_NSLOTS_BITS 1
 #endif
 
 #ifndef TDMA_SLOT
+#warning "Slot number for TDMA not defined! Defaulting to 0."
 #define TDMA_SLOT 0
 #endif
 

--- a/src/deck/drivers/src/vl53l0x.c
+++ b/src/deck/drivers/src/vl53l0x.c
@@ -441,7 +441,7 @@ bool vl53l0xInitSensor(bool io_2v8)
 // Defaults to 0.25 MCPS as initialized by the ST API and this library.
 bool vl53l0xSetSignalRateLimit(float limit_Mcps)
 {
-  if (limit_Mcps < 0 || limit_Mcps > 511.99) { return false; }
+  if (limit_Mcps < 0 || limit_Mcps > 511.99f) { return false; }
 
   // Q9.7 fixed point format (9 integer bits, 7 fractional bits)
   uint16_t fixed_pt = limit_Mcps * (1 << 7);

--- a/src/drivers/src/lps25h.c
+++ b/src/drivers/src/lps25h.c
@@ -99,7 +99,7 @@ bool lps25hEvaluateSelfTest(float min, float max, float value, char* string)
   if (value < min || value > max)
   {
     DEBUG_PRINT("Self test %s [FAIL]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
-                string, min, max, value);
+                string, (double)min, (double)max, (double)value);
     return false;
   }
   return true;

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -221,10 +221,10 @@ void motorsSetRatio(uint32_t id, uint16_t ithrust)
     if (motorMap[id]->drvType == BRUSHED)
     {
       float thrust = ((float)ithrust / 65536.0f) * 60;
-      float volts = -0.0006239 * thrust * thrust + 0.088 * thrust;
+      float volts = -0.0006239f * thrust * thrust + 0.088f * thrust;
       float supply_voltage = pmGetBatteryVoltage();
       float percentage = volts / supply_voltage;
-      percentage = percentage > 1.0 ? 1.0 : percentage;
+      percentage = percentage > 1.0f ? 1.0f : percentage;
       ratio = percentage * UINT16_MAX;
       motor_ratios[id] = ratio;
 

--- a/src/drivers/src/mpu6050.c
+++ b/src/drivers/src/mpu6050.c
@@ -193,7 +193,7 @@ bool mpu6050EvaluateSelfTest(float low, float high, float value, char* string)
   if (value < low || value > high)
   {
     DEBUG_PRINT("Self test %s [FAIL]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
-                string, low, high, value);
+                string, (double)low, (double)high, (double)value);
     return false;
   }
   return true;
@@ -1145,7 +1145,7 @@ void mpu6050SetMasterClockSpeed(uint8_t speed)
  * operation, and if it is cleared, then it's a write operation. The remaining
  * bits (6-0) are the 7-bit device address of the slave device.
  *
- * In read mode, the result of the read is placed in the lowest available 
+ * In read mode, the result of the read is placed in the lowest available
  * EXT_SENS_DATA register. For further information regarding the allocation of
  * read results, please refer to the EXT_SENS_DATA register description
  * (Registers 73 - 96).

--- a/src/drivers/src/mpu6500.c
+++ b/src/drivers/src/mpu6500.c
@@ -258,7 +258,7 @@ bool mpu6500EvaluateSelfTest(float low, float high, float value, char* string)
   if (value < low || value > high)
   {
     DEBUG_PRINT("Self test %s [FAIL]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
-                string, low, high, value);
+                string, (double)low, (double)high, (double)value);
     return false;
   }
   return true;
@@ -994,7 +994,7 @@ void mpu6500SetMasterClockSpeed(uint8_t speed)
  * operation, and if it is cleared, then it's a write operation. The remaining
  * bits (6-0) are the 7-bit device address of the slave device.
  *
- * In read mode, the result of the read is placed in the lowest available 
+ * In read mode, the result of the read is placed in the lowest available
  * EXT_SENS_DATA register. For further information regarding the allocation of
  * read results, please refer to the EXT_SENS_DATA register description
  * (Registers 73 - 96).

--- a/src/drivers/src/ms5611.c
+++ b/src/drivers/src/ms5611.c
@@ -130,7 +130,7 @@ bool ms5611EvaluateSelfTest(float min, float max, float value, char* string)
   if (value < min || value > max)
   {
     DEBUG_PRINT("Self test %s [FAIL]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
-                string, min, max, value);
+                string, (double)min, (double)max, (double)value);
     return false;
   }
   return true;
@@ -214,7 +214,7 @@ float ms5611CalcTemp(int32_t deltaT)
   {
     return (float)(((1 << EXTRA_PRECISION) * 2000)
             + (((int64_t)deltaT * calReg.tsens) >> (23 - EXTRA_PRECISION)))
-            / ((1 << EXTRA_PRECISION)* 100.0);
+            / ((1 << EXTRA_PRECISION)* 100.0f);
   }
 }
 
@@ -392,9 +392,9 @@ float ms5611PressureToAltitude(float* pressure/*, float* ground_pressure, float*
 {
     if (*pressure > 0)
     {
-        //return (1.f - pow(*pressure / CONST_SEA_PRESSURE, CONST_PF)) * CONST_PF2;
-        //return ((pow((1015.7 / *pressure), CONST_PF) - 1.0) * (25. + 273.15)) / 0.0065;
-        return ((pow((1015.7 / *pressure), CONST_PF) - 1.0) * (FIX_TEMP + 273.15)) / 0.0065;
+        //return (1.f - powf(*pressure / CONST_SEA_PRESSURE, CONST_PF)) * CONST_PF2;
+        //return ((powf((1015.7f / *pressure), CONST_PF) - 1.0f) * (25.f + 273.15f)) / 0.0065f;
+        return ((powf((1015.7f / *pressure), CONST_PF) - 1.0f) * (FIX_TEMP + 273.15f)) / 0.0065f;
     }
     else
     {

--- a/src/hal/src/eskylink.c
+++ b/src/hal/src/eskylink.c
@@ -188,17 +188,17 @@ static void eskylinkDecode(char* packet)
   pitch = ((packet[2]<<8) | packet[3])-PPM_ZERO;
   if (roll<(-PPM_RANGE)) roll = -PPM_RANGE;
   if (roll>PPM_RANGE) roll = PPM_RANGE;
-  pitch *= 20.0/PPM_RANGE;
+  pitch *= 20.0f/PPM_RANGE;
 
   roll = ((packet[0]<<8) | packet[1])-PPM_ZERO;
   if (roll<(-PPM_RANGE)) roll = -PPM_RANGE;
   if (roll>PPM_RANGE) roll = PPM_RANGE;
-  roll *= 20.0/PPM_RANGE;
+  roll *= 20.0f/PPM_RANGE;
 
   yaw = ((packet[6]<<8) | packet[7])-PPM_ZERO;
   if (yaw<(-PPM_RANGE)) yaw = -PPM_RANGE;
   if (yaw>PPM_RANGE) yaw = PPM_RANGE;
-  yaw *= 200.0/PPM_RANGE;
+  yaw *= 200.0f/PPM_RANGE;
 
   thrust = ((packet[4]<<8) | packet[5])-PPM_MIN;
   if (thrust<0) thrust = 0;

--- a/src/hal/src/imu_cf1.c
+++ b/src/hal/src/imu_cf1.c
@@ -1,6 +1,6 @@
 /**
- *    ||          ____  _ __                           
- * +------+      / __ )(_) /_______________ _____  ___ 
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
  * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
  * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
  *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
@@ -52,7 +52,7 @@
 #define IMU_DEG_PER_LSB_CFG   MPU6050_DEG_PER_LSB_2000
 #define IMU_ACCEL_FS_CFG      MPU6050_ACCEL_FS_8
 #define IMU_G_PER_LSB_CFG     MPU6050_G_PER_LSB_8
-#define IMU_1G_RAW            (int16_t)(1.0 / MPU6050_G_PER_LSB_8)
+#define IMU_1G_RAW            (int16_t)(1.0f / MPU6050_G_PER_LSB_8)
 
 #define IMU_STARTUP_TIME_MS   1000
 
@@ -71,8 +71,9 @@
 #define GYRO_VARIANCE_THRESHOLD_Z (GYRO_VARIANCE_BASE)
 
 #define MAG_GAUSS_PER_LSB_CFG    HMC5883L_GAIN_660
-#define MAG_GAUSS_PER_LSB        660.0
+#define MAG_GAUSS_PER_LSB        660.0f
 
+#define M_PI_F (float)M_PI
 
 typedef struct
 {
@@ -206,10 +207,10 @@ void imu6Init(void)
   varianceSampleTime = -GYRO_MIN_BIAS_TIMEOUT_MS + 1;
   imuAccLpfAttFactor = IMU_ACC_IIR_LPF_ATT_FACTOR;
 
-  cosPitch = cos(configblockGetCalibPitch() * M_PI/180);
-  sinPitch = sin(configblockGetCalibPitch() * M_PI/180);
-  cosRoll = cos(configblockGetCalibRoll() * M_PI/180);
-  sinRoll = sin(configblockGetCalibRoll() * M_PI/180);
+  cosPitch = cos(configblockGetCalibPitch() * M_PI_F/180);
+  sinPitch = sin(configblockGetCalibPitch() * M_PI_F/180);
+  cosRoll = cos(configblockGetCalibRoll() * M_PI_F/180);
+  sinRoll = sin(configblockGetCalibRoll() * M_PI_F/180);
 
   isInit = true;
 }
@@ -313,9 +314,9 @@ void imu9Read(Axis3f* gyroOut, Axis3f* accOut, Axis3f* magOut)
   }
   else
   {
-    magOut->x = 0.0;
-    magOut->y = 0.0;
-    magOut->z = 0.0;
+    magOut->x = 0.0f;
+    magOut->y = 0.0f;
+    magOut->z = 0.0f;
   }
 }
 

--- a/src/hal/src/sensors_cf2.c
+++ b/src/hal/src/sensors_cf2.c
@@ -811,7 +811,7 @@ bool sensorsManufacturingTest(void)
       }
       else
       {
-        DEBUG_PRINT("Acc level test Roll:%0.2f, Pitch:%0.2f [FAIL]\n", roll, pitch);
+        DEBUG_PRINT("Acc level test Roll:%0.2f, Pitch:%0.2f [FAIL]\n", (double)roll, (double)pitch);
         testStatus = false;
       }
     }

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -139,10 +139,10 @@ void attitudeControllerCorrectAttitudePID(
   // Update PID for yaw axis
   float yawError;
   yawError = eulerYawDesired - eulerYawActual;
-  if (yawError > 180.0)
-    yawError -= 360.0;
-  else if (yawError < -180.0)
-    yawError += 360.0;
+  if (yawError > 180.0f)
+    yawError -= 360.0f;
+  else if (yawError < -180.0f)
+    yawError += 360.0f;
   pidSetError(&pidYaw, yawError);
   *yawRateDesired = pidUpdate(&pidYaw, eulerYawActual, false);
 }

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -40,11 +40,11 @@ void stateController(control_t *control, setpoint_t *setpoint,
   if (RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
     // Rate-controled YAW is moving YAW angle setpoint
     if (setpoint->mode.yaw == modeVelocity) {
-       attitudeDesired.yaw -= setpoint->attitudeRate.yaw/500.0;
-      while (attitudeDesired.yaw > 180.0)
-        attitudeDesired.yaw -= 360.0;
-      while (attitudeDesired.yaw < -180.0)
-        attitudeDesired.yaw += 360.0;
+       attitudeDesired.yaw -= setpoint->attitudeRate.yaw/500.0f;
+      while (attitudeDesired.yaw > 180.0f)
+        attitudeDesired.yaw -= 360.0f;
+      while (attitudeDesired.yaw < -180.0f)
+        attitudeDesired.yaw += 360.0f;
     } else {
       attitudeDesired.yaw = setpoint->attitude.yaw;
     }

--- a/src/modules/src/estimator_kalman.c
+++ b/src/modules/src/estimator_kalman.c
@@ -177,7 +177,7 @@ static inline bool stateEstimatorHasTDOAPacket(tdoaMeasurement_t *uwb) {
 
 // The bounds on the covariance, these shouldn't be hit, but sometimes are... why?
 #define MAX_COVARIANCE (100)
-#define MIN_COVARIANCE (1e-6)
+#define MIN_COVARIANCE (1e-6f)
 
 // The bounds on states, these shouldn't be hit...
 #define MAX_POSITION (10) //meters
@@ -942,7 +942,7 @@ static void stateEstimatorFinalize(sensorData_t *sensors, uint32_t tick)
   float v2 = S[STATE_D2];
 
   // Move attitude error into attitude if any of the angle errors are large enough
-  if ((fabsf(v0) > 0.1e-3 || fabsf(v1) > 0.1e-3 || fabsf(v2) > 0.1e-3) && (fabsf(v0) < 10 && fabsf(v1) < 10 && fabsf(v2) < 10))
+  if ((fabsf(v0) > 0.1e-3f || fabsf(v1) > 0.1e-3f || fabsf(v2) > 0.1e-3f) && (fabsf(v0) < 10 && fabsf(v1) < 10 && fabsf(v2) < 10))
   {
     float angle = arm_sqrt(v0*v0 + v1*v1 + v2*v2);
     float ca = arm_cos_f32(angle / 2.0f);

--- a/src/modules/src/pid.c
+++ b/src/modules/src/pid.c
@@ -125,7 +125,7 @@ bool pidIsActive(PidObject* pid)
 {
   bool isActive = true;
 
-  if (pid->kp < 0.0001 && pid->ki < 0.0001 && pid->kd < 0.0001)
+  if (pid->kp < 0.0001f && pid->ki < 0.0001f && pid->kd < 0.0001f)
   {
     isActive = false;
   }

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -168,7 +168,7 @@ void positionController(float* thrust, attitude_t *attitude, setpoint_t *setpoin
   this.pidY.pid.outputLimit = xyVelMax * velMaxOverhead;
   // The ROS landing detector will prematurely trip if
   // this value is below 0.5
-  this.pidZ.pid.outputLimit = max(zVelMax, 0.5)  * velMaxOverhead;
+  this.pidZ.pid.outputLimit = max(zVelMax, 0.5f)  * velMaxOverhead;
 
   // X, Y
   setpoint->velocity.x = runPid(state->position.x, &this.pidX, setpoint->position.x, DT);

--- a/src/modules/src/position_estimator_altitude.c
+++ b/src/modules/src/position_estimator_altitude.c
@@ -29,7 +29,7 @@
 #include "num.h"
 #include "position_estimator.h"
 
-#define G 9.81;
+#define G 9.81f;
 
 struct selfState_s {
   float estimatedZ; // The current Z estimate, has same offset as asl
@@ -42,13 +42,13 @@ struct selfState_s {
 };
 
 static struct selfState_s state = {
-  .estimatedZ = 0.0,
-  .velocityZ = 0.0,
-  .estAlpha = 0.997,
-  .velocityFactor = 1.0,
-  .vAccDeadband = 0.04,
-  .velZAlpha = 0.995,
-  .estimatedVZ = 0.0,
+  .estimatedZ = 0.0f,
+  .velocityZ = 0.0f,
+  .estAlpha = 0.997f,
+  .velocityFactor = 1.0f,
+  .vAccDeadband = 0.04f,
+  .velZAlpha = 0.995f,
+  .estimatedVZ = 0.0f,
 };
 
 static void positionEstimateInternal(state_t* estimate, float asl, float dt, struct selfState_s* state);
@@ -65,11 +65,11 @@ void positionUpdateVelocity(float accWZ, float dt) {
 static void positionEstimateInternal(state_t* estimate, float asl, float dt, struct selfState_s* state) {
   static float prev_estimatedZ = 0;
   state->estimatedZ = state->estAlpha * state->estimatedZ +
-                     (1.0 - state->estAlpha) * asl +
+                     (1.0f - state->estAlpha) * asl +
                      state->velocityFactor * state->velocityZ * dt;
 
-  estimate->position.x = 0.0;
-  estimate->position.y = 0.0;
+  estimate->position.x = 0.0f;
+  estimate->position.y = 0.0f;
   estimate->position.z = state->estimatedZ;
   estimate->velocity.z = (state->estimatedZ - prev_estimatedZ) / dt;
   state->estimatedVZ = estimate->velocity.z;

--- a/src/utils/src/filter.c
+++ b/src/utils/src/filter.c
@@ -29,6 +29,8 @@
 
 #include "filter.h"
 
+#define M_PI_F (float)M_PI
+
 /**
  * IIR filter the samples.
  */
@@ -73,13 +75,13 @@ void lpf2pInit(lpf2pData* lpfData, float sample_freq, float cutoff_freq)
 void lpf2pSetCutoffFreq(lpf2pData* lpfData, float sample_freq, float cutoff_freq)
 {
   float fr = sample_freq/cutoff_freq;
-  float ohm = tanf(M_PI/fr);
-  float c = 1.0f+2.0f*cosf(M_PI/4.0f)*ohm+ohm*ohm;
+  float ohm = tanf(M_PI_F/fr);
+  float c = 1.0f+2.0f*cosf(M_PI_F/4.0f)*ohm+ohm*ohm;
   lpfData->b0 = ohm*ohm/c;
   lpfData->b1 = 2.0f*lpfData->b0;
   lpfData->b2 = lpfData->b0;
   lpfData->a1 = 2.0f*(ohm*ohm-1.0f)/c;
-  lpfData->a2 = (1.0f-2.0f*cosf(M_PI/4.0f)*ohm+ohm*ohm)/c;
+  lpfData->a2 = (1.0f-2.0f*cosf(M_PI_F/4.0f)*ohm+ohm*ohm)/c;
   lpfData->delay_element_1 = 0.0f;
   lpfData->delay_element_2 = 0.0f;
 }

--- a/src/utils/src/num.c
+++ b/src/utils/src/num.c
@@ -1,6 +1,6 @@
 /**
- *    ||          ____  _ __                           
- * +------+      / __ )(_) /_______________ _____  ___ 
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
  * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
  * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
  *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
@@ -36,13 +36,13 @@
  * FP16 or Half precision floating points is specified by IEEE 754 as binary 16.
  * (float is specified as binary 32). This implementation is NOT GUARANTEED to
  * be conform to the ieee 754 specification, it is 'just' good enough for the
- * Crazyflie usage. For more info about fp16 see 
+ * Crazyflie usage. For more info about fp16 see
  * http://en.wikipedia.org/wiki/Half-precision_floating-point_format
  *
  * The current implementation has the following limitation:
  *  * No subnormalized number generation
  *  * Rounding seems to give at least 11 bits precision
- *  * Faster and smaller than the GCC implementation 
+ *  * Faster and smaller than the GCC implementation
  */
 
 uint16_t single2half(float number)
@@ -50,14 +50,14 @@ uint16_t single2half(float number)
     uint32_t num = *((uint32_t*)&number);
     uint32_t s = num>>31;
     uint32_t e = (num>>23)&0x0FF;
-    
+
     if ((e==255) && (num&0x007fffff))
         return 0x7E00; // NaN
     if (e>(127+15))
         return s?0xFC00:0x7C00;  //+/- inf
     if (e<(127-15))
         return 0; //Do not handle generating subnormalised representation
-    
+
     return (s<<15) | ((e-127+15)<<10) | (((num>>13)&0x3FF)+((num>>12)&0x01));
 }
 
@@ -66,7 +66,7 @@ float half2single(uint16_t number)
     uint32_t fp32;
     uint32_t s = number>>15;
     uint32_t e = (number>>10)&0x01F;
-    
+
     //All binary16 can be mapped in a binary32
     if(e==0)
         e=15-127;
@@ -79,7 +79,7 @@ float half2single(uint16_t number)
     }
     else
         fp32 = (s<<31) | ((e+127-15)<<23) | ((number&0x3ff)<<13);
-    
+
     return *(float*)&fp32;
 }
 
@@ -107,7 +107,7 @@ float constrain(float value, const float minVal, const float maxVal)
 
 float deadband(float value, const float threshold)
 {
-  if (fabs(value) < threshold)
+  if (fabsf(value) < threshold)
   {
     value = 0;
   }


### PR DESCRIPTION
Prevents double promotion to ensure the floating-point unit is used instead of software libraries. Also adds a warning if defines are missing for TDMA.

Depends on bitcraze/libdw1000#3