### PR TITLE
Avoid compilation error on newer toolchains (2019-q3).

### DIFF
--- a/src/lib/STM32_USB_OTG_Driver/src/usb_core.c
+++ b/src/lib/STM32_USB_OTG_Driver/src/usb_core.c
@@ -156,6 +156,11 @@ static USB_OTG_STS USB_OTG_CoreReset(USB_OTG_CORE_HANDLE *pdev)
   return status;
 }
 
+// USB_OTG_WritePacket and USB_OTG_ReadPacket report warnings
+// on GNU Embedded Toolchain for Arm 2019-q3
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+
 /**
 * @brief  USB_OTG_WritePacket : Writes a packet into the Tx FIFO associated 
 *         with the EP
@@ -210,6 +215,7 @@ void *USB_OTG_ReadPacket(USB_OTG_CORE_HANDLE *pdev,
   }
   return ((void *)dest);
 }
+#pragma GCC diagnostic pop
 
 /**
 * @brief  USB_OTG_SelectCore 


### PR DESCRIPTION
This change temporarily disables a warning (that leads to a
compiler error in release builds) in USB_OTG_WritePacket and
USB_OTG_ReadPacket.