### PR TITLE
Uninitialized variable if queue is empty

### DIFF
--- a/src/modules/src/worker.c
+++ b/src/modules/src/worker.c
@@ -65,10 +65,8 @@ void workerLoop()
     return;
 
   while (1)
-  {
-    xQueueReceive(workerQueue, &work, portMAX_DELAY);
-    
-    if (work.function)
+  { 
+    if (xQueueReceive(workerQueue, &work, portMAX_DELAY)== pdPASS && work.function)
       work.function(work.arg);
   }
 }


### PR DESCRIPTION
xQueueReceive can return xQueueReceive, in which case work should not be used.

This is a pattern that is repeated in other places as well. If people consider this valuable enough to fix, then I will continue to find the other locations and issue a pull request combining them.