### PR TITLE
Heap management options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ VPATH += $(LIB)/vl53l1/core/src
 VPATH += $(PORT)
 PORT_OBJ = port.o
 VPATH +=  $(FREERTOS)/portable/MemMang
-MEMMANG_OBJ = heap_4.o
+MEMMANG_OBJ ?= heap_4.o
 
 VPATH += $(FREERTOS)
 FREERTOS_OBJ = list.o tasks.o queue.o timers.o $(MEMMANG_OBJ)

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -54,7 +54,9 @@
   #define CONFIG_BLOCK_ADDRESS    (2048 * (64-1))
   #define MCU_ID_ADDRESS          0x1FFF7A10
   #define MCU_FLASH_SIZE_ADDRESS  0x1FFF7A22
-  #define FREERTOS_HEAP_SIZE      40000
+  #ifndef FREERTOS_HEAP_SIZE
+    #define FREERTOS_HEAP_SIZE      40000
+  #endif
   #define FREERTOS_MIN_STACK_SIZE 150       // M4-FPU register setup is bigger so stack needs to be bigger
   #define FREERTOS_MCU_CLOCK_HZ   168000000
 


### PR DESCRIPTION
This PR enables OOT apps to overwrite MEMMANG_OBJ with a custom implementantion of the heap manager.

It also enables the build system to set FREERTOS_HEAP_SIZE from CFLAGS.