### PR TITLE
Update sensors_bosch.c

### DIFF
--- a/src/hal/src/sensors_bosch.c
+++ b/src/hal/src/sensors_bosch.c
@@ -212,7 +212,7 @@ bool sensorsAreCalibrated()
 
 static void sensorsTask(void *param)
 {
-  uint32_t lastWakeTime;
+  uint32_t lastWakeTime = xTaskGetTickCount();
 
   systemWaitStart();
 


### PR DESCRIPTION
critical bugfix: uninitialized variable could cause unexpected behaviour (SensorTask could run with higher frequency)