### PR TITLE
 Add option to dynamically change estimator using "stabilizer.estimator" parameter

### DIFF
--- a/src/modules/interface/estimator.h
+++ b/src/modules/interface/estimator.h
@@ -32,6 +32,7 @@ typedef enum {
   anyEstimator = 0,
   complementaryEstimator,
   kalmanEstimator,
+  StateEstimatorTypeCount,
 } StateEstimatorType;
 
 void stateEstimatorInit(StateEstimatorType estimator);

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -8,7 +8,6 @@
 
 #define DEFAULT_ESTIMATOR complementaryEstimator
 static StateEstimatorType currentEstimator = anyEstimator;
-static bool isInit;
 
 static void initEstimator();
 
@@ -26,8 +25,6 @@ static EstimatorFcns estimatorFunctions[] = {
 
 
 void stateEstimatorInit(StateEstimatorType estimator) {
-  ASSERT(!isInit);
-
   currentEstimator = estimator;
 
   if (anyEstimator == currentEstimator) {
@@ -41,7 +38,6 @@ void stateEstimatorInit(StateEstimatorType estimator) {
   }
 
   initEstimator();
-  isInit = true;
 
   DEBUG_PRINT("Using estimator %d\n", currentEstimator);
 }

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -25,6 +25,10 @@ static EstimatorFcns estimatorFunctions[] = {
 
 
 void stateEstimatorInit(StateEstimatorType estimator) {
+  if (estimator < 0 || estimator >= StateEstimatorTypeCount) {
+    return;
+  }
+
   currentEstimator = estimator;
 
   if (anyEstimator == currentEstimator) {

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -54,6 +54,8 @@ static sensorData_t sensorData;
 static state_t state;
 static control_t control;
 
+static StateEstimatorType estimatorType;
+
 static void stabilizerTask(void* param);
 
 void stabilizerInit(StateEstimatorType estimator)
@@ -69,6 +71,7 @@ void stabilizerInit(StateEstimatorType estimator)
   {
     sitAwInit();
   }
+  estimatorType = getStateEstimator();
 
   xTaskCreate(stabilizerTask, STABILIZER_TASK_NAME,
               STABILIZER_TASK_STACKSIZE, NULL, STABILIZER_TASK_PRI, NULL);
@@ -124,6 +127,11 @@ static void stabilizerTask(void* param)
   while(1) {
     vTaskDelayUntil(&lastWakeTime, F2T(RATE_MAIN_LOOP));
 
+    // allow to update estimator dynamically
+    if (getStateEstimator() != estimatorType) {
+      stateEstimatorInit(estimatorType);
+    }
+
     getExtPosition(&state);
     stateEstimator(&state, &sensorData, &control, tick);
 
@@ -160,6 +168,10 @@ void stabilizerSetEmergencyStopTimeout(int timeout)
   emergencyStop = false;
   emergencyStopTimeout = timeout;
 }
+
+PARAM_GROUP_START(stabilizer)
+PARAM_ADD(PARAM_UINT8, estimator, &estimatorType)
+PARAM_GROUP_STOP(stabilizer)
 
 LOG_GROUP_START(ctrltarget)
 LOG_ADD(LOG_FLOAT, roll, &setpoint.attitude.roll)

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -130,6 +130,7 @@ static void stabilizerTask(void* param)
     // allow to update estimator dynamically
     if (getStateEstimator() != estimatorType) {
       stateEstimatorInit(estimatorType);
+      estimatorType = getStateEstimator();
     }
 
     getExtPosition(&state);


### PR DESCRIPTION
This adds a new parameter ("stabilizer.estimator") such that a user can switch the estimator at runtime, independent of the decks available.