### PR TITLE
driver for PCA9685 16-channel I2C PWM chip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ PROJ_OBJ_CF2 += ak8963.o eeprom.o maxsonar.o piezo.o
 PROJ_OBJ_CF2 += uart_syslink.o swd.o uart1.o uart2.o watchdog.o
 PROJ_OBJ_CF2 += cppm.o
 PROJ_OBJ_CF2 += bmi055_accel.o bmi055_gyro.o bmi160.o bmp280.o bstdr_comm_support.o bmm150.o
+PROJ_OBJ_CF2 += pca9685.o
 # USB Files
 PROJ_OBJ_CF2 += usb_bsp.o usblink.o usbd_desc.o usb.o
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -90,6 +90,7 @@
 #define PM_TASK_PRI             0
 #define USDLOG_TASK_PRI         1
 #define USDWRITE_TASK_PRI       0
+#define PCA9685_TASK_PRI        3
 
 #ifdef PLATFORM_CF2
   #define SYSLINK_TASK_PRI        5
@@ -131,6 +132,7 @@
 #define VL53_TASK_NAME          "VL53"
 #define USDLOG_TASK_NAME        "USDLOG"
 #define USDWRITE_TASK_NAME      "USDWRITE"
+#define PCA9685_TASK_NAME       "PCA9685"
 
 //Task stack sizes
 #define SYSTEM_TASK_STACKSIZE         (2* configMINIMAL_STACK_SIZE)
@@ -154,6 +156,7 @@
 #define VL53_TASK_STACKSIZE           (2 * configMINIMAL_STACK_SIZE)
 #define USDLOG_TASK_STACKSIZE         (2 * configMINIMAL_STACK_SIZE)
 #define USDWRITE_TASK_STACKSIZE       (2 * configMINIMAL_STACK_SIZE)
+#define PCA9685_TASK_STACKSIZE        (2 * configMINIMAL_STACK_SIZE)
 
 //The radio channel. From 0 to 125
 #define RADIO_CHANNEL 80

--- a/src/drivers/interface/pca9685.h
+++ b/src/drivers/interface/pca9685.h
@@ -1,0 +1,73 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2017 BitCraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * pca9685.h: 12-bit, 16-channel PWM servo (, LED, ESC, ...) driver
+ */
+
+
+// start the device. All channels will be initialized to 0% duty.
+// returns true if successful.
+bool pca9685init(int addr, float pwmFreq);
+
+// set duty cycle of several channels at once.
+// duties should lie in [0, 1] inclusive.
+// invalid duties clipped silently.
+// returns true if successful.
+bool pca9685setDuties(
+  int addr, int chanBegin, int nChan, float const *duties);
+
+// set the (positive) pulse duration of several channels at once.
+// durations should lie in [0, 4096],
+// where 0 represents DC ground and 4096 represents DC Vcc.
+// the actual duration value depends on the PWM frequency.
+// invalid durations clipped silently.
+// returns true if successful.
+bool pca9685setDurations(
+  int addr, int chanBegin, int nChan, uint16_t const *durations);
+
+
+//
+// ------------------------ Asynchronous Interface ------------------------//
+//
+// Large I2C writes take a long time because we wait for ACKs from the slave.
+// This is a problem if, e.g., we want to drive ESCs with this device,
+// and we don't want to block the stabilizer loop waiting for I2C writes.
+// To deal with this problem, we implement an asynchronous interface
+// using a separate task and a one-element queue.
+//
+// Current implementation will drop messages if async writes occur faster
+// than they can be sent. This could be relaxed if needed, 
+// but it's the right behavior for driving ESCs.
+
+
+bool pca9685startAsyncTask();
+
+// see sync version for description.
+// returns true if the message was enqueued, false if queue is already full.
+bool pca9685setDutiesAsync(
+  int addr, int chanBegin, int nChan, float const *duties);
+
+// see sync version for description.
+// returns true if the message was enqueued, false if queue is already full.
+bool pca9685setDurationsAsync(
+  int addr, int chanBegin, int nChan, uint16_t const *durations);

--- a/src/drivers/src/pca9685.c
+++ b/src/drivers/src/pca9685.c
@@ -169,7 +169,7 @@ struct asyncRequest
   uint16_t durations[16];
 };
 
-static struct asyncRequest reqPush;
+// reqPush is not static for thread safety
 static struct asyncRequest reqPop;
 
 static TaskHandle_t task;
@@ -208,9 +208,11 @@ bool pca9685startAsyncTask()
 bool pca9685setDutiesAsync(
   int addr, int chanBegin, int nChan, float const *duties)
 {
-  reqPush.addr = addr;
-  reqPush.chanBegin = chanBegin;
-  reqPush.nChan = nChan;
+  struct asyncRequest reqPush = {
+    .addr = addr,
+    .chanBegin = chanBegin,
+    .nChan = nChan,
+  };
   for (int i = 0; i < nChan; ++i) {
     reqPush.durations[i] = dutyToDuration(duties[i]);
   }
@@ -222,9 +224,11 @@ bool pca9685setDutiesAsync(
 bool pca9685setDurationsAsync(
   int addr, int chanBegin, int nChan, uint16_t const *durations)
 {
-  reqPush.addr = addr;
-  reqPush.chanBegin = chanBegin;
-  reqPush.nChan = nChan;
+  struct asyncRequest reqPush = {
+    .addr = addr,
+    .chanBegin = chanBegin,
+    .nChan = nChan,
+  };
   for (int i = 0; i < nChan; ++i) {
     reqPush.durations[i] = durations[i];
   }

--- a/src/drivers/src/pca9685.c
+++ b/src/drivers/src/pca9685.c
@@ -1,0 +1,234 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2012 BitCraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * pca9685.c: 12-bit, 16-channel PWM servo (, LED, ESC, ...) driver
+ */
+
+#include "i2cdev.h"
+#include "pca9685.h"
+#include "math.h" // fmax, fmin
+
+// the pca9685 uses 8-bit internal addresses.
+enum Registers
+{
+  regMode1 = 0x00,
+  regMode2,
+  regSubAdr1,
+  regSubAdr2,
+  regSubAdr3,
+  regAllCallAdr,
+  // Each channel has 4 registers:
+  // [ ON_L | ON_H | OFF_L | OFF_H ]
+  regLED_FIRST = 0x06,
+  regLED_LAST = 0x45,
+  regLED_ALL = 0xFA,
+  regPreScale = 0xFE,
+  regTestMode = 0xFF,
+};
+
+int const LED_NBYTES = 4 * (regLED_LAST - regLED_FIRST + 1);
+
+// the bits of the Mode1 register, as masks.
+enum Mode1
+{
+   m1AllCall = 1 << 0,
+      m1Sub3 = 1 << 1,
+      m1Sub2 = 1 << 2,
+      m1Sub1 = 1 << 3,
+     m1Sleep = 1 << 4,
+  m1AutoIncr = 1 << 5,
+    m1ExtClk = 1 << 6,
+   m1Restart = 1 << 7,
+};
+
+// TODO: mode2
+
+static inline int channelReg(int channel)
+{
+  return regLED_FIRST + 4 * channel;
+}
+
+static inline void u16ToByte(uint16_t i, uint8_t *bytes)
+{
+  bytes[0] = i & 0xFF;
+  bytes[1] = i >> 8;
+}
+
+static void durationToBytes(uint16_t duration, uint8_t *bytes)
+{
+  if (duration >= 4096) {
+    u16ToByte(4096, bytes);
+    u16ToByte(0, bytes + 2);
+  }
+  else if (duration == 0) {
+    u16ToByte(0, bytes);
+    u16ToByte(4096, bytes + 2);
+  }
+  else {
+    u16ToByte(0, bytes);
+    u16ToByte(duration, bytes + 2);
+  }
+}
+
+static uint16_t dutyToDuration(float duty)
+{
+  duty = fmax(duty, 0.0f);
+  duty = fmin(duty, 1.0f);
+  return duty * 4096.0f;
+}
+
+//
+// SYNCHRONOUS
+// (see pca9685.h for function descriptions.)
+//
+
+bool pca9685init(int addr, float pwmFreq)
+{
+  if (!i2cdevInit(I2C1_DEV)) {
+    return false;
+  }
+
+  // initial state is sleeping.
+  // must be asleep to set PWM freq.
+
+  // set up value of Mode1 register. compared to default state, we:
+  // - wake up from sleep
+  // - enable AutoIncrement
+  // - disable AllCall
+  uint8_t mode1val = m1AutoIncr;
+
+  static float const OSC_CLOCK = 25.0f * 1000.0f * 1000.0f;
+  // according to my measurements with an oscilloscope,
+  // i think the datasheet is wrong about the minus one!
+  //int const prescale = OSC_CLOCK / (4096.0f * pwmFreq) + 0.5f - 1.0f
+  int const prescale = OSC_CLOCK / (4096.0f * pwmFreq) + 0.5f;
+  return
+    (prescale >= 0x03) && (prescale <= 0xFF) &&
+    i2cdevWriteByte(&deckBus, addr, regPreScale, (uint8_t)prescale) &&
+    i2cdevWriteByte(&deckBus, addr, regMode1, mode1val);
+}
+
+bool pca9685setDuties(
+  int addr, int chanBegin, int nChan, float const *duties)
+{
+  uint8_t data[LED_NBYTES];
+  for (int i = 0; i < nChan; ++i) {
+    uint16_t duration = dutyToDuration(duties[i]);
+    durationToBytes(duration, data + 4*i);
+  }
+  int const reg = channelReg(chanBegin);
+  return i2cdevWrite(&deckBus, addr, reg, 4*nChan, data);
+}
+
+bool pca9685setDurations(
+  int addr, int chanBegin, int nChan, uint16_t const *durations)
+{
+  uint8_t data[LED_NBYTES];
+  for (int i = 0; i < nChan; ++i) {
+    durationToBytes(durations[i], data + 4*i);
+  }
+  int const reg = channelReg(chanBegin);
+  return i2cdevWrite(&deckBus, addr, reg, 4*nChan, data);
+}
+
+//
+// ASYNCHRONOUS
+// (see pca9685.h for function descriptions.)
+//
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "config.h"
+
+struct asyncRequest
+{
+  int addr;
+  int chanBegin;
+  int nChan;
+  uint16_t durations[16];
+};
+
+static struct asyncRequest reqPush;
+static struct asyncRequest reqPop;
+
+static TaskHandle_t task;
+static QueueHandle_t queue;
+
+static void asyncTask(__attribute__((unused)) void *param)
+{
+  while (true) {
+    BaseType_t ok = xQueueReceive(queue, &reqPop, portMAX_DELAY);
+    if (ok == pdTRUE) {
+      // blocking message send.
+      pca9685setDurations(
+        reqPop.addr, reqPop.chanBegin, reqPop.nChan, reqPop.durations);
+    }
+  }
+}
+
+bool pca9685startAsyncTask()
+{
+  queue = xQueueCreate(1, sizeof(struct asyncRequest));
+  if (queue == 0) {
+    return false;
+  }
+
+  BaseType_t xReturned = xTaskCreate(
+    &asyncTask,
+    PCA9685_TASK_NAME,
+    PCA9685_TASK_STACKSIZE,
+    NULL,
+    PCA9685_TASK_PRI - 1,
+    &task);
+
+  return xReturned == pdPASS;
+}
+
+bool pca9685setDutiesAsync(
+  int addr, int chanBegin, int nChan, float const *duties)
+{
+  reqPush.addr = addr;
+  reqPush.chanBegin = chanBegin;
+  reqPush.nChan = nChan;
+  for (int i = 0; i < nChan; ++i) {
+    reqPush.durations[i] = dutyToDuration(duties[i]);
+  }
+  // drop message unless queue is empty!
+  xQueueSend(queue, &reqPush, 0);
+  return true;
+}
+
+bool pca9685setDurationsAsync(
+  int addr, int chanBegin, int nChan, uint16_t const *durations)
+{
+  reqPush.addr = addr;
+  reqPush.chanBegin = chanBegin;
+  reqPush.nChan = nChan;
+  for (int i = 0; i < nChan; ++i) {
+    reqPush.durations[i] = durations[i];
+  }
+  // drop message unless queue is empty!
+  xQueueSend(queue, &reqPush, 0);
+  return true;
+}


### PR DESCRIPTION
this driver only implements the minimal features of the hardware needed to drive ESCs:

- initialize with a fixed PWM frequency
- set duty or pulse duration
- async task for writes, to avoid blocking stabilizer task

notable missing features include:

- change PWM frequency after init
- sleep/wake
- software reset
- out-of-phase PWM cycles (for reducing peak current when PWM wave directly drives load)
- programmable behavior of OE pin
- "all call" and "sub call" multi-device addressing
- external clock

if other users need these features, let me know...