### PR TITLE
Update types for parameters in i2cdrvCreateMessage and i2cdrvCreateMe…

### DIFF
--- a/src/drivers/src/i2c_drv.c
+++ b/src/drivers/src/i2c_drv.c
@@ -368,7 +368,7 @@ void i2cdrvInit(I2cDrv* i2c)
 
 void i2cdrvCreateMessage(I2cMessage *message,
                       uint8_t  slaveAddress,
-                      uint8_t  direction,
+                      I2cDirection  direction,
                       uint32_t length,
                       uint8_t  *buffer)
 {
@@ -386,7 +386,7 @@ void i2cdrvCreateMessageIntAddr(I2cMessage *message,
                              uint8_t  slaveAddress,
                              bool IsInternal16,
                              uint16_t intAddress,
-                             uint8_t  direction,
+                             I2cDirection  direction,
                              uint32_t length,
                              uint8_t  *buffer)
 {


### PR DESCRIPTION
…ssageIntAddr

The type for direction in both these differ in the .c from the .h. Sensitive parsers don't like it.