### PR TITLE
Closes issue #524

### DIFF
--- a/src/modules/src/outlierFilter.c
+++ b/src/modules/src/outlierFilter.c
@@ -33,6 +33,7 @@
 #define BUCKET_ACCEPTANCE_LEVEL 2
 #define MAX_BUCKET_FILL 10
 #define FILTER_CLOSE_DELAY_COUNT 30
+#define LH_TICKS_PER_FRAME 1000.0f / 120
 
 static float acceptanceLevel = 0.0;
 static float errorDistance;
@@ -103,11 +104,10 @@ bool outlierFilterValidateTdoaSteps(const tdoaMeasurement_t* tdoa, const float e
 }
 
 
-static const uint32_t lhTicksPerFrame = 1000 / 120;
-static const int32_t lhMinWindowTime = -2 * lhTicksPerFrame;
-static const int32_t lhMaxWindowTime = 5 * lhTicksPerFrame;
-static const int32_t lhBadSampleWindowChange = -lhTicksPerFrame;
-static const int32_t lhGoodSampleWindowChange = lhTicksPerFrame / 2;
+static const int32_t lhMinWindowTime = -2 * LH_TICKS_PER_FRAME;
+static const int32_t lhMaxWindowTime = 5 * LH_TICKS_PER_FRAME;
+static const int32_t lhBadSampleWindowChange = -LH_TICKS_PER_FRAME;
+static const int32_t lhGoodSampleWindowChange = LH_TICKS_PER_FRAME / 2;
 static const float lhMaxError = 0.05f;
 
 void outlierFilterReset(OutlierFilterLhState_t* this, const uint32_t now) {


### PR DESCRIPTION
Moved lhTicksPerFrame to a macro to remove compiler errors due to initialization of static variables with non-constant values.