### PR TITLE
LOCO deck alternative pins for IRQ and RESET

### DIFF
--- a/src/deck/drivers/src/locodeck.c
+++ b/src/deck/drivers/src/locodeck.c
@@ -262,20 +262,9 @@ static void spiRead(dwDevice_t* dev, const void *header, size_t headerLength,
 
 #if LOCODECK_USE_ALT_PINS
 	void __attribute__((used)) EXTI5_Callback(void)
-	{
-	  portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
-
-	  NVIC_ClearPendingIRQ(EXTI_IRQChannel);
-	  EXTI_ClearITPendingBit(EXTI_LineN);
-
-	  //To unlock RadioTask
-	  xSemaphoreGiveFromISR(irqSemaphore, &xHigherPriorityTaskWoken);
-
-	  if(xHigherPriorityTaskWoken)
-		portYIELD();
-	}
 #else
 	void __attribute__((used)) EXTI11_Callback(void)
+#endif
 	{
 	  portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
 
@@ -288,9 +277,6 @@ static void spiRead(dwDevice_t* dev, const void *header, size_t headerLength,
 	  if(xHigherPriorityTaskWoken)
 		portYIELD();
 	}
-#endif
-
-
 
 static void spiSetSpeed(dwDevice_t* dev, dwSpiSpeed_t speed)
 {

--- a/src/deck/drivers/src/locodeck.c
+++ b/src/deck/drivers/src/locodeck.c
@@ -63,6 +63,26 @@
 
 #define CS_PIN DECK_GPIO_IO1
 
+// LOCO deck alternative IRQ and RESET pins(IO_2, IO_3) instead of default (RX1, TX1), leaving UART1 free for use
+#ifdef LOCODECK_USE_ALT_PINS
+    #define GPIO_PIN_IRQ 	GPIO_Pin_5
+	#define GPIO_PIN_RESET 	GPIO_Pin_4
+	#define GPIO_PORT		GPIOB
+	#define EXTI_PortSource EXTI_PortSourceGPIOB
+	#define EXTI_PinSource 	EXTI_PinSource5
+	#define EXTI_LineN 		EXTI_Line5
+	#define EXTI_IRQChannel EXTI9_5_IRQn
+#else
+    #define GPIO_PIN_IRQ 	GPIO_Pin_11
+	#define GPIO_PIN_RESET 	GPIO_Pin_10
+	#define GPIO_PORT		GPIOC
+	#define EXTI_PortSource EXTI_PortSourceGPIOC
+	#define EXTI_PinSource 	EXTI_PinSource11
+	#define EXTI_LineN 		EXTI_Line11
+	#define EXTI_IRQChannel EXTI15_10_IRQn
+#endif
+
+
 #if LPS_TDOA_ENABLE
   #define RX_TIMEOUT 10000
 #else
@@ -181,7 +201,7 @@ static void uwbTask(void* parameters)
     if (xSemaphoreTake(irqSemaphore, timeout/portTICK_PERIOD_MS)) {
       do{
           dwHandleInterrupt(dwm);
-      } while(digitalRead(DECK_GPIO_RX1) != 0);
+      } while(digitalRead(GPIO_PIN_IRQ) != 0);
     } else {
       timeout = algorithm->onEvent(dwm, eventTimeout);
     }
@@ -240,19 +260,37 @@ static void spiRead(dwDevice_t* dev, const void *header, size_t headerLength,
   spiEndTransaction();
 }
 
-void __attribute__((used)) EXTI11_Callback(void)
-{
-  portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
+#if LOCODECK_USE_ALT_PINS
+	void __attribute__((used)) EXTI5_Callback(void)
+	{
+	  portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
 
-  NVIC_ClearPendingIRQ(EXTI15_10_IRQn);
-  EXTI_ClearITPendingBit(EXTI_Line11);
+	  NVIC_ClearPendingIRQ(EXTI_IRQChannel);
+	  EXTI_ClearITPendingBit(EXTI_LineN);
 
-  //To unlock RadioTask
-  xSemaphoreGiveFromISR(irqSemaphore, &xHigherPriorityTaskWoken);
+	  //To unlock RadioTask
+	  xSemaphoreGiveFromISR(irqSemaphore, &xHigherPriorityTaskWoken);
 
-  if(xHigherPriorityTaskWoken)
-    portYIELD();
-}
+	  if(xHigherPriorityTaskWoken)
+		portYIELD();
+	}
+#else
+	void __attribute__((used)) EXTI11_Callback(void)
+	{
+	  portBASE_TYPE  xHigherPriorityTaskWoken = pdFALSE;
+
+	  NVIC_ClearPendingIRQ(EXTI_IRQChannel);
+	  EXTI_ClearITPendingBit(EXTI_LineN);
+
+	  //To unlock RadioTask
+	  xSemaphoreGiveFromISR(irqSemaphore, &xHigherPriorityTaskWoken);
+
+	  if(xHigherPriorityTaskWoken)
+		portYIELD();
+	}
+#endif
+
+
 
 static void spiSetSpeed(dwDevice_t* dev, dwSpiSpeed_t speed)
 {
@@ -290,33 +328,33 @@ static void dwm1000Init(DeckInfo *info)
 
   // Init IRQ input
   bzero(&GPIO_InitStructure, sizeof(GPIO_InitStructure));
-  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_11;
+  GPIO_InitStructure.GPIO_Pin = GPIO_PIN_IRQ;
   GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
   //GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_DOWN;
-  GPIO_Init(GPIOC, &GPIO_InitStructure);
+  GPIO_Init(GPIO_PORT, &GPIO_InitStructure);
 
-  SYSCFG_EXTILineConfig(EXTI_PortSourceGPIOC, EXTI_PinSource11);
+  SYSCFG_EXTILineConfig(EXTI_PortSource, EXTI_PinSource);
 
-  EXTI_InitStructure.EXTI_Line = EXTI_Line11;
+  EXTI_InitStructure.EXTI_Line = EXTI_LineN;
   EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
   EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
   EXTI_InitStructure.EXTI_LineCmd = ENABLE;
   EXTI_Init(&EXTI_InitStructure);
 
   // Init reset output
-  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_10;
+  GPIO_InitStructure.GPIO_Pin = GPIO_PIN_RESET;
   GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
   GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
   GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
-  GPIO_Init(GPIOC, &GPIO_InitStructure);
+  GPIO_Init(GPIO_PORT, &GPIO_InitStructure);
 
   // Init CS pin
   pinMode(CS_PIN, OUTPUT);
 
   // Reset the DW1000 chip
-  GPIO_WriteBit(GPIOC, GPIO_Pin_10, 0);
+  GPIO_WriteBit(GPIO_PORT, GPIO_PIN_RESET, 0);
   vTaskDelay(M2T(10));
-  GPIO_WriteBit(GPIOC, GPIO_Pin_10, 1);
+  GPIO_WriteBit(GPIO_PORT, GPIO_PIN_RESET, 1);
   vTaskDelay(M2T(10));
 
   // Initialize the driver
@@ -350,7 +388,7 @@ static void dwm1000Init(DeckInfo *info)
   dwCommitConfiguration(dwm);
 
   // Enable interrupt
-  NVIC_InitStructure.NVIC_IRQChannel = EXTI15_10_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannel = EXTI_IRQChannel;
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_LOW_PRI;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -25,3 +25,6 @@
 
 ## Set number of anchor in LocoPositioningSystem
 # CFLAGS += -DLOCODECK_NR_OF_ANCHORS=8
+
+## Set alternative pins for LOCO deck (IRQ=IO_2, RESET=IO_3, default are RX1 and TX1)
+# CFLAGS += -DLOCODECK_USE_ALT_PINS


### PR DESCRIPTION
Loco deck has an option for alternative pins for IRQ and RESET. This is the implementation that changes to the alternative pins set in the config.mk.

