### PR TITLE
fix compilation of unit tests on macOS

### DIFF
--- a/src/modules/interface/log.h
+++ b/src/modules/interface/log.h
@@ -74,9 +74,15 @@ struct log_s {
    { \
   .type = TYPE, .name = #NAME, .address = (void*)(ADDRESS), },
 
+#ifdef __APPLE__
+#define LOG_GROUP_START(NAME)  \
+  static const struct log_s __logs_##NAME[] __attribute__((section("__DATA,__.log." #NAME), used)) = { \
+  LOG_ADD_GROUP(LOG_GROUP | LOG_START, NAME, 0x0)
+#else
 #define LOG_GROUP_START(NAME)  \
   static const struct log_s __logs_##NAME[] __attribute__((section(".log." #NAME), used)) = { \
   LOG_ADD_GROUP(LOG_GROUP | LOG_START, NAME, 0x0)
+#endif
 
 //#define LOG_GROUP_START_SYNC(NAME, LOCK) LOG_ADD_GROUP(LOG_GROUP | LOG_START, NAME, LOCK);
 


### PR DESCRIPTION
This PR fixes the compilation of unit tests on macOS where the compiler does not seem to be happy with the original `__attribute__((section(...)))` tag and insists on formatting it the way I modified it in the PR.

Note that the PR does not change anything when the firmware is compiled with `arm-none-eabi-gcc`; the `__APPLE__` macro is defined only when compiling _for_ macOS and not cross-compiling for another platform.