### PR TITLE
Fixed default address of VL53L1X driver from 0x51 to 0x52 to reflect …

### DIFF
--- a/src/drivers/interface/vl53l1x.h
+++ b/src/drivers/interface/vl53l1x.h
@@ -39,7 +39,7 @@ extern "C"
 {
 #endif
 
-#define VL53L1X_DEFAULT_ADDRESS 0b0101001
+#define VL53L1X_DEFAULT_ADDRESS 0b01010010
 
 #define USE_I2C_2V8
 


### PR DESCRIPTION
Fixed default address of VL53L1X driver from 0x51 to 0x52 to reflect the actual default address as reported in the datasheet.
