### PR TITLE
Fixes #418: compilation error due to isspace() in usddeck.c

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -235,7 +235,7 @@ TCHAR* f_gets_without_comments (
     if (c == '\n') {
       break;   /* Break on EOL */
     }
-    if (isspace(c)) {
+    if (isspace((int)c)) {
       continue; /* Strip whitespace */
     }
     if (c == '#') {
@@ -338,7 +338,7 @@ static void usdInit(DeckInfo *info)
         success = true;
         break;
       }
-      
+
       if (!success) {
           DEBUG_PRINT("Config read [FAIL].\n");
       }
@@ -379,7 +379,7 @@ static void usdLogTask(void* prm)
         line = f_gets_without_comments(readBuffer, sizeof(readBuffer), &logFile);
         if (!line) break;
       }
-      
+
       while (line) {
         line = f_gets_without_comments(readBuffer, sizeof(readBuffer), &logFile);
         if (!line) break;


### PR DESCRIPTION
HINT: On Ubuntu 16.04 it resolves the error: array subscript has type
'char' [-Werror=char-subscripts] as all warnings are treated as errors.