### PR TITLE
Improved debugger support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,13 @@ endif
 #Flash the stm.
 flash:
 	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
-                 -c "flash write_image erase $(PROG).elf" -c "verify_image $(PROG).elf" -c "reset run" -c shutdown
+                 -c "flash write_image erase $(PROG).bin $(LOAD_ADDRESS) bin" \
+                 -c "verify_image $(PROG).bin $(LOAD_ADDRESS) bin" -c "reset run" -c shutdown
+
+#verify only
+flash_verify:
+	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
+                 -c "verify_image $(PROG).bin $(LOAD_ADDRESS) bin" -c "reset run" -c shutdown
 
 flash_dfu:
 	$(DFU_UTIL) -a 0 -D $(PROG).dfu

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -31,3 +31,8 @@
 
 ## Compile positioning system for TDoA mode
 # LPS_TDOA_ENABLE=1
+
+## Use J-Link as Debugger/flasher
+# OPENOCD_INTERFACE ?= interface/jlink.cfg
+# OPENOCD_TARGET    ?= target/stm32f4x.cfg
+# OPENOCD_CMDS      ?= -c "transport select swd"


### PR DESCRIPTION
This change fixes a number of issues:
 * when using "make flash" it now flashes at the correct address, depending on CLOAD
 * A new command "make flash_verify" can be used to just verify the current firmware
 * "make flash" and "make flash_verify" now use the same (bin)-file as the cloader script
 * Included a template for the use of J-Link debuggers

Tested with ST-Link/V2 and J-Link EDU Mini using openocd 0.10.0