### PR TITLE
stabilizer.thrust is a float so it should be logged as a float

### DIFF
--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -583,7 +583,7 @@ LOG_GROUP_START(stabilizer)
 LOG_ADD(LOG_FLOAT, roll, &state.attitude.roll)
 LOG_ADD(LOG_FLOAT, pitch, &state.attitude.pitch)
 LOG_ADD(LOG_FLOAT, yaw, &state.attitude.yaw)
-LOG_ADD(LOG_UINT16, thrust, &control.thrust)
+LOG_ADD(LOG_FLOAT, thrust, &control.thrust)
 
 STATS_CNT_RATE_LOG_ADD(rtStab, &stabilizerRate)
 LOG_ADD(LOG_UINT32, intToOut, &inToOutLatency)


### PR DESCRIPTION
In `stabilizer.c`, the `thrust` log variable in the `stabilizer` group (which actually comes from `control.thrust` where `control` is of type `control_t`) is logged as an `UINT16_T`, even though it is declared as a float in `control_t`. This PR fixes the type of the log variable.