### PR TITLE
feat: pca9555 library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ PROJ_OBJ_CF2 += uart_syslink.o swd.o uart1.o uart2.o watchdog.o
 PROJ_OBJ_CF2 += cppm.o
 PROJ_OBJ_CF2 += bmi055_accel.o bmi055_gyro.o bmi160.o bmp280.o bstdr_comm_support.o bmm150.o
 PROJ_OBJ_CF2 += bmi088_accel.o bmi088_gyro.o bmi088_fifo.o bmp3.o
-PROJ_OBJ_CF2 += pca9685.o vl53l0x.o pca95x4.o vl53l1x.o pmw3901.o
+PROJ_OBJ_CF2 += pca9685.o vl53l0x.o pca95x4.o pca9555.o vl53l1x.o pmw3901.o
 
 # USB Files
 PROJ_OBJ_CF2 += usb_bsp.o usblink.o usbd_desc.o usb.o

--- a/src/hal/interface/pca9555.h
+++ b/src/hal/interface/pca9555.h
@@ -1,0 +1,88 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2017 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * pca9555.h - Functions for interfacing PCA9555 I2C GPIO extender
+ */
+#ifndef __PCA9555_H__
+#define __PCA9555_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define PCA9555_DEFAULT_ADDRESS 0b0100000
+
+#define PCA9555_INPUT_REGA   (0x00)
+#define PCA9555_INPUT_REGB   (0x01)
+#define PCA9555_OUTPUT_REGA  (0x02)
+#define PCA9555_OUTPUT_REGB  (0x03)
+#define PCA9555_POL_REGA     (0x04)
+#define PCA9555_POL_REGB     (0x05)
+#define PCA9555_CONFIG_REGA  (0x06)
+#define PCA9555_CONFIG_REGB  (0x07)
+
+#define PCA9555_P00 (1 << 0)
+#define PCA9555_P01 (1 << 1)
+#define PCA9555_P02 (1 << 2)
+#define PCA9555_P03 (1 << 3)
+#define PCA9555_P04 (1 << 4)
+#define PCA9555_P05 (1 << 5)
+#define PCA9555_P06 (1 << 6)
+#define PCA9555_P07 (1 << 7)
+#define PCA9555_P10 (1 << 0)
+#define PCA9555_P11 (1 << 1)
+#define PCA9555_P12 (1 << 2)
+#define PCA9555_P13 (1 << 3)
+#define PCA9555_P14 (1 << 4)
+#define PCA9555_P15 (1 << 5)
+#define PCA9555_P16 (1 << 6)
+#define PCA9555_P17 (1 << 7)
+
+/**
+ * Initialize the PCA9555 sub-system.
+ */
+void pca9555Init();
+
+/**
+ * Test the PCA9555 sub-system.
+ */
+bool pca9555Test();
+
+/**
+ * Set the output register values.
+ */
+bool pca9555ConfigOutputRegA(uint32_t val);
+bool pca9555ConfigOutputRegB(uint32_t val);
+
+/**
+ * Set output bits.
+ */
+bool pca9555SetOutputRegA(uint32_t mask);
+bool pca9555SetOutputRegB(uint32_t mask);
+
+/**
+ * Reset output bits.
+ */
+bool pca9555ClearOutputRegA(uint32_t mask);
+bool pca9555ClearOutputRegB(uint32_t mask);
+
+#endif //__PCA9555_H__

--- a/src/hal/src/pca9555.c
+++ b/src/hal/src/pca9555.c
@@ -1,0 +1,116 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2017 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * pca9555.c - Functions for interfacing PCA9555 I2C GPIO extender
+ */
+#define DEBUG_MODULE "PCA9555"
+
+#include "i2cdev.h"
+
+#include "pca9555.h"
+
+#include "debug.h"
+
+static uint8_t devAddr;
+static I2C_Dev *I2Cx;
+
+void pca9555Init()
+{
+  i2cdevInit(I2C1_DEV);
+  I2Cx = I2C1_DEV;
+  devAddr = PCA9555_DEFAULT_ADDRESS;
+}
+
+/**
+ * Reads the config registers and checks if there are any errors in reading
+ * the registers
+ */
+bool pca9555Test()
+{
+  uint8_t tb;
+  bool pass_set1, pass_set2;
+
+  // Test reading the config registers
+  pass_set1 = i2cdevReadByte(I2Cx, devAddr, PCA9555_CONFIG_REGA, &tb);
+  pass_set2 = i2cdevReadByte(I2Cx, devAddr, PCA9555_CONFIG_REGB, &tb);
+
+  return pass_set1 & pass_set2;
+}
+
+bool pca9555ConfigOutputRegA(uint32_t val)
+{
+  return i2cdevWriteByte(I2Cx, devAddr, PCA9555_CONFIG_REGA, val);
+}
+
+bool pca9555ConfigOutputRegB(uint32_t val)
+{
+  return i2cdevWriteByte(I2Cx, devAddr, PCA9555_CONFIG_REGB, val);
+}
+
+bool pca9555SetOutputRegA(uint32_t mask)
+{
+  uint8_t val;
+  bool pass;
+
+  pass = i2cdevReadByte(I2Cx, devAddr, PCA9555_OUTPUT_REGA, &val);
+  val |= mask;
+  pass = i2cdevWriteByte(I2Cx, devAddr, PCA9555_OUTPUT_REGA, val);
+
+  return pass;
+}
+
+bool pca9555SetOutputRegB(uint32_t mask)
+{
+  uint8_t val;
+  bool pass;
+
+  pass = i2cdevReadByte(I2Cx, devAddr, PCA9555_OUTPUT_REGB, &val);
+  val |= mask;
+  pass = i2cdevWriteByte(I2Cx, devAddr, PCA9555_OUTPUT_REGB, val);
+
+  return pass;
+}
+
+bool pca9555ClearOutputRegA(uint32_t mask)
+{
+  uint8_t val;
+  bool pass;
+
+  pass = i2cdevReadByte(I2Cx, devAddr, PCA9555_OUTPUT_REGA, &val);
+  val &= ~mask;
+  pass = i2cdevWriteByte(I2Cx, devAddr, PCA9555_OUTPUT_REGA, val);
+
+  return pass;
+}
+
+bool pca9555ClearOutputRegB(uint32_t mask)
+{
+  uint8_t val;
+  bool pass;
+
+  pass = i2cdevReadByte(I2Cx, devAddr, PCA9555_OUTPUT_REGB, &val);
+  val &= ~mask;
+  pass = i2cdevWriteByte(I2Cx, devAddr, PCA9555_OUTPUT_REGB, val);
+
+  return pass;
+}


### PR DESCRIPTION
Added library files to use PCA9555 16bit IO extender. Existing PCA library was 8 bit.

I used this library to update firmware for a custom deck I've built mounting 13 VL53L1X ToF sensors.

| Bottom | Top |
| ------ | ------- |
| ![Bottom](https://user-images.githubusercontent.com/14261304/46098471-1e4e0780-c1e2-11e8-8a74-53fb5281310f.JPG) | ![Top](https://user-images.githubusercontent.com/14261304/46098472-1ee69e00-c1e2-11e8-8caf-d2791563acc8.JPG) |
