### PR TITLE
Hotfix: Added crosscompile prefix to math library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ bin/vendor:
 	mkdir -p bin/vendor
 
 libarm_math.a:
-	+$(MAKE) -C $(CRAZYFLIE_BASE)/tools/make/cmsis_dsp/ CRAZYFLIE_BASE=$(abspath $(CRAZYFLIE_BASE)) PROJ_ROOT=$(CURDIR) V=$(V)
+	+$(MAKE) -C $(CRAZYFLIE_BASE)/tools/make/cmsis_dsp/ CRAZYFLIE_BASE=$(abspath $(CRAZYFLIE_BASE)) PROJ_ROOT=$(CURDIR) V=$(V) CROSS_COMPILE=$(CROSS_COMPILE)
 
 clean_version:
 ifeq ($(SHELL),/bin/sh)


### PR DESCRIPTION
This PR adds CROSS_COMPILE prefix to libarm_math. Useful when using a custom gcc toolchain, because libarm_math uses the default value `arm-none-eabi`.