### PR TITLE
Uninitialized variable in skip_to_next

### DIFF
--- a/src/deck/drivers/src/gtgps.c
+++ b/src/deck/drivers/src/gtgps.c
@@ -95,7 +95,7 @@ static MeasData m;
 
 // Only use on 0-terminated strings!
 static int skip_to_next(char ** sp, const char ch) {
-  int steps;
+  int steps=0;
   while (ch != 0 && (**sp) != ch) {
     (*sp)++;
     steps++;


### PR DESCRIPTION
steps needs to be initialized to 0 or undefined behavior may happen. Found during static analysis by GrammaTech CodeSonar