### PR TITLE
Remove max,min,isnan macros in favor of built-ins

### DIFF
--- a/src/modules/src/crtp_commander_rpyt.c
+++ b/src/modules/src/crtp_commander_rpyt.c
@@ -133,7 +133,7 @@ void crtpCommanderRpytDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk)
   if (thrustLocked || (rawThrust < MIN_THRUST)) {
     setpoint->thrust = 0;
   } else {
-    setpoint->thrust = min(rawThrust, MAX_THRUST);
+    setpoint->thrust = fminf(rawThrust, MAX_THRUST);
   }
 
   if (altHoldMode) {

--- a/src/modules/src/pid.c
+++ b/src/modules/src/pid.c
@@ -27,6 +27,7 @@
 
 #include "pid.h"
 #include "num.h"
+#include <math.h>
 #include <float.h>
 
 void pidInit(PidObject* pid, const float desired, const float kp,

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -168,7 +168,7 @@ void positionController(float* thrust, attitude_t *attitude, setpoint_t *setpoin
   this.pidY.pid.outputLimit = xyVelMax * velMaxOverhead;
   // The ROS landing detector will prematurely trip if
   // this value is below 0.5
-  this.pidZ.pid.outputLimit = max(zVelMax, 0.5f)  * velMaxOverhead;
+  this.pidZ.pid.outputLimit = fmaxf(zVelMax, 0.5f)  * velMaxOverhead;
 
   float cosyaw = cosf(state->attitude.yaw * (float)M_PI / 180.0f);
   float sinyaw = sinf(state->attitude.yaw * (float)M_PI / 180.0f);

--- a/src/utils/interface/num.h
+++ b/src/utils/interface/num.h
@@ -29,18 +29,6 @@
 
 #include <stdint.h>
 
-#undef max
-#define max(a,b) ((a) > (b) ? (a) : (b))
-#undef min
-#define min(a,b) ((a) < (b) ? (a) : (b))
-
-#undef abs
-#define abs(a) ((a) > 0 ? (a) : (-1*(a)))
-
-#undef isnan
-#define isnan(n) ((n != n) ? 1 : 0)
-
-
 uint16_t single2half(float number);
 float half2single(uint16_t number);
 

--- a/src/utils/src/num.c
+++ b/src/utils/src/num.c
@@ -102,7 +102,7 @@ uint16_t limitUint16(int32_t value)
 
 float constrain(float value, const float minVal, const float maxVal)
 {
-  return min(maxVal, max(minVal,value));
+  return fminf(maxVal, fmaxf(minVal,value));
 }
 
 float deadband(float value, const float threshold)


### PR DESCRIPTION
This change removes the max,min and isnan macros
in num.h. The min, max macros are replaced by
fminf and fmaxf, avoiding side-effects that can
be caused by macros.

isnan is replaced by the compiler-provided
macro (part of math.h).

This fixes issue #352.