### PR TITLE
Implementing a rate-based commander packet type

### DIFF
--- a/src/modules/interface/attitude_controller.h
+++ b/src/modules/interface/attitude_controller.h
@@ -54,6 +54,16 @@ void attitudeControllerCorrectRatePID(
        float rollRateDesired, float pitchRateDesired, float yawRateDesired);
 
 /**
+ * Reset controller roll attitude PID
+ */
+void attitudeControllerResetRollAttitudePID(void);
+
+/**
+ * Reset controller pitch attitude PID
+ */
+void attitudeControllerResetPitchAttitudePID(void);
+
+/**
  * Reset controller roll, pitch and yaw PID's.
  */
 void attitudeControllerResetAllPID(void);

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -135,6 +135,16 @@ void attitudeControllerCorrectAttitudePID(
   *yawRateDesired = pidUpdate(&pidYaw, eulerYawActual, false);
 }
 
+void attitudeControllerResetRollAttitudePID(void)
+{
+    pidReset(&pidRoll);
+}
+
+void attitudeControllerResetPitchAttitudePID(void)
+{
+    pidReset(&pidRoll);
+}
+
 void attitudeControllerResetAllPID(void)
 {
   pidReset(&pidRoll);

--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -89,7 +89,7 @@ void commanderGetSetpoint(setpoint_t *setpoint, const state_t *state)
     setpoint->mode.yaw = modeVelocity;
     setpoint->attitude.roll = 0;
     setpoint->attitude.pitch = 0;
-    setpoint->attitude.yaw = 0;
+    setpoint->attitudeRate.yaw = 0;
     // Keep Z as it is
   }
 }

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -72,11 +72,16 @@ void stateController(control_t *control, setpoint_t *setpoint,
                                 attitudeDesired.roll, attitudeDesired.pitch, attitudeDesired.yaw,
                                 &rateDesired.roll, &rateDesired.pitch, &rateDesired.yaw);
 
+    // For roll and pitch, if velocity mode, overwrite rateDesired with the setpoint
+    // value. Also reset the PID to avoid error buildup, which can lead to unstable
+    // behavior if level mode is engaged later
     if (setpoint->mode.roll == modeVelocity) {
       rateDesired.roll = setpoint->attitudeRate.roll;
+      attitudeControllerResetRollAttitudePID();
     }
     if (setpoint->mode.pitch == modeVelocity) {
       rateDesired.pitch = setpoint->attitudeRate.pitch;
+      attitudeControllerResetPitchAttitudePID();
     }
 
     // TODO: Investigate possibility to subtract gyro drift.


### PR DESCRIPTION
nearly the same as the standard CRTP commander packet except values for
roll and pitch will always be interpreted as rates instead of angles
(this is 'rate mode' or 'acro mode' in other flight controllers)

Also added code to reset the pitch/roll attitude PIDs if the pitch/roll
setpoints are set to type velocity. This prevents error from
accumulating, which can cause unstable behavior if level mode is
re-engaged during flight