### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ tags
 *.gch
 
 /generated-test/**
+**/__pycache__/**
 
 current_platform.mk


### PR DESCRIPTION
This cleans git status for python scripts such as the ones used in
tools/usdlog for example.