### PR TITLE
feat: AMG8833 Thermal Camera

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ PROJ_OBJ += cppm.o
 PROJ_OBJ += bmi055_accel.o bmi055_gyro.o bmi160.o bmp280.o bstdr_comm_support.o bmm150.o
 PROJ_OBJ += bmi088_accel.o bmi088_gyro.o bmi088_fifo.o bmp3.o
 PROJ_OBJ += pca9685.o vl53l0x.o pca95x4.o pca9555.o vl53l1x.o pmw3901.o
+PROJ_OBJ += amg8833.o
 
 # USB Files
 PROJ_OBJ += usb_bsp.o usblink.o usbd_desc.o usb.o

--- a/src/hal/interface/amg8833.h
+++ b/src/hal/interface/amg8833.h
@@ -1,0 +1,122 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2017 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * amg8833.h - Functions for interfacing AMG8833 thermal sensor
+ * Reference : https://github.com/adafruit/Adafruit_AMG88xx
+ */
+#ifndef __AMG8833_H__
+#define __AMG8833_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "i2cdev.h"
+#include "task.h"
+#include "num.h"
+
+
+#define MINTEMP                        22
+#define MAXTEMP                        34
+
+#define AMG_I2C_CHUNKSIZE              32
+#define AMG88xx_PIXEL_ARRAY_SIZE       64
+
+#define AMG88xx_ADDRESS              0x68
+/************** Registers ***************/
+#define AMG88xx_PCTL                 0x00
+#define AMG88xx_RST                  0x01
+#define AMG88xx_FPSC                 0x02
+#define AMG88xx_INTC                 0x03
+#define AMG88xx_STAT                 0x04
+#define AMG88xx_SCLR                 0x05
+#define AMG88xx_AVE                  0x07
+#define AMG88xx_INTHL                0x08
+#define AMG88xx_INTHH                0x09
+#define AMG88xx_INTLL                0x0A
+#define AMG88xx_INTLH                0x0B
+#define AMG88xx_IHYSL                0x0C
+#define AMG88xx_IHYSH                0x0D
+#define AMG88xx_TTHL                 0x0E
+#define AMG88xx_TTHH                 0x0F
+#define AMG88xx_INT_OFFSET           0x10
+#define AMG88xx_PIXEL_OFFSET         0x80
+/************* Power modes *************/
+#define AMG88xx_NORMAL_MODE          0x00
+#define	AMG88xx_SLEEP_MODE           0x01
+#define AMG88xx_STAND_BY_60          0x20
+#define AMG88xx_STAND_BY_10          0x21
+/*********** Software resets ***********/
+#define AMG88xx_FLAG_RESET           0x30
+#define AMG88xx_INITIAL_RESET        0x3F
+/************* Frame rates *************/
+#define AMG88xx_FPS_10               0x00
+#define AMG88xx_FPS_1                0x01
+/********** Interrupt Enables **********/
+#define AMG88xx_INT_DISABLED         0x00
+#define AMG88xx_INT_ENABLED          0x01
+/********** Interrupt modes ************/
+#define AMG88xx_DIFFERENCE           0x00
+#define AMG88xx_ABSOLUTE_VALUE       0x01
+
+typedef struct {
+  uint8_t devAddr;
+  I2C_Dev *I2Cx;
+} AMG8833_Dev_t;
+
+typedef AMG8833_Dev_t *AMG8833_DEV;
+
+// Initiate thermal sensor
+bool begin(AMG8833_Dev_t *dev, I2C_Dev *I2Cx);
+
+// Data capture
+void readPixels(AMG8833_Dev_t *dev, float *buf, uint8_t size);
+float readThermistor(AMG8833_Dev_t *dev);
+
+// Interrupts
+bool enableInterrupt(AMG8833_Dev_t *dev);
+bool disableInterrupt(AMG8833_Dev_t *dev);
+void setInterruptMode(AMG8833_Dev_t *dev, uint8_t mode);
+void getInterrupt(AMG8833_Dev_t *dev, uint8_t *buf, uint8_t size);
+void clearInterrupt(AMG8833_Dev_t *dev);
+// This will automatically set hysteresis to 95% of the high value
+void setInterruptLevels_N(AMG8833_Dev_t *dev, float high, float low);
+// This will manually set hysteresis
+void setInterruptLevels_H(AMG8833_Dev_t *dev, float high, float low, float hysteresis);
+
+// Modes
+void setMovingAverageMode(AMG8833_Dev_t *dev, bool mode);
+
+// Read operations
+uint8_t read8(AMG8833_Dev_t *dev, uint8_t reg);
+void read(AMG8833_Dev_t *dev, uint8_t reg, uint8_t *buf, uint8_t num);
+
+// Write operations
+bool write8(AMG8833_Dev_t *dev, uint16_t reg, uint8_t value);
+void write(AMG8833_Dev_t *dev, uint8_t reg, uint8_t *buf, uint8_t num);
+
+// Supportive calculations
+float signedMag12ToFloat(uint16_t val);
+float int12ToFloat(uint16_t val);
+uint8_t min(uint8_t a, uint8_t b);
+
+#endif /* __AMG8833_H__ */

--- a/src/hal/src/amg8833.c
+++ b/src/hal/src/amg8833.c
@@ -1,0 +1,303 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2017 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * amg8833.c - Functions for interfacing AMG8833 thermal sensor
+ * Reference : https://github.com/adafruit/Adafruit_AMG88xx
+ */
+#include "amg8833.h"
+
+const float AMG88xx_TEMP_CONVERSION = 0.25;
+const float AMG88xx_THRM_CONVERSION = 0.0625;
+
+static uint8_t mode = 1;
+
+/**************************************************************************
+ Setups the I2C interface and thermal camera basic registers
+
+ @param  dev Thermal camera struct
+ @param  I2Cx I2C driver instance
+ @returns True if device is set up, false on any failure
+**************************************************************************/
+bool begin(AMG8833_Dev_t *dev, I2C_Dev *I2Cx)
+{
+  // Set I2C parameters
+  dev->I2Cx = I2Cx;
+  dev->devAddr = AMG88xx_ADDRESS;
+  bool i2c_complete = i2cdevInit(dev->I2Cx);
+  // Enter normal mode
+  bool mode_selected = write8(dev, AMG88xx_PCTL, AMG88xx_NORMAL_MODE);
+  // Software reset
+  bool software_resetted = write8(dev, AMG88xx_RST, AMG88xx_INITIAL_RESET);
+  //disable interrupts by default
+  bool interrupts_set = disableInterrupt(dev);
+  //set to 10 FPS
+  bool fps_set = write8(dev, AMG88xx_FPSC, (AMG88xx_FPS_10 & 0x01));
+  vTaskDelay(M2T(10));
+  return i2c_complete && mode_selected && software_resetted &&
+    interrupts_set && fps_set;
+}
+
+/**************************************************************************
+ Read Infrared sensor values
+
+ @param  pdev Thermal camera struct
+ @param  buf the array to place the pixels in
+ @param  size Optionsl number of bytes to read (up to 64). Default is 64 bytes.
+ @return up to 64 bytes of pixel data in buf
+**************************************************************************/
+void readPixels(AMG8833_Dev_t *dev, float *buf, uint8_t size)
+{
+  uint16_t recast;
+  float converted;
+  uint8_t bytesToRead = min((uint8_t) (size << 1), (uint8_t) (AMG88xx_PIXEL_ARRAY_SIZE << 1));
+  uint8_t rawArray[bytesToRead];
+  read(dev, AMG88xx_PIXEL_OFFSET, rawArray, bytesToRead);
+
+  for (int i = 0; i < size; i++) {
+    uint8_t pos = i << 1;
+    recast = ((uint16_t) rawArray[pos + 1] << 8) | ((uint16_t) rawArray[pos]);
+    converted = int12ToFloat(recast) * AMG88xx_TEMP_CONVERSION;
+    buf[i] = converted;
+  }
+}
+
+/**************************************************************************
+ Read the onboard thermistor
+
+ @param  pdev Thermal camera struct
+ @returns a the floating point temperature in degrees Celsius
+**************************************************************************/
+float readThermistor(AMG8833_Dev_t *dev)
+{
+  uint8_t raw[2];
+  read(dev, AMG88xx_TTHL, raw, 2);
+  uint16_t recast = ((uint16_t) raw[1] << 8) | ((uint16_t) raw[0]);
+  return signedMag12ToFloat(recast) * AMG88xx_THRM_CONVERSION;
+}
+
+/**************************************************************************
+ Enables the interrupt pin on the device.
+
+ @param  pdev Thermal camera struct
+**************************************************************************/
+bool enableInterrupt(AMG8833_Dev_t *dev)
+{
+  // 0 = Difference interrupt mode
+  // 1 = absolute value interrupt mode
+  return write8(dev, AMG88xx_INTC, (mode << 1 | 1) & 0x03);
+}
+
+/**************************************************************************
+ Disables the interrupt pin on the device
+
+ @param  pdev Thermal camera struct
+**************************************************************************/
+bool disableInterrupt(AMG8833_Dev_t *dev)
+{
+  // 0 = Difference interrupt mode
+  // 1 = absolute value interrupt mode
+  return write8(dev, AMG88xx_INTC, (mode << 1 | 0) & 0x03);
+}
+
+/**************************************************************************
+ Set the interrupt to either absolute value or difference mode
+
+ @param  pdev Thermal camera struct
+ @param  mode passing AMG88xx_DIFFERENCE sets the device to difference
+ mode, AMG88xx_ABSOLUTE_VALUE sets to absolute value mode.
+**************************************************************************/
+void setInterruptMode(AMG8833_Dev_t *dev, uint8_t m)
+{
+  mode = m;
+  write8(dev, AMG88xx_INTC, (mode << 1 | 1) & 0x03);
+}
+
+/**************************************************************************
+ Read the state of the triggered interrupts on the device. The full
+ interrupt register is 8 bytes in length.
+
+ @param  pdev Thermal camera struct
+ @param  buf the pointer to where the returned data will be stored
+ @param  size Optional number of bytes to read. Default is 8 bytes.
+ @returns up to 8 bytes of data in buf
+**************************************************************************/
+void getInterrupt(AMG8833_Dev_t *dev, uint8_t *buf, uint8_t size)
+{
+  uint8_t bytesToRead = min(size, (uint8_t) 8);
+  read(dev, AMG88xx_INT_OFFSET, buf, bytesToRead);
+}
+
+/**************************************************************************
+ Clear any triggered interrupts
+
+ @param  pdev Thermal camera struct
+**************************************************************************/
+void clearInterrupt(AMG8833_Dev_t *dev)
+{
+  write8(dev, AMG88xx_RST, AMG88xx_FLAG_RESET);
+}
+
+/**************************************************************************
+ Set the interrupt levels. The hysteresis value defaults to .95 * high
+
+ @param  pdev Thermal camera struct
+ @param  high the value above which an interrupt will be triggered
+ @param  low the value below which an interrupt will be triggered
+**************************************************************************/
+void setInterruptLevels_N(AMG8833_Dev_t *dev, float high, float low)
+{
+  setInterruptLevels_H(dev, high, low, high * 0.95f);
+}
+
+/**************************************************************************
+ Set the interrupt levels
+
+ @param  pdev Thermal camera struct
+ @param  high the value above which an interrupt will be triggered
+ @param  low the value below which an interrupt will be triggered
+ @param  hysteresis the hysteresis value for interrupt detection
+**************************************************************************/
+void setInterruptLevels_H(AMG8833_Dev_t *dev, float high, float low,
+  float hysteresis)
+{
+  int highConv = high / AMG88xx_TEMP_CONVERSION;
+  highConv = constrain(highConv, -4095, 4095);
+  write8(dev, AMG88xx_INTHL, (highConv & 0xFF));
+  write8(dev, AMG88xx_INTHH, ((highConv & 0xF) >> 4));
+
+  int lowConv = low / AMG88xx_TEMP_CONVERSION;
+  lowConv = constrain(lowConv, -4095, 4095);
+  write8(dev, AMG88xx_INTLL, (lowConv & 0xFF));
+  write8(dev, AMG88xx_INTLH, (((lowConv & 0xF) >> 4) & 0xF));
+
+  int hysConv = hysteresis / AMG88xx_TEMP_CONVERSION;
+  hysConv = constrain(hysConv, -4095, 4095);
+  write8(dev, AMG88xx_IHYSL, (hysConv & 0xFF));
+  write8(dev, AMG88xx_IHYSH, (((hysConv & 0xF) >> 4) & 0xF));
+}
+
+/**************************************************************************
+ Set the moving average mode.
+
+ @param  pdev Thermal camera struct
+ @param  mode If false, no moving average. If true, twice the moving average
+**************************************************************************/
+void setMovingAverageMode(AMG8833_Dev_t *dev, bool mode)
+{
+  write8(dev, AMG88xx_AVE, (mode << 5));
+}
+
+/**************************************************************************
+ Read one byte of data from the specified register
+
+ @param  dev Thermal camera struct
+ @param  reg the register to read
+ @returns one byte of register data
+**************************************************************************/
+uint8_t read8(AMG8833_Dev_t *dev, uint8_t reg)
+{
+  uint8_t ret;
+  read(dev, reg, &ret, 1);
+  return ret;
+}
+
+/**************************************************************************
+ Read a chunk of bytes of data from the specified register
+
+ @param  dev Thermal camera struct
+ @param  reg the register to read
+ @param  buf integer buffer to save read bytes
+ @param  num number of bytes need to be read
+**************************************************************************/
+void read(AMG8833_Dev_t *dev, uint8_t reg, uint8_t *buf, uint8_t num)
+{
+  i2cdevRead(dev->I2Cx, dev->devAddr, reg, num, buf);
+}
+
+/**************************************************************************
+ Write one byte of data to the specified register
+
+ @param  dev Thermal camera struct
+ @param  reg the register to write to
+ @param  value the value to write
+ @returns result of the write operation
+**************************************************************************/
+bool write8(AMG8833_Dev_t *dev, uint16_t reg, uint8_t value)
+{
+  return (i2cdevWrite16(dev->I2Cx, dev->devAddr, reg, 1, &value));
+}
+
+/**************************************************************************
+ Read one byte of data from the specified register
+
+ @param  dev Thermal camera struct
+ @param  reg the register to write
+ @param  buf integer buffer containing data to write
+ @param  num number of bytes need to be written
+**************************************************************************/
+void write(AMG8833_Dev_t *dev, uint8_t reg, uint8_t *buf, uint8_t num)
+{
+  for (int i = 0; i < num; i++) {
+    write8(dev, reg, buf[i]);
+  }
+}
+
+/**************************************************************************
+ Convert a 12-bit signed magnitude value to a floating point number
+
+ @param  val the 12-bit signed magnitude value to be converted
+ @returns the converted floating point value
+**************************************************************************/
+float signedMag12ToFloat(uint16_t val)
+{
+  // Take first 11 bits as absolute val
+  uint16_t absVal = (val & 0x7FF);
+  return (val & 0x800) ? 0 - (float) absVal : (float) absVal;
+}
+
+/**************************************************************************
+ Convert a 12-bit integer two's complement value to a floating point number
+
+ @param  val the 12-bit integer  two's complement value to be converted
+ @returns the converted floating point value
+**************************************************************************/
+float int12ToFloat(uint16_t val)
+{
+  // Shift to left so that sign bit of 12 bit integer number is placed on
+  // sign bit of 16 bit signed integer number
+  int16_t sVal = (val << 4);
+  // Shift back the signed number, return converts to float
+  return sVal >> 4;
+}
+
+/**************************************************************************
+ Finds the minimum value between two integers
+
+ @param  a first integer value
+ @param  b second integer value
+ @returns the minimum of a and b integers
+**************************************************************************/
+uint8_t min(uint8_t a, uint8_t b)
+{
+  return (a < b) ? a : b;
+}


### PR DESCRIPTION
Added library files derived from [Adafruit_AMG88xx](https://github.com/adafruit/Adafruit_AMG88xx) which was specific for Arduino IDE based systems to use with Crazyflie 2.0 as an additional deck.

I used this library to integrate an AMG8833 thermal camera to detect heat sources in CF flying path.

### Deck

![Thermal Camera Deck](https://user-images.githubusercontent.com/14261304/51099992-f2d74300-17f9-11e9-9b17-2d6928df4f79.JPG)

### Results

| Temperature Readings - Thermistor | Temperature from multiple pixels  |
| -------------- | -------------- |
| ![temperature_output_from_amg8833](https://user-images.githubusercontent.com/14261304/51100080-5a8d8e00-17fa-11e9-9ea7-c36ee87f43ec.png) | ![temperature_readings_from_amg8833_pixels](https://user-images.githubusercontent.com/14261304/51100081-5a8d8e00-17fa-11e9-865f-ecc8bb352471.png) |
