### PR TITLE
Removed memset setpoint overwrite

### DIFF
--- a/src/modules/src/crtp_commander_generic.c
+++ b/src/modules/src/crtp_commander_generic.c
@@ -247,8 +247,6 @@ void crtpCommanderGenericDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk)
 
   uint8_t type = pk->data[0];
 
-  memset(setpoint, 0, sizeof(setpoint_t));
-
   if (type<nTypes && (packetDecoders[type] != NULL)) {
     packetDecoders[type](setpoint, type, ((char*)pk->data)+1, pk->size-1);
   }


### PR DESCRIPTION
We were running some tests with the generic message type and realized that the generic decoder was memset-ing the setpoint variable to zeros, which erased any previous changes made to setpoint from [crtp_commander_rpy.c](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/src/crtp_commander_rpyt.c). 