### PR TITLE
uSD: Allow comments in config.txt

### DIFF
--- a/tools/usdlog/config.txt
+++ b/tools/usdlog/config.txt
@@ -1,6 +1,6 @@
-250
-50
-log
+250   # frequency
+50    # buffer size
+log   # file name
 acc.x
 acc.y
 acc.z


### PR DESCRIPTION
This change allows comments (#) and whitespace in config.txt
used for logging data on a uSD card. This will be in particular
useful as we add more features to config.txt in the future.