### PR TITLE
Remove clean from compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ endif
 
 all: check_submodules build
 build: 
+	# Each target is in a different line, so they are executed one after the other even when the processor has multiple cores (when the -j option for the make command is > 1). See: https://www.gnu.org/software/make/manual/html_node/Parallel.html
 	@$(MAKE) clean_version
 	@$(MAKE) compile
 	@$(MAKE) print_version 

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ endif
 
 all: check_submodules build
 build: clean_version compile print_version size
-compile: clean_version $(PROG).hex $(PROG).bin $(PROG).dfu
+compile: $(PROG).hex $(PROG).bin $(PROG).dfu
 
 libarm_math.a:
 	+$(MAKE) -C tools/make/cmsis_dsp/ V=$(V)

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,11 @@ endif
 
 
 all: check_submodules build
-build: clean_version compile print_version size
+build: 
+	@$(MAKE) clean_version
+	@$(MAKE) compile
+	@$(MAKE) print_version 
+	@$(MAKE) size
 compile: $(PROG).hex $(PROG).bin $(PROG).dfu
 
 libarm_math.a:
@@ -334,7 +338,7 @@ ifeq ($(SHELL),/bin/sh)
 	@rm -f version.c
 endif
 
-print_version: compile
+print_version:
 ifeq ($(PLATFORM), CF2)
 	@echo "Crazyflie 2.0 build!"
 endif
@@ -346,7 +350,7 @@ ifeq ($(FATFS_DISKIO_TESTS), 1)
 	@echo "WARNING: FatFS diskio tests enabled. Erases SD-card!"
 endif
 
-size: compile
+size:
 	@$(SIZE) -B $(PROG).elf
 
 #Radio bootloader

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ endif
 
 all: check_submodules build
 build: 
-	# Each target is in a different line, so they are executed one after the other even when the processor has multiple cores (when the -j option for the make command is > 1). See: https://www.gnu.org/software/make/manual/html_node/Parallel.html
+# Each target is in a different line, so they are executed one after the other even when the processor has multiple cores (when the -j option for the make command is > 1). See: https://www.gnu.org/software/make/manual/html_node/Parallel.html
 	@$(MAKE) clean_version
 	@$(MAKE) compile
 	@$(MAKE) print_version 


### PR DESCRIPTION
In this PR:
* Make the build target run in serie: when using `-j2`, there were cases were the version file was being cleaned after the build, and not before. NOTE: compilation is still done in paralell, which is what gives the speed improvements.
* Avoid cleaning the version when compiling. From the readme:
```
compile    : Compile cflie.hex. WARNING: Do NOT update version.c
build      : Update version.c and compile cflie.elf/hex
```
* Remove unnecesary dependencies between the `compile` target and the `print_version` and `size` targets.