### PR TITLE
xQueuePeek with third parameter '0' does not initialize the 2nd param…

### DIFF
--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -66,9 +66,9 @@ void commanderInit(void)
 void commanderSetSetpoint(setpoint_t *setpoint, int priority)
 {
   int currentPriority;
-  xQueuePeek(priorityQueue, &currentPriority, 0);
 
-  if (priority >= currentPriority) {
+
+  if (xQueuePeek(priorityQueue, &currentPriority, 0) == pdPass && priority >= currentPriority) {
     setpoint->timestamp = xTaskGetTickCount();
     // This is a potential race but without effect on functionality
     xQueueOverwrite(setpointQueue, setpoint);


### PR DESCRIPTION
…eter

If the queue is empty, then priority in commanderSetSetpoint is not initialized. The same holds for commanderGetSetpoint (the XQueuePeek would not initialize set point on line 81 if the queue is empty, but it is not clear to me how to fix that code.

@ataffanel : This is a similar problem as I reported earlier. Unclear to me if this queue can ever be empty.