### PR TITLE
Add status messages in stabilizer for sensor calibration

### DIFF
--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -141,6 +141,8 @@ static void stabilizerTask(void* param)
   //Wait for the system to be fully started to start stabilization loop
   systemWaitStart();
 
+  DEBUG_PRINT("Wait for sensor calibration...\n");
+
   // Wait for sensors to be calibrated
   lastWakeTime = xTaskGetTickCount ();
   while(!sensorsAreCalibrated()) {
@@ -148,6 +150,8 @@ static void stabilizerTask(void* param)
   }
   // Initialize tick to something else then 0
   tick = 1;
+
+  DEBUG_PRINT("Ready to fly.\n");
 
   while(1) {
     // The sensor should unlock at 1kHz


### PR DESCRIPTION
This helps debug cases where the CF is not taking off, because
the sensors were not (yet) successfully calibrated without the need
of analyzing the blinking pattern of the LEDs.