### PR TITLE
Implementation of a CPPM-like passthrough CRTP packet type

### DIFF
--- a/src/modules/interface/attitude_controller.h
+++ b/src/modules/interface/attitude_controller.h
@@ -54,6 +54,16 @@ void attitudeControllerCorrectRatePID(
        float rollRateDesired, float pitchRateDesired, float yawRateDesired);
 
 /**
+ * Reset controller roll attitude PID
+ */
+void attitudeControllerResetRollAttitudePID(void);
+
+/**
+ * Reset controller pitch attitude PID
+ */
+void attitudeControllerResetPitchAttitudePID(void);
+
+/**
  * Reset controller roll, pitch and yaw PID's.
  */
 void attitudeControllerResetAllPID(void);

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -135,6 +135,16 @@ void attitudeControllerCorrectAttitudePID(
   *yawRateDesired = pidUpdate(&pidYaw, eulerYawActual, false);
 }
 
+void attitudeControllerResetRollAttitudePID(void)
+{
+    pidReset(&pidRoll);
+}
+
+void attitudeControllerResetPitchAttitudePID(void)
+{
+    pidReset(&pidRoll);
+}
+
 void attitudeControllerResetAllPID(void)
 {
   pidReset(&pidRoll);

--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -89,7 +89,7 @@ void commanderGetSetpoint(setpoint_t *setpoint, const state_t *state)
     setpoint->mode.yaw = modeVelocity;
     setpoint->attitude.roll = 0;
     setpoint->attitude.pitch = 0;
-    setpoint->attitude.yaw = 0;
+    setpoint->attitudeRate.yaw = 0;
     // Keep Z as it is
   }
 }

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -72,11 +72,16 @@ void stateController(control_t *control, setpoint_t *setpoint,
                                 attitudeDesired.roll, attitudeDesired.pitch, attitudeDesired.yaw,
                                 &rateDesired.roll, &rateDesired.pitch, &rateDesired.yaw);
 
+    // For roll and pitch, if velocity mode, overwrite rateDesired with the setpoint
+    // value. Also reset the PID to avoid error buildup, which can lead to unstable
+    // behavior if level mode is engaged later
     if (setpoint->mode.roll == modeVelocity) {
       rateDesired.roll = setpoint->attitudeRate.roll;
+      attitudeControllerResetRollAttitudePID();
     }
     if (setpoint->mode.pitch == modeVelocity) {
       rateDesired.pitch = setpoint->attitudeRate.pitch;
+      attitudeControllerResetPitchAttitudePID();
     }
 
     // TODO: Investigate possibility to subtract gyro drift.

--- a/src/modules/src/crtp_commander_generic.c
+++ b/src/modules/src/crtp_commander_generic.c
@@ -29,7 +29,9 @@
 #include "crtp_commander.h"
 
 #include "commander.h"
+#include "param.h"
 #include "crtp.h"
+#include "num.h"
 #include "FreeRTOS.h"
 
 /* The generic commander format contains a packet type and data that has to be
@@ -51,7 +53,8 @@
  *   2 - Implement a decoder function with good documentation about the data
  *       structure and the intent of the packet.
  *   3 - Add the decoder function to the packetDecoders array.
- *   4 - Pull-request your change :-)
+ *   4 - Create a new params group for your handler if necessary
+ *   5 - Pull-request your change :-)
  */
 
 typedef void (*packetDecoder_t)(setpoint_t *setpoint, uint8_t type, const void *data, size_t datalen);
@@ -60,7 +63,8 @@ typedef void (*packetDecoder_t)(setpoint_t *setpoint, uint8_t type, const void *
 enum packet_type {
   stopType          = 0,
   velocityWorldType = 1,
-  zDistanceType = 2,
+  zDistanceType     = 2,
+  cppmEmuType       = 3,
 };
 
 /* ---===== 2 - Decoding functions =====--- */
@@ -69,7 +73,7 @@ enum packet_type {
  */
 
 /* stopDecoder
- * Keeps setopoint to 0: stops the motors and fall
+ * Keeps setpoint to 0: stops the motors and fall
  */
 static void stopDecoder(setpoint_t *setpoint, uint8_t type, const void *data, size_t datalen)
 {
@@ -137,11 +141,97 @@ static void zDistanceDecoder(setpoint_t *setpoint, uint8_t type, const void *dat
   setpoint->attitude.pitch = values->pitch;
 }
 
+/* cppmEmuDecoder
+ * CRTP packet containing an emulation of CPPM channels
+ * Channels have a range of 1000-2000 with a midpoint of 1500
+ * Supports the ordinary RPYT channels plus up to MAX_AUX_RC_CHANNELS auxiliary channels.
+ * Auxiliary channels are optional and transmitters do not have to transmit all the data
+ * unless a given channel is actually in use (numAuxChannels must be set accordingly)
+ *
+ * Current aux channel assignments:
+ * - AuxChannel0: set high to enable self-leveling, low to disable
+ */
+#define MAX_AUX_RC_CHANNELS 10
+
+static float s_CppmEmuRollMaxRateDps = 720.0f; // For rate mode
+static float s_CppmEmuPitchMaxRateDps = 720.0f; // For rate mode
+static float s_CppmEmuRollMaxAngleDeg = 50.0f; // For level mode
+static float s_CppmEmuPitchMaxAngleDeg = 50.0f; // For level mode
+static float s_CppmEmuYawMaxRateDps = 400.0f; // Used regardless of flight mode
+
+struct cppmEmuPacket_s {
+  struct {
+      uint8_t numAuxChannels : 4;   // Set to 0 through MAX_AUX_RC_CHANNELS
+      uint8_t reserved : 4;
+  } hdr;
+  uint16_t channelRoll;
+  uint16_t channelPitch;
+  uint16_t channelYaw;
+  uint16_t channelThrust;
+  uint16_t channelAux[MAX_AUX_RC_CHANNELS];
+} __attribute__((packed));
+
+static inline float getChannelUnitMultiplier(uint16_t channelValue, uint16_t channelMidpoint, uint16_t channelRange)
+{
+  // Compute a float from -1 to 1 based on the RC channel value, midpoint, and total range magnitude
+  return ((float)channelValue - (float)channelMidpoint) / (float)channelRange;
+}
+
+static void cppmEmuDecoder(setpoint_t *setpoint, uint8_t type, const void *data, size_t datalen)
+{
+  bool isSelfLevelEnabled = true;
+
+  ASSERT(datalen >= 9); // minimum 9 bytes expected - 1byte header + four 2byte channels
+  const struct cppmEmuPacket_s *values = data;
+  ASSERT(datalen == 9 + (2*values->hdr.numAuxChannels)); // Total size is 9 + number of active aux channels
+
+  // Aux channel 0 is reserved for enabling/disabling self-leveling
+  // If it's in use, check and see if it's set and enable self-leveling.
+  // If aux channel 0 is not in use, default to self-leveling enabled.
+  isSelfLevelEnabled = !(values->hdr.numAuxChannels >= 1 && values->channelAux[0] < 1500);
+
+  // Set the modes
+
+  // Position is disabled
+  setpoint->mode.x = modeDisable;
+  setpoint->mode.y = modeDisable;
+  setpoint->mode.z = modeDisable;
+
+  // Yaw is always velocity
+  setpoint->mode.yaw = modeVelocity;
+
+  // Roll/Pitch mode is either velocity or abs based on isSelfLevelEnabled
+  setpoint->mode.roll = isSelfLevelEnabled ? modeAbs : modeVelocity;
+  setpoint->mode.pitch = isSelfLevelEnabled ? modeAbs : modeVelocity;
+
+  // Rescale the CPPM values into angles to build the setpoint packet
+  if(isSelfLevelEnabled)
+  {
+    setpoint->attitude.roll = -1 * getChannelUnitMultiplier(values->channelRoll, 1500, 500) * s_CppmEmuRollMaxAngleDeg; // roll inverted
+    setpoint->attitude.pitch = -1 * getChannelUnitMultiplier(values->channelPitch, 1500, 500) * s_CppmEmuPitchMaxAngleDeg; // pitch inverted
+  }
+  else
+  {
+    setpoint->attitudeRate.roll = -1 * getChannelUnitMultiplier(values->channelRoll, 1500, 500) * s_CppmEmuRollMaxRateDps; // roll inverted
+    setpoint->attitudeRate.pitch = -1 * getChannelUnitMultiplier(values->channelPitch, 1500, 500) * s_CppmEmuPitchMaxRateDps; // pitch inverted
+  }
+
+  setpoint->attitudeRate.yaw = -1 * getChannelUnitMultiplier(values->channelYaw, 1500, 500) * s_CppmEmuYawMaxRateDps; // yaw inverted
+  setpoint->thrust = getChannelUnitMultiplier(values->channelThrust, 1000, 1000) * (float)UINT16_MAX; // Thrust is positive only - uses the full 1000-2000 range
+
+  // Make sure thrust isn't negative
+  if(setpoint->thrust < 0)
+  {
+    setpoint->thrust = 0;
+  }
+}
+
  /* ---===== 3 - packetDecoders array =====--- */
 const static packetDecoder_t packetDecoders[] = {
   [stopType]          = stopDecoder,
   [velocityWorldType] = velocityDecoder,
-  [zDistanceType] = zDistanceDecoder,
+  [zDistanceType]     = zDistanceDecoder,
+  [cppmEmuType]       = cppmEmuDecoder,
 };
 
 /* Decoder switch */
@@ -163,3 +253,14 @@ void crtpCommanderGenericDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk)
     packetDecoders[type](setpoint, type, ((char*)pk->data)+1, pk->size-1);
   }
 }
+
+// Params for generic CRTP handlers
+
+// CPPM Emulation commander
+PARAM_GROUP_START(cmdrCPPM)
+PARAM_ADD(PARAM_FLOAT, rateRoll, &s_CppmEmuRollMaxRateDps)
+PARAM_ADD(PARAM_FLOAT, ratePitch, &s_CppmEmuPitchMaxRateDps)
+PARAM_ADD(PARAM_FLOAT, rateYaw, &s_CppmEmuYawMaxRateDps)
+PARAM_ADD(PARAM_FLOAT, angRoll, &s_CppmEmuRollMaxAngleDeg)
+PARAM_ADD(PARAM_FLOAT, angPitch, &s_CppmEmuPitchMaxAngleDeg)
+PARAM_GROUP_STOP(cmdrCPPM)


### PR DESCRIPTION
Values are represented as a set of channels which range from 1000 to
2000 similar to how classic CPPM functions. Defaults to RPYT and has
room for 10 additional optional auxiliary channels. Aux channel 0 is
reserved for selecting between rate and level flight modes.

Also added code to reset the pitch/roll attitude PIDs if the pitch/roll
setpoints are set to type velocity. This prevents error from
accumulating, which can cause unstable behavior if level mode is
re-engaged during flight