### PR TITLE
Fixing a handful of compile warnings found on the latest arm-none-eabi-gcc

### DIFF
--- a/src/deck/drivers/src/bigquad.c
+++ b/src/deck/drivers/src/bigquad.c
@@ -46,13 +46,14 @@
 #define BIGQUAD_BAT_CURR_PIN       DECK_GPIO_SCK
 #define BIGQUAD_BAT_AMP_PER_VOLT   1.0f
 
+#ifdef ENABLE_BQ_DECK
 //Hardware configuration
 static bool isInit;
 
 #ifdef BQ_DECK_ENABLE_OSD
 static MspObject s_MspObject;
 
-void osdTask(void *param)
+static void osdTask(void *param)
 {
   while(1)
   {
@@ -63,7 +64,7 @@ void osdTask(void *param)
   }
 }
 
-void osdResponseCallback(uint8_t* pBuffer, uint32_t bufferLen)
+static void osdResponseCallback(uint8_t* pBuffer, uint32_t bufferLen)
 {
   uart1SendData(bufferLen, pBuffer);
 }
@@ -116,6 +117,5 @@ static const DeckDriver bigquad_deck = {
   .test = bigquadTest,
 };
 
-#ifdef ENABLE_BQ_DECK
 DECK_DRIVER(bigquad_deck);
-#endif
+#endif // ENABLE_BQ_DECK

--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -126,17 +126,17 @@ static const uint8_t blueRing[][3] = {{64, 64, 255}, {32,32,64}, {8,8,16},
                                        BLACK, BLACK, BLACK,
                                       };
 
-static const uint8_t greenRing[][3] = {{64, 255, 64}, {32,64,32}, {8,16,8},
-                                       BLACK, BLACK, BLACK,
-                                       BLACK, BLACK, BLACK,
-                                       BLACK, BLACK, BLACK,
-                                      };
-
-static const uint8_t redRing[][3] = {{64, 0, 0}, {16,0,0}, {8,0,0},
-                                       {4,0,0}, {2,0,0}, {1,0,0},
-                                       BLACK, BLACK, BLACK,
-                                       BLACK, BLACK, BLACK,
-                                      };
+//static const uint8_t greenRing[][3] = {{64, 255, 64}, {32,64,32}, {8,16,8},
+//                                       BLACK, BLACK, BLACK,
+//                                       BLACK, BLACK, BLACK,
+//                                       BLACK, BLACK, BLACK,
+//                                      };
+//
+//static const uint8_t redRing[][3] = {{64, 0, 0}, {16,0,0}, {8,0,0},
+//                                       {4,0,0}, {2,0,0}, {1,0,0},
+//                                       BLACK, BLACK, BLACK,
+//                                       BLACK, BLACK, BLACK,
+//                                      };
 
 static void whiteSpinEffect(uint8_t buffer[][3], bool reset)
 {

--- a/src/lib/CMSIS/STM32F4xx/Source/system_stm32f4xx.c
+++ b/src/lib/CMSIS/STM32F4xx/Source/system_stm32f4xx.c
@@ -552,7 +552,7 @@ static void SetSysClock(void)
     RCC->CFGR |= RCC_CFGR_SW_PLL;
 
     /* Wait till the main PLL is used as system clock source */
-    while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
+    while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL)
     {
     }
   }

--- a/src/lib/FatFS/ff.c
+++ b/src/lib/FatFS/ff.c
@@ -4939,7 +4939,9 @@ FRESULT f_setlabel (
 	dj.obj.fs = fs;
 
 	/* Get length of given volume label */
-	for (slen = 0; (UINT)label[slen] >= ' '; slen++) ;	/* Get name length */
+	for (slen = 0; (UINT)label[slen] >= ' '; slen++) /* Get name length */
+	{
+	}
 
 #if _FS_EXFAT
 	if (fs->fs_type == FS_EXFAT) {	/* On the exFAT volume */


### PR DESCRIPTION
I'm getting a handful of compile time warnings/failures when building on the latest arm-none-eabi-gcc. Version info for my gcc:

```
arm-none-eabi-gcc -v
Using built-in specs.
COLLECT_GCC=arm-none-eabi-gcc
COLLECT_LTO_WRAPPER=/usr/bin/../lib/gcc/arm-none-eabi/6.2.1/lto-wrapper
Target: arm-none-eabi
Configured with: /build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/src/gcc/configure --target=arm-none-eabi --prefix=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native --libexecdir=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native/lib --infodir=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native/share/doc/gcc-arm-none-eabi/info --mandir=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native/share/doc/gcc-arm-none-eabi/man --htmldir=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native/share/doc/gcc-arm-none-eabi/html --pdfdir=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native/share/doc/gcc-arm-none-eabi/pdf --enable-languages=c,c++ --enable-plugins --disable-decimal-float --disable-libffi --disable-libgomp --disable-libmudflap --disable-libquadmath --disable-libssp --disable-libstdcxx-pch --disable-nls --disable-shared --disable-threads --disable-tls --with-gnu-as --with-gnu-ld --with-newlib --with-headers=yes --with-python-dir=share/gcc-arm-none-eabi --with-sysroot=/build/gcc-arm-none-eabi-vHKUlg/gcc-arm-none-eabi-6-2016q4/install-native/arm-none-eabi --with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' --with-pkgversion='GNU Tools for ARM Embedded Processors' --with-multilib-list=rmprofile
Thread model: single
gcc version 6.2.1 20161205 (release) [ARM/embedded-6-branch revision 243739] (GNU Tools for ARM Embedded Processors)
```

I'm seeing a couple misleading-indentation warnings which I have fixed:
```
src/lib/CMSIS/STM32F4xx/Source/system_stm32f4xx.c:555:5: error: this 'while' clause does not guard... [-Werror=misleading-indentation]
     while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
     ^~~~~
src/lib/CMSIS/STM32F4xx/Source/system_stm32f4xx.c:556:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'while'
     {
     ^


src/lib/FatFS/ff.c: In function 'f_setlabel':
src/lib/FatFS/ff.c:4942:2: error: this 'for' clause does not guard... [-Werror=misleading-indentation]
  for (slen = 0; (UINT)label[slen] >= ' '; slen++) ; /* Get name length */
  ^~~
src/lib/FatFS/ff.c:4962:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the
for'
  { /* On the FAT12/16/32 volume */
  ^
```

And a several unused variable/function warnings which I have fixed by not treating these warnings as errors in the Makefile. I'm not crazy about this solution but it seemed like a cleaner fix. Most of them are unused functions/variables that we want to keep around, like bigquad (unused because of the compile time flags) or the LED ring (redRing and greenRing structures are not used). I'm open to a more case-by-case fix (for example, do we have an UNUSED_VARIABLE macro already? If not I can always add one) if the bitcraze folks would prefer that.