### PR TITLE
add comments including the units used in datatypes

### DIFF
--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -83,9 +83,9 @@ typedef struct tdoaMeasurement_s {
 } tdoaMeasurement_t;
 
 typedef struct baro_s {
-  float pressure;
-  float temperature;
-  float asl;
+  float pressure;           // mbar
+  float temperature;        // degree Celcius
+  float asl;                // m (ASL = altitude above sea level)
 } baro_t;
 
 typedef struct positionMeasurement_s {
@@ -115,28 +115,28 @@ typedef struct distanceMeasurement_s {
 
 typedef struct zDistance_s {
   uint32_t timestamp;
-  float distance;
+  float distance;           // m
 } zDistance_t;
 
 typedef struct sensorData_s {
-  Axis3f acc;
-  Axis3f gyro;
-  Axis3f mag;
+  Axis3f acc;               // Gs
+  Axis3f gyro;              // deg/s
+  Axis3f mag;               // gauss
   baro_t baro;
   zDistance_t zrange;
-  point_t position;
+  point_t position;         // m
 #ifdef LOG_SEC_IMU
-  Axis3f accSec;
-  Axis3f gyroSec;
+  Axis3f accSec;            // Gs
+  Axis3f gyroSec;           // deg/s
 #endif
 } sensorData_t;
 
 typedef struct state_s {
-  attitude_t attitude;
+  attitude_t attitude;      // deg (legacy CF2 body coordinate system, where pitch is inverted)
   quaternion_t attitudeQuaternion;
-  point_t position;
-  velocity_t velocity;
-  acc_t acc;
+  point_t position;         // m
+  velocity_t velocity;      // m/s
+  acc_t acc;                // Gs (but acc.z without considering gravity)
 } state_t;
 
 typedef struct control_s {
@@ -155,14 +155,14 @@ typedef enum mode_e {
 typedef struct setpoint_s {
   uint32_t timestamp;
 
-  attitude_t attitude;
-  attitude_t attitudeRate;
+  attitude_t attitude;      // deg
+  attitude_t attitudeRate;  // deg/s
   quaternion_t attitudeQuaternion;
   float thrust;
-  point_t position;
-  velocity_t velocity;
-  acc_t acceleration;
-  bool velocity_body;
+  point_t position;         // m
+  velocity_t velocity;      // m/s
+  acc_t acceleration;       // m/s^2
+  bool velocity_body;       // true if velocity is given in body frame; false if velocity is given in world frame
 
   struct {
     stab_mode_t x;


### PR DESCRIPTION
I found the units used scattered around in the code and hope I didn't make any mistake (please double check). Also, from what I understand pitch is only inverted in state_t.attitude, but not setpoint_t.attitude?

(@jpreiss feel free to take a look if that matches your investigation)