### PR TITLE
Port and channels dedicated to GPS receiver exchange of informations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ OPENOCD_TARGET    ?= target/stm32f4x_stlink.cfg
 USE_FPU           ?= 1
 endif
 
-
 ifeq ($(PLATFORM), CF2)
 # Now needed for SYSLINK
 CFLAGS += -DUSE_RADIOLINK_CRTP     # Set CRTP link to radio

--- a/hal/src/ubx.h
+++ b/hal/src/ubx.h
@@ -1,0 +1,88 @@
+#ifndef __UBX_H__
+#define __UBX_H__
+
+struct aid_alpsrv {
+    uint8_t idSize;
+    uint8_t type;
+    uint16_t ofs;
+    uint16_t size;
+    uint16_t fileId;
+    uint16_t dataSize;
+    uint8_t id1;
+    uint8_t id2;
+    uint32_t id3;
+} __attribute__ ((packed));
+
+struct nav_posllh {
+    uint32_t itow;
+    int32_t lon;
+    int32_t lat;
+    int32_t height;
+    uint32_t hacc;
+    uint32_t vacc;
+} __attribute__ ((packed));
+  
+struct nav_pvt {
+    uint32_t iTow;
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t min;
+    uint8_t sec;
+    uint8_t valid;
+    uint32_t tAcc;
+    int32_t nano;
+    uint8_t fixType;
+    uint8_t flags;
+    uint8_t reserved1;
+    uint8_t numSV;
+    int32_t lon;
+    int32_t lat;
+    int32_t height;
+    int32_t hMSL;
+    uint32_t hAcc;
+    uint32_t vAcc;
+    int32_t velN;
+    int32_t velE;
+    int32_t velD;
+    int32_t gSpeed;
+    int32_t heading;
+    uint32_t sAcc;
+    uint32_t headingAcc;
+    uint16_t pDOP;
+    uint16_t reserved2;
+    uint32_t reserved3;
+} __attribute__ ((packed));
+
+struct ubx_message {
+    union {
+        struct {
+            uint8_t class;
+            uint8_t id;
+        } __attribute__ ((packed));
+        uint16_t class_id;
+    } __attribute__ ((packed));
+    uint16_t len;
+    union {
+        void * payload;
+        struct nav_pvt* nav_pvt;
+        struct nav_posllh* nav_posllh;
+        struct aid_alpsrv* naid_alpsrv;
+    };
+    union {
+        struct {
+            uint8_t ck_a;
+            uint8_t ck_b;
+        } __attribute__ ((packed));
+        uint16_t ck;
+    };
+} __attribute__ ((packed));
+
+#define CFG_MSG 0x0106
+#define AID_ALPSRV 0x320b
+
+#define NAV_POSLLH 0x0201
+#define NAV_PVT 0x0701
+
+#endif //__UBX_H__

--- a/src/deck/core/deck.c
+++ b/src/deck/core/deck.c
@@ -54,12 +54,15 @@ void deckInit()
 
   for (i=0; i<nDecks; i++) {
     DeckInfo *deck = deckInfo(i);
+    DEBUG_PRINT("%d deck OW codes %x-%x\n", i, deck->vid, deck->pid);
 
     if (deck->driver->init) {
       if (deck->driver->name) {
         DECK_CORE_DBG_PRINT("Calling INIT from driver %s for deck %i\n", deck->driver->name, i);
+        DEBUG_PRINT("Calling INIT from driver %s for deck %i\n", deck->driver->name, i);
       } else {
         DECK_CORE_DBG_PRINT("Calling INIT for deck %i\n", i);
+        DEBUG_PRINT("Calling INIT for deck %i\n", i);
       }
 
       deck->driver->init(deck);

--- a/src/deck/core/deck_drivers.c
+++ b/src/deck/core/deck_drivers.c
@@ -60,8 +60,10 @@ static void deckdriversInit() {
     for (i=0; i<driversLen; i++) {
       if (drivers[i]->name) {
         DECK_DRV_DBG_PRINT("VID:PID %02x:%02x (%s)\n", drivers[i]->vid, drivers[i]->pid, drivers[i]->name);
+        DEBUG_PRINT("VID:PID %02x:%02x (%s)\n", drivers[i]->vid, drivers[i]->pid, drivers[i]->name);
       } else {
-        DECK_DRV_DBG_PRINT("VID:PID %02x:%02x\n", drivers[i]->vid, drivers[i]->pid);
+        DECK_DRV_DBG_PRINT("VID:PID %02x:%02x (%s)\n", drivers[i]->vid, drivers[i]->pid, drivers[i]->name);
+        DEBUG_PRINT("VID:PID %02x:%02x (%s)\n", drivers[i]->vid, drivers[i]->pid, drivers[i]->name);
       }
 
     }

--- a/src/deck/core/deck_info.c
+++ b/src/deck/core/deck_info.c
@@ -60,7 +60,7 @@ static bool requiredLowInterferenceRadioMode = false;
 #define xstr(s) str(s)
 #define str(s) #s
 
-static char* deck_force = xstr(DECK_FORCE);
+static char* deck_force = xstr(bcGTGPS);
 
 void deckInfoInit()
 {
@@ -131,6 +131,8 @@ void printDeckInfo(DeckInfo *info)
     DEBUG_PRINT("Warning! No driver found for deck.\n");
   } else {
     DECK_INFO_DBG_PRINT("Driver implements: [ %s%s]\n",
+                        info->driver->init?"init ":"", info->driver->test?"test ":"");
+    DEBUG_PRINT("Driver implements: [ %s%s]\n",
                         info->driver->init?"init ":"", info->driver->test?"test ":"");
   }
 }

--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -81,7 +81,7 @@ typedef void (*Ledring12Effect)(uint8_t buffer[][3], bool reset);
 #define LINSCALE(domain_low, domain_high, codomain_low, codomain_high, value) ((codomain_high - codomain_low) / (domain_high - domain_low)) * (value - domain_low) + codomain_low
 #define SET_WHITE(dest, intensity) dest[0] = intensity; dest[1] = intensity; dest[2] = intensity;
 
-static uint32_t effect = 6;
+static uint32_t effect = 0;
 static uint32_t neffect;
 static uint8_t headlightEnable = 0;
 static uint8_t black[][3] = {BLACK, BLACK, BLACK,
@@ -207,10 +207,10 @@ static void boatEffect(uint8_t buffer[][3], bool reset)
 {
   int i;
 
-  uint8_t reds[] = {1,2,3,4,5};
-  uint8_t greens[] = {7,8,9,10,11};
-  uint8_t whites[] = {0};
-  uint8_t blacks[] = {6};
+  uint8_t reds[] = {8,9,10,11};
+  uint8_t greens[] = {1,2,3,4};
+  uint8_t whites[] = {5,6,7};
+  uint8_t blacks[] = {0};
 
 
   for (i=0; i<sizeof(reds); i++)

--- a/src/drivers/src/lps25h.c
+++ b/src/drivers/src/lps25h.c
@@ -175,7 +175,8 @@ float lps25hPressureToAltitude(float* pressure/*, float* ground_pressure, float*
     {
         //return (1.f - pow(*pressure / CONST_SEA_PRESSURE, CONST_PF)) * CONST_PF2;
         //return ((pow((1015.7 / *pressure), CONST_PF) - 1.0) * (25. + 273.15)) / 0.0065;
-        return ((powf((1015.7f / *pressure), CONST_PF) - 1.0f) * (FIX_TEMP + 273.15f)) / 0.0065f;
+        //return ((powf((1015.7f / *pressure), CONST_PF) - 1.0f) * (FIX_TEMP + 273.15f)) / 0.0065f;
+        return (- (float)8.68 * (*pressure)) + (float)8795.;
     }
     else
     {

--- a/src/hal/interface/pm.h
+++ b/src/hal/interface/pm.h
@@ -46,14 +46,17 @@
 #else
   #define PM_BAT_LOW_VOLTAGE   LOW_VOLTAGE
 #endif
+
 #ifndef LOW_TIMEOUT
   #define PM_BAT_LOW_TIMEOUT   M2T(1000 * 5) // 5 sec default
 #else
   #define PM_BAT_LOW_TIMEOUT   LOW_TIMEOUT
 #endif
 
+#define ACTIVATE_AUTO_SHUTDOWN
+
 #ifndef SYSTEM_SHUTDOWN_TIMEOUT
-  #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * 5) // 5 min default
+  #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * 2) // 2 min default
 #else
   #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * SYSTEM_SHUTDOWN_TIMEOUT)
 #endif

--- a/src/hal/src/pm_f103.c
+++ b/src/hal/src/pm_f103.c
@@ -258,7 +258,7 @@ static void pmSetBatteryVoltage(float voltage)
 static void pmSystemShutdown(void)
 {
 #ifdef ACTIVATE_AUTO_SHUTDOWN
-  GPIO_SetBits(PM_GPIO_SYSOFF_PORT, PM_GPIO_SYSOFF);
+  //GPIO_SetBits(PM_GPIO_SYSOFF_PORT, PM_GPIO_SYSOFF);
 #endif
 }
 

--- a/src/hal/src/pm_f405.c
+++ b/src/hal/src/pm_f405.c
@@ -135,7 +135,10 @@ static void pmSetBatteryVoltage(float voltage)
 static void pmSystemShutdown(void)
 {
 #ifdef ACTIVATE_AUTO_SHUTDOWN
-//TODO: Implement syslink call to shutdown
+  SyslinkPacket slp;
+  slp.type = SYSLINK_PM_ONOFF_SWITCHOFF;
+  slp.length = 0;
+  syslinkSendPacket(&slp);
 #endif
 }
 
@@ -367,7 +370,7 @@ void pmTask(void *param)
         break;
       case battery:
         {
-          if ((commanderGetInactivityTime() > PM_SYSTEM_SHUTDOWN_TIMEOUT))
+          if ((commanderGetInactivityTime() > PM_SYSTEM_SHUTDOWN_TIMEOUT) && systemStop())
           {
             pmSystemShutdown();
           }

--- a/src/hal/src/usec_time.c
+++ b/src/hal/src/usec_time.c
@@ -69,6 +69,10 @@ uint64_t usecTimestamp(void)
   __atomic_load(&usecTimerHighCount, &high0, __ATOMIC_SEQ_CST);
   uint32_t low = TIM7->CNT;
   uint32_t high;
+  uint32_t low;
+
+  __atomic_load(&usecTimerHighCount, &high0, __ATOMIC_SEQ_CST);
+  low = TIM1->CNT;
   __atomic_load(&usecTimerHighCount, &high, __ATOMIC_SEQ_CST);
 
   // There was no increment in between

--- a/src/hal/src/usec_time.c
+++ b/src/hal/src/usec_time.c
@@ -69,7 +69,6 @@ uint64_t usecTimestamp(void)
   __atomic_load(&usecTimerHighCount, &high0, __ATOMIC_SEQ_CST);
   uint32_t low = TIM7->CNT;
   uint32_t high;
-  uint32_t low;
 
   __atomic_load(&usecTimerHighCount, &high0, __ATOMIC_SEQ_CST);
   low = TIM1->CNT;

--- a/src/init/main.c
+++ b/src/init/main.c
@@ -46,7 +46,6 @@ int main()
 {
   //Initialize the platform.
   platformInit();
-
   //Launch the system task that will initialize and start everything
   systemLaunch();
 

--- a/src/modules/interface/crtp_localization_service.h
+++ b/src/modules/interface/crtp_localization_service.h
@@ -45,6 +45,8 @@ typedef enum
   LPS_SHORT_LPP_PACKET    = 2,
   EMERGENCY_STOP          = 3,
   EMERGENCY_STOP_WATCHDOG = 4,
+  COMM_GPS_NMEA           = 6,
+  COMM_GPS_PROPRIETARY    = 7,
 } locsrv_t;
 
 // Set up the callback for the CRTP_PORT_LOCALIZATION

--- a/src/modules/interface/system.h
+++ b/src/modules/interface/system.h
@@ -39,5 +39,6 @@ void systemStart();
 void systemWaitStart(void);
 void systemSetCanFly(bool val);
 bool systemCanFly(void);
+bool systemStop(void);
 
 #endif //__SYSTEM_H__

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -82,7 +82,7 @@ void stateController(control_t *control, setpoint_t *setpoint,
 
     // TODO: Investigate possibility to subtract gyro drift.
     attitudeControllerCorrectRatePID(sensors->gyro.x, -sensors->gyro.y, sensors->gyro.z,
-                             rateDesired.roll, rateDesired.pitch, rateDesired.yaw);
+                             rateDesired.roll, rateDesired.pitch, rateDesired.yaw); //// cas du vol stationnaire ?
 
     attitudeControllerGetActuatorOutput(&control->roll,
                                         &control->pitch,

--- a/src/modules/src/crtp_commander_rpyt.c
+++ b/src/modules/src/crtp_commander_rpyt.c
@@ -172,7 +172,7 @@ void crtpCommanderRpytDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk)
     setpoint->attitude.pitch = 0;
     setpoint->attitude.yaw = values->yaw;
     setpoint->thrust = 0;
-  } else {
+  } else { /////////////////////////////////cas sans assistance, althold et heighthold et hover ????
     setpoint->mode.x = modeDisable;
     setpoint->mode.y = modeDisable;
 

--- a/src/modules/src/queuemonitor.c
+++ b/src/modules/src/queuemonitor.c
@@ -150,7 +150,7 @@ static bool filter(Data* queueData) {
 }
 
 static void debugPrintQueue(Data* queueData) {
-  DEBUG_PRINT("%s:%s, sent: %i, peak: %i, full: %i\n",
+  DEBUG_PRINT("XXXX Queue %s:%s, sent: %i, peak: %i, full: %i\n",
     queueData->fileName, queueData->queueName, queueData->sendCount,
     queueData->maxWaiting, queueData->fullCount);
 }

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -68,6 +68,7 @@
 static bool selftestPassed;
 static bool canFly;
 static bool isInit;
+static bool timeOutSys = true;
 
 /* System wide synchronisation */
 xSemaphoreHandle canStartMutex;
@@ -143,7 +144,7 @@ void systemTask(void *arg)
 #endif
 
 #ifdef ENABLE_UART1
-  uart1Init();
+  uart1Init(UART1_BAUDRATE);
 #endif
 #ifdef ENABLE_UART2
   uart2Init();
@@ -272,18 +273,26 @@ void vApplicationIdleHook( void )
 #endif
 }
 
-/*System parameters (mostly for test, should be removed from here) */
+bool systemStop(void)
+{
+return timeOutSys;
+}
+
+/*System parameters (mostly for test, should be removed from here)
 PARAM_GROUP_START(cpu)
 PARAM_ADD(PARAM_UINT16 | PARAM_RONLY, flash, MCU_FLASH_SIZE_ADDRESS)
 PARAM_ADD(PARAM_UINT32 | PARAM_RONLY, id0, MCU_ID_ADDRESS+0)
 PARAM_ADD(PARAM_UINT32 | PARAM_RONLY, id1, MCU_ID_ADDRESS+4)
 PARAM_ADD(PARAM_UINT32 | PARAM_RONLY, id2, MCU_ID_ADDRESS+8)
-PARAM_GROUP_STOP(cpu)
+PARAM_GROUP_STOP(cpu)*/
 
 PARAM_GROUP_START(system)
 PARAM_ADD(PARAM_INT8, selftestPassed, &selftestPassed)
 PARAM_GROUP_STOP(sytem)
 
+PARAM_GROUP_START(pm)
+PARAM_ADD(PARAM_UINT8, timeOutSystem, &timeOutSys)
+PARAM_GROUP_STOP(pm)
 /* Loggable variables */
 LOG_GROUP_START(sys)
 LOG_ADD(LOG_INT8, canfly, &canFly)


### PR DESCRIPTION
Two channels to be dedicated to communication with GPS receiver. Useful to avoid mixing of standard console communication and differentiation between NMEA and chip proprietary messages. If not, everything would be mixed. 
Branch nexon_gps
 Validated modifications:
	modified:         src/modules/interface/crtp_localization_service.h