### PR TITLE
Fixing the build when the OSD library is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ PROJ_OBJ_CF2 += libdw1000.o libdw1000Spi.o
 
 # Modules
 PROJ_OBJ += system.o comm.o console.o pid.o crtpservice.o param.o mem.o
-PROJ_OBJ += log.o worker.o trigger.o sitaw.o queuemonitor.o
+PROJ_OBJ += log.o worker.o trigger.o sitaw.o queuemonitor.o msp.o
 PROJ_OBJ_CF1 += sound_cf1.o sensors_cf1.o
 PROJ_OBJ_CF2 += platformservice.o sound_cf2.o extrx.o sysload.o
 


### PR DESCRIPTION
in the bigquad deck code. msp.o needs to be
added to the Makefile.