### PR TITLE
Fix sign error on y-component of velocity update. Also change related…

### DIFF
--- a/src/modules/src/estimator_kalman.c
+++ b/src/modules/src/estimator_kalman.c
@@ -659,9 +659,9 @@ static void stateEstimatorPredict(float cmdThrust, Axis3f *acc, Axis3f *gyro, fl
     tmpSPY = S[STATE_PY];
     tmpSPZ = S[STATE_PZ];
 
-    // body-velocity update: accelerometers + gyros cross velocity - gravity in body frame
+    // body-velocity update: accelerometers - gyros cross velocity - gravity in body frame
     S[STATE_PX] += dt * (gyro->z * tmpSPY - gyro->y * tmpSPZ - GRAVITY_MAGNITUDE * R[2][0]);
-    S[STATE_PY] += dt * (gyro->z * tmpSPX + gyro->x * tmpSPZ - GRAVITY_MAGNITUDE * R[2][1]);
+    S[STATE_PY] += dt * (-gyro->z * tmpSPX + gyro->x * tmpSPZ - GRAVITY_MAGNITUDE * R[2][1]);
     S[STATE_PZ] += dt * (zacc + gyro->y * tmpSPX - gyro->x * tmpSPY - GRAVITY_MAGNITUDE * R[2][2]);
   }
   else // Acceleration can be in any direction, as measured by the accelerometer. This occurs, eg. in freefall or while being carried.
@@ -681,9 +681,9 @@ static void stateEstimatorPredict(float cmdThrust, Axis3f *acc, Axis3f *gyro, fl
     tmpSPY = S[STATE_PY];
     tmpSPZ = S[STATE_PZ];
 
-    // body-velocity update: accelerometers + gyros cross velocity - gravity in body frame
+    // body-velocity update: accelerometers - gyros cross velocity - gravity in body frame
     S[STATE_PX] += dt * (acc->x + gyro->z * tmpSPY - gyro->y * tmpSPZ - GRAVITY_MAGNITUDE * R[2][0]);
-    S[STATE_PY] += dt * (acc->y + gyro->z * tmpSPX + gyro->x * tmpSPZ - GRAVITY_MAGNITUDE * R[2][1]);
+    S[STATE_PY] += dt * (acc->y - gyro->z * tmpSPX + gyro->x * tmpSPZ - GRAVITY_MAGNITUDE * R[2][1]);
     S[STATE_PZ] += dt * (acc->z + gyro->y * tmpSPX - gyro->x * tmpSPY - GRAVITY_MAGNITUDE * R[2][2]);
   }
 


### PR DESCRIPTION
… comments accordingly

This didn't make a noticeable difference when I tried it out in matlab, but now it's compatible with the underlying paper (http://ieeexplore.ieee.org/document/7139421/?arnumber=7139421&tag=1).

@mikehamer 