### PR TITLE
Add getDeviceTypeName to platform service.

### DIFF
--- a/src/modules/src/platformservice.c
+++ b/src/modules/src/platformservice.c
@@ -36,6 +36,7 @@
 #include "platformservice.h"
 #include "syslink.h"
 #include "version.h"
+#include "platform.h"
 
 static bool isInit=false;
 
@@ -51,6 +52,7 @@ typedef enum {
 typedef enum {
   getProtocolVersion = 0x00,
   getFirmwareVersion = 0x01,
+  getDeviceTypeName  = 0x02,
 } VersionCommand;
 
 void platformserviceHandler(CRTPPacket *p);
@@ -116,6 +118,14 @@ static void versionCommandProcess(CRTPPacket *p)
       strncpy((char*)&p->data[1], V_STAG, CRTP_MAX_DATA_SIZE-1);
       p->size = (strlen(V_STAG)>CRTP_MAX_DATA_SIZE-1)?CRTP_MAX_DATA_SIZE:strlen(V_STAG)+1;
       crtpSendPacket(p);
+      break;
+    case getDeviceTypeName:
+      {
+      const char* name = platformConfigGetDeviceTypeName();
+      strncpy((char*)&p->data[1], name, CRTP_MAX_DATA_SIZE-1);
+      p->size = (strlen(name)>CRTP_MAX_DATA_SIZE-1)?CRTP_MAX_DATA_SIZE:strlen(name)+1;
+      crtpSendPacket(p);
+      }
       break;
     default:
       break;


### PR DESCRIPTION
This will allow us to change the client behavior based on the device type.
Tested with CF 2.0, CF 2.1, RR 1.0 using crazyflie_tools/version.