### PR TITLE
LED Ring - add lighthouseRateEffect

### DIFF
--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -683,16 +683,30 @@ static float badRssi = 85, goodRssi = 35;
 static void rssiEffect(uint8_t buffer[][3], bool reset)
 {
   int i;
-  static int rssiid;
+  static int isConnectedId, rssiId;
   float rssi;
+  bool isConnected;
 
-  rssiid = logGetVarId("radio", "rssi");
-  rssi = logGetFloat(rssiid);
+  isConnectedId = logGetVarId("radio", "isConnected");
+  isConnected = logGetUint(isConnectedId);
+
+  rssiId = logGetVarId("radio", "rssi");
+  rssi = logGetFloat(rssiId);
 
   for (i = 0; i < NBR_LEDS; i++) {
-    buffer[i][0] = LIMIT(LINSCALE(badRssi, goodRssi, 255, 0, rssi)); // Red (bad)
-    buffer[i][1] = LIMIT(LINSCALE(badRssi, goodRssi, 0, 255, rssi)); // Green (good)
-    buffer[i][2] = 0; // Blue
+	if(isConnected){
+      buffer[i][0] = LIMIT(LINSCALE(badRssi, goodRssi, 255, 0, rssi)); // Red (bad)
+	  buffer[i][1] = LIMIT(LINSCALE(badRssi, goodRssi, 0, 255, rssi)); // Green (good)
+	  buffer[i][2] = 0; // Blue
+	}else{
+//	  buffer[i][0] = 255; // Red
+//	  buffer[i][1] = 0; // Green
+//	  buffer[i][2] = 0; // Blue
+
+	  buffer[i][0] = 100; // Red
+	  buffer[i][1] = 100; // Green
+	  buffer[i][2] = 100; // Blue
+	}
   }
 }
 

--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -696,6 +696,28 @@ static void rssiEffect(uint8_t buffer[][3], bool reset)
   }
 }
 
+/**
+ * An effect that shows the Lighthouse Reception Rate on the LED ring.
+ *
+ * Red means bad, green means good.
+ */
+static float badRate = 0, goodRate = 120;
+static void lighthouseRateEffect(uint8_t buffer[][3], bool reset)
+{
+  int i;
+  static int posRtId;
+  float posRt;
+
+  posRtId = logGetVarId("lighthouse", "posRt"); //rate of successful retrieval of position data
+  posRt = logGetFloat(posRtId);
+
+  for (i = 0; i < NBR_LEDS; i++) {
+    buffer[i][0] = LIMIT(LINSCALE(badRate, goodRate, 255, 0, posRt)); // Red (bad)
+    buffer[i][1] = LIMIT(LINSCALE(badRate, goodRate, 0, 255, posRt)); // Green (good)
+    buffer[i][2] = 0; // Blue
+  }
+}
+
 /**************** Effect list ***************/
 
 
@@ -717,6 +739,7 @@ Ledring12Effect effectsFct[] =
   virtualMemEffect,
   fadeColorEffect,
   rssiEffect,
+  lighthouseRateEffect,
 };
 
 /********** Ring init and switching **********/

--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -57,6 +57,7 @@ static int radiolinkReceiveCRTPPacket(CRTPPacket *p);
 
 //Local RSSI variable used to enable logging of RSSI values from Radio
 static uint8_t rssi;
+static bool isConnected;
 static uint32_t lastPacketTick;
 
 
@@ -166,10 +167,12 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
     ledseqRun(LINK_LED, seq_linkup);
     // no ack for broadcasts
   } else if (slp->type == SYSLINK_RADIO_RSSI)
-	{
-		//Extract RSSI sample sent from radio
-		memcpy(&rssi, slp->data, sizeof(uint8_t));
-	}
+  {
+    //Extract RSSI sample sent from radio
+    memcpy(&rssi, slp->data, sizeof(uint8_t)); //rssi will not change on disconnect
+  }
+
+  isConnected = radiolinkIsConnected();
 }
 
 static int radiolinkReceiveCRTPPacket(CRTPPacket *p)
@@ -212,4 +215,5 @@ static int radiolinkSetEnable(bool enable)
 
 LOG_GROUP_START(radio)
 LOG_ADD(LOG_UINT8, rssi, &rssi)
+LOG_ADD(LOG_UINT8, isConnected, &isConnected)
 LOG_GROUP_STOP(radio)


### PR DESCRIPTION
With full reception / max quality, it is expected to receive 120 position samples per second (posRt)

0 is the worst quality possible

LED Ring will be Red if 0, Green if 120

Tested to work, though the reaction time is a bit slow since the rate counter can only work at 1 second intervals (tried to lower, it seems the rate is not uniform so it'll produce unstable rate counts)