### PR TITLE
LOG bugfix

### DIFF
--- a/src/deck/drivers/src/vl53l0x.c
+++ b/src/deck/drivers/src/vl53l0x.c
@@ -1167,5 +1167,5 @@ static const DeckDriver vl53l0x_deck = {
 DECK_DRIVER(vl53l0x_deck);
 
 LOG_GROUP_START(range)
-LOG_ADD(LOG_UINT16, range, &range_last)
+LOG_ADD(LOG_UINT16, zrange, &range_last)
 LOG_GROUP_STOP(range)


### PR DESCRIPTION
logGetVarId("range", "range") returns the id of group start. Better call the log entry something else :)