### PR TITLE
Add option to switch controllers dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ LPS_TDOA_ENABLE   ?= 0
 ######### Stabilizer configuration ##########
 ##### Sets the name of the stabilizer module to use.
 ESTIMATOR          ?= any
-CONTROLLER         ?= pid
+CONTROLLER         ?= Any # one of Any, PID, Mellinger
 POWER_DISTRIBUTION ?= stock
 SENSORS 					 ?= cf2
 
@@ -155,7 +155,7 @@ PROJ_OBJ += crtp_commander_generic.o crtp_localization_service.o
 PROJ_OBJ += attitude_pid_controller.o sensfusion6.o stabilizer.o
 PROJ_OBJ += position_estimator_altitude.o position_controller_pid.o
 PROJ_OBJ += estimator.o estimator_complementary.o
-PROJ_OBJ += controller_$(CONTROLLER).o
+PROJ_OBJ += controller.o controller_pid.o controller_mellinger.o
 PROJ_OBJ += power_distribution_$(POWER_DISTRIBUTION).o
 PROJ_OBJ_CF2 += estimator_kalman.o
 
@@ -270,7 +270,7 @@ ifeq ($(USE_ESKYLINK), 1)
   CFLAGS += -DUSE_ESKYLINK
 endif
 
-CFLAGS += -DBOARD_REV_$(REV) -DESTIMATOR_NAME=$(ESTIMATOR)Estimator -DCONTROLLER_TYPE_$(CONTROLLER) -DPOWER_DISTRIBUTION_TYPE_$(POWER_DISTRIBUTION)
+CFLAGS += -DBOARD_REV_$(REV) -DESTIMATOR_NAME=$(ESTIMATOR)Estimator -DCONTROLLER_NAME=ControllerType$(CONTROLLER) -DPOWER_DISTRIBUTION_TYPE_$(POWER_DISTRIBUTION)
 
 CFLAGS += $(PROCESSOR) $(INCLUDES) $(STFLAGS)
 ifeq ($(PLATFORM), CF2)

--- a/src/modules/interface/controller_mellinger.h
+++ b/src/modules/interface/controller_mellinger.h
@@ -21,26 +21,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * controller.h - Controller interface
+ * controller_pid.h - Mellinger Controller Interface
  */
-#ifndef __CONTROLLER_H__
-#define __CONTROLLER_H__
+#ifndef __CONTROLLER_MELLINGER_H__
+#define __CONTROLLER_MELLINGER_H__
 
 #include "stabilizer_types.h"
 
-typedef enum {
-  ControllerTypeAny,
-  ControllerTypePID,
-  ControllerTypeMellinger,
-  ControllerType_COUNT,
-} ControllerType;
-
-void controllerInit(ControllerType controller);
-bool controllerTest(void);
-void controller(control_t *control, setpoint_t *setpoint,
+void controllerMellingerInit(void);
+bool controllerMellingerTest(void);
+void controllerMellinger(control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);
-ControllerType getControllerType(void);
 
-#endif //__CONTROLLER_H__
+#endif //__CONTROLLER_MELLINGER_H__

--- a/src/modules/interface/controller_pid.h
+++ b/src/modules/interface/controller_pid.h
@@ -21,26 +21,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * controller.h - Controller interface
+ * controller_pid.h - PID Controller Interface
  */
-#ifndef __CONTROLLER_H__
-#define __CONTROLLER_H__
+#ifndef __CONTROLLER_PID_H__
+#define __CONTROLLER_PID_H__
 
 #include "stabilizer_types.h"
 
-typedef enum {
-  ControllerTypeAny,
-  ControllerTypePID,
-  ControllerTypeMellinger,
-  ControllerType_COUNT,
-} ControllerType;
-
-void controllerInit(ControllerType controller);
-bool controllerTest(void);
-void controller(control_t *control, setpoint_t *setpoint,
+void controllerPidInit(void);
+bool controllerPidTest(void);
+void controllerPid(control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);
-ControllerType getControllerType(void);
 
-#endif //__CONTROLLER_H__
+#endif //__CONTROLLER_PID_H__

--- a/src/modules/src/controller.c
+++ b/src/modules/src/controller.c
@@ -1,0 +1,63 @@
+#define DEBUG_MODULE "CONTROLLER"
+#include "debug.h"
+
+#include "cfassert.h"
+#include "controller.h"
+#include "controller_pid.h"
+#include "controller_mellinger.h"
+
+#define DEFAULT_CONTROLLER ControllerTypePID
+static ControllerType currentController = ControllerTypeAny;
+
+static void initController();
+
+typedef struct {
+  void (*init)(void);
+  bool (*test)(void);
+  void (*update)(control_t *control, setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick);
+} ControllerFcns;
+
+static ControllerFcns controllerFunctions[] = {
+  {.init = 0, .test = 0, .update = 0}, // Any
+  {.init = controllerPidInit, .test = controllerPidTest, .update = controllerPid},
+  {.init = controllerMellingerInit, .test = controllerMellingerTest, .update = controllerMellinger},
+};
+
+
+void controllerInit(ControllerType controller) {
+  if (controller < 0 || controller >= ControllerType_COUNT) {
+    return;
+  }
+
+  currentController = controller;
+
+  if (ControllerTypeAny == currentController) {
+    currentController = DEFAULT_CONTROLLER;
+  }
+
+  ControllerType forcedController = CONTROLLER_NAME;
+  if (forcedController != ControllerTypeAny) {
+    DEBUG_PRINT("Controller type forced\n");
+    currentController = forcedController;
+  }
+
+  initController();
+
+  DEBUG_PRINT("Using controller %d\n", currentController);
+}
+
+ControllerType getControllerType(void) {
+  return currentController;
+}
+
+static void initController() {
+  controllerFunctions[currentController].init();
+}
+
+bool controllerTest(void) {
+  return controllerFunctions[currentController].test();
+}
+
+void controller(control_t *control, setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick) {
+  controllerFunctions[currentController].update(control, setpoint, sensors, state, tick);
+}

--- a/src/modules/src/controller_mellinger.c
+++ b/src/modules/src/controller_mellinger.c
@@ -41,6 +41,7 @@ We added the following:
 #include "log.h"
 #include "math3d.h"
 #include "position_controller.h"
+#include "controller_mellinger.h"
 
 #define GRAVITY_MAGNITUDE (9.81f)
 
@@ -92,16 +93,7 @@ static float i_error_m_z = 0;
 // Logging variables
 static struct vec z_axis_desired;
 
-void stateControllerInit(void)
-{
-}
-
-bool stateControllerTest(void)
-{
-  return true;
-}
-
-void stateControllerReset(void)
+void controllerMellingerReset(void)
 {
   i_error_x = 0;
   i_error_y = 0;
@@ -111,13 +103,23 @@ void stateControllerReset(void)
   i_error_m_z = 0;
 }
 
+void controllerMellingerInit(void)
+{
+  controllerMellingerReset();
+}
+
+bool controllerMellingerTest(void)
+{
+  return true;
+}
+
 float clamp(float value, float min, float max) {
   if (value < min) return min;
   if (value > max) return max;
   return value;
 }
 
-void stateController(control_t *control, setpoint_t *setpoint,
+void controllerMellinger(control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick)
@@ -297,7 +299,7 @@ void stateController(control_t *control, setpoint_t *setpoint,
     control->roll = 0;
     control->pitch = 0;
     control->yaw = 0;
-    stateControllerReset();
+    controllerMellingerReset();
   }
 }
 

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -5,6 +5,7 @@
 #include "attitude_controller.h"
 #include "sensfusion6.h"
 #include "position_controller.h"
+#include "controller_pid.h"
 
 #include "log.h"
 #include "param.h"
@@ -17,13 +18,13 @@ static attitude_t attitudeDesired;
 static attitude_t rateDesired;
 static float actuatorThrust;
 
-void stateControllerInit(void)
+void controllerPidInit(void)
 {
   attitudeControllerInit(ATTITUDE_UPDATE_DT);
   positionControllerInit();
 }
 
-bool stateControllerTest(void)
+bool controllerPidTest(void)
 {
   bool pass = true;
 
@@ -32,7 +33,7 @@ bool stateControllerTest(void)
   return pass;
 }
 
-void stateController(control_t *control, setpoint_t *setpoint,
+void controllerPid(control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick)

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -55,6 +55,7 @@ static state_t state;
 static control_t control;
 
 static StateEstimatorType estimatorType;
+static ControllerType controllerType;
 
 static void stabilizerTask(void* param);
 
@@ -65,13 +66,14 @@ void stabilizerInit(StateEstimatorType estimator)
 
   sensorsInit();
   stateEstimatorInit(estimator);
-  stateControllerInit();
+  controllerInit(ControllerTypeAny);
   powerDistributionInit();
   if (estimator == kalmanEstimator)
   {
     sitAwInit();
   }
   estimatorType = getStateEstimator();
+  controllerType = getControllerType();
 
   xTaskCreate(stabilizerTask, STABILIZER_TASK_NAME,
               STABILIZER_TASK_STACKSIZE, NULL, STABILIZER_TASK_PRI, NULL);
@@ -85,7 +87,7 @@ bool stabilizerTest(void)
 
   pass &= sensorsTest();
   pass &= stateEstimatorTest();
-  pass &= stateControllerTest();
+  pass &= controllerTest();
   pass &= powerDistributionTest();
 
   return pass;
@@ -132,6 +134,11 @@ static void stabilizerTask(void* param)
       stateEstimatorInit(estimatorType);
       estimatorType = getStateEstimator();
     }
+    // allow to update controller dynamically
+    if (getControllerType() != controllerType) {
+      controllerInit(controllerType);
+      controllerType = getControllerType();
+    }
 
     getExtPosition(&state);
     stateEstimator(&state, &sensorData, &control, tick);
@@ -140,7 +147,7 @@ static void stabilizerTask(void* param)
 
     sitAwUpdateSetpoint(&setpoint, &sensorData, &state);
 
-    stateController(&control, &setpoint, &sensorData, &state, tick);
+    controller(&control, &setpoint, &sensorData, &state, tick);
 
     checkEmergencyStopTimeout();
 
@@ -172,6 +179,7 @@ void stabilizerSetEmergencyStopTimeout(int timeout)
 
 PARAM_GROUP_START(stabilizer)
 PARAM_ADD(PARAM_UINT8, estimator, &estimatorType)
+PARAM_ADD(PARAM_UINT8, controller, &controllerType)
 PARAM_GROUP_STOP(stabilizer)
 
 LOG_GROUP_START(ctrltarget)


### PR DESCRIPTION
* New parameter: "stabilizer.controller"
* Default controller as before (PID)
* It is now possible to switch at runtime to another
  controller (e.g., mellinger, for the Crazyswarm)