### PR TITLE
add support for attitute quaternion state estimation in complementary…

### DIFF
--- a/src/modules/interface/sensfusion6.h
+++ b/src/modules/interface/sensfusion6.h
@@ -31,6 +31,7 @@ void sensfusion6Init(void);
 bool sensfusion6Test(void);
 
 void sensfusion6UpdateQ(float gx, float gy, float gz, float ax, float ay, float az, float dt);
+void sensfusion6GetQuaternion(float* qx, float* qy, float* qz, float* qw);
 void sensfusion6GetEulerRPY(float* roll, float* pitch, float* yaw);
 float sensfusion6GetAccZWithoutGravity(const float ax, const float ay, const float az);
 float sensfusion6GetInvThrustCompensationForTilt();

--- a/src/modules/src/estimator_complementary.c
+++ b/src/modules/src/estimator_complementary.c
@@ -32,7 +32,17 @@ void estimatorComplementary(state_t *state, sensorData_t *sensorData, control_t 
     sensfusion6UpdateQ(sensorData->gyro.x, sensorData->gyro.y, sensorData->gyro.z,
                        sensorData->acc.x, sensorData->acc.y, sensorData->acc.z,
                        ATTITUDE_UPDATE_DT);
+
+    // Save attitude, adjusted for the legacy CF2 body coordinate system
     sensfusion6GetEulerRPY(&state->attitude.roll, &state->attitude.pitch, &state->attitude.yaw);
+
+    // Save quaternion, hopefully one day this could be used in a better controller.
+    // Note that this is not adjusted for the legacy coordinate system
+    sensfusion6GetQuaternion(
+      &state->attitudeQuaternion.x,
+      &state->attitudeQuaternion.y,
+      &state->attitudeQuaternion.z,
+      &state->attitudeQuaternion.w);
 
     state->acc.z = sensfusion6GetAccZWithoutGravity(sensorData->acc.x,
                                                     sensorData->acc.y,

--- a/src/modules/src/sensfusion6.c
+++ b/src/modules/src/sensfusion6.c
@@ -253,6 +253,14 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
 }
 #endif
 
+void sensfusion6GetQuaternion(float* qx, float* qy, float* qz, float* qw)
+{
+  *qx = q1;
+  *qy = q2;
+  *qz = q3;
+  *qw = q0;
+}
+
 void sensfusion6GetEulerRPY(float* roll, float* pitch, float* yaw)
 {
   float gx = gravX;


### PR DESCRIPTION
… filter

This will avoid potential issues with new controllers while using the complementary filter instead of the EKF as state estimator.