### PR TITLE
Fixing a typo in bigquad.c introduced by #495 Refactoring...

### DIFF
--- a/src/deck/drivers/src/bigquad.c
+++ b/src/deck/drivers/src/bigquad.c
@@ -91,7 +91,7 @@ static void bigquadInit(DeckInfo *info)
   uart1Init(115200);
   mspInit(&s_MspObject, osdResponseCallback);
   xTaskCreate(osdTask, BQ_OSD_TASK_NAME,
-              configMINIMAL_STACK_SIZE, NULL, BQ_DECK_TASK_PRI, NULL);
+              configMINIMAL_STACK_SIZE, NULL, BQ_OSD_TASK_PRI, NULL);
 #endif
 
   isInit = true;


### PR DESCRIPTION
Fixing a typo in bigquad.c introduced in 
https://github.com/bitcraze/crazyflie-firmware/commit/bf8a584bf6c05b6ee4a3d1f61f05e0c56147b3e7