### PR TITLE
commander packet for full-state control

### DIFF
--- a/src/modules/interface/quatcompress.h
+++ b/src/modules/interface/quatcompress.h
@@ -1,0 +1,86 @@
+#ifndef QUATCOMPRESS_H
+#define QUATCOMPRESS_H
+
+/*
+
+MIT License
+
+Copyright (c) 2016 James A. Preiss
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include <stdint.h>
+#include <math.h>
+
+// assumes input quaternion is normalized. will fail if not.
+static inline uint32_t quatcompress(float const q[4])
+{
+	// we send the values of the quaternion's smallest 3 elements.
+	unsigned i_largest = 0;
+	for (unsigned i = 1; i < 4; ++i) {
+		if (fabsf(q[i]) > fabsf(q[i_largest])) {
+			i_largest = i;
+		}
+	}
+
+	// since -q represents the same rotation as q,
+	// transform the quaternion so the largest element is positive.
+	// this avoids having to send its sign bit.
+	unsigned negate = q[i_largest] < 0;
+
+	// 1/sqrt(2) is the largest possible value 
+	// of the second-largest element in a unit quaternion.
+
+	// do compression using sign bit and 9-bit precision per element.
+	uint32_t comp = i_largest;
+	for (unsigned i = 0; i < 4; ++i) {
+		if (i != i_largest) {
+			unsigned negbit = (q[i] < 0) ^ negate;
+			unsigned mag = ((1 << 9) - 1) * (fabsf(q[i]) / (float)M_SQRT1_2) + 0.5f;
+			comp = (comp << 10) | (negbit << 9) | mag;
+		}
+	}
+
+	return comp;
+}
+
+static inline void quatdecompress(uint32_t comp, float q[4])
+{
+	unsigned const mask = (1 << 9) - 1;
+
+	int const i_largest = comp >> 30;
+	float sum_squares = 0;
+	for (int i = 3; i >= 0; --i) {
+		if (i != i_largest) {
+			unsigned mag = comp & mask;
+			unsigned negbit = (comp >> 9) & 0x1;
+			comp = comp >> 10;
+			q[i] = ((float)M_SQRT1_2) * ((float)mag) / mask;
+			if (negbit == 1) {
+				q[i] = -q[i];
+			}
+			sum_squares += q[i] * q[i];
+		}
+	}
+	q[i_largest] = sqrtf(1.0f - sum_squares);
+}
+
+#endif // QUATCOMPRESS_H

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -157,9 +157,11 @@ typedef struct setpoint_s {
 
   attitude_t attitude;
   attitude_t attitudeRate;
+  quaternion_t attitudeQuaternion;
   float thrust;
   point_t position;
   velocity_t velocity;
+  acc_t acceleration;
   bool velocity_body;
 
   struct {
@@ -169,6 +171,7 @@ typedef struct setpoint_s {
     stab_mode_t roll;
     stab_mode_t pitch;
     stab_mode_t yaw;
+    stab_mode_t quat;
   } mode;
 } setpoint_t;
 


### PR DESCRIPTION
This PR adds a generic commander packet for a full state setpoint, i.e. from an advanced trajectory planner. This is intended to be a first step towards implementing more onboard autonomy. By adding this packet, we can test onboard trajectory tracking controllers without needing to implement the whole framework of uploading trajectories, etc.

The packet includes position, velocity, acceleration, quaternion, and attitude rate. There is not enough room in the CRTP packet to include all these values as 32-bit floats, so we transmit fixed-point (integer number of millimeters / milliradians) and compress the quaternion into 32 bits. This gives a position range of +/- 32 meters, enough for most indoor operations. The attitude rate max is about 5 full circles per second, enough for anything but the most crazy flips.

It also adds acceleration and quaternion values to `struct setpoint_s` and another mode value for the quaternion. I could use some feedback on this part. If you accidentally set all of {`quat, roll, pitch, yaw`} to `modeAbs` then the setpoint is self-inconsistent. However, I think this is not the only possible problem with the `stab_mode_t` concept. For example, if the xyz position is set to `modeAbs`, should the controller ignore the velocity component of `setpoint_s`?

Maybe we can put off addressing these issues after we have more clearly defined all the possible control modes users might want?

(@whoenig and I will add support on the PC side in `crazyflie_ros` soon.)