### PR TITLE
drop Python 2.x requirement for building as the scripts work fine with Python 3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OPENOCD           ?= openocd
 OPENOCD_INTERFACE ?= interface/stlink-v2.cfg
 OPENOCD_CMDS      ?=
 CROSS_COMPILE     ?= arm-none-eabi-
-PYTHON2           ?= python2
+PYTHON            ?= python
 DFU_UTIL          ?= dfu-util
 CLOAD             ?= 1
 DEBUG             ?= 0
@@ -374,7 +374,7 @@ endif
 
 print_version:
 	@echo "Build for the $(PLATFORM_NAME_$(PLATFORM))!"
-	@$(PYTHON2) $(CRAZYFLIE_BASE)/tools/make/versionTemplate.py --crazyflie-base $(CRAZYFLIE_BASE) --print-version
+	@$(PYTHON) $(CRAZYFLIE_BASE)/tools/make/versionTemplate.py --crazyflie-base $(CRAZYFLIE_BASE) --print-version
 ifeq ($(CLOAD), 1)
 	@echo "Crazyloader build!"
 endif
@@ -431,7 +431,7 @@ prep:
 	@$(CC) $(CFLAGS) -dM -E - < /dev/null
 
 check_submodules:
-	@cd $(CRAZYFLIE_BASE); $(PYTHON2) tools/make/check-for-submodules.py
+	@cd $(CRAZYFLIE_BASE); $(PYTHON) tools/make/check-for-submodules.py
 
 include $(CRAZYFLIE_BASE)/tools/make/targets.mk
 

--- a/tools/make/check-for-submodules.py
+++ b/tools/make/check-for-submodules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from subprocess import check_output
 import sys

--- a/tools/make/targets.mk
+++ b/tools/make/targets.mk
@@ -13,7 +13,7 @@ endif
 
 target = @$(if $(QUIET), ,echo $($1_COMMAND$(VERBOSE)) ); @$($1_COMMAND)
 
-VTMPL_COMMAND=$(PYTHON2) $(CRAZYFLIE_BASE)/tools/make/versionTemplate.py --crazyflie-base $(CRAZYFLIE_BASE) $< $@
+VTMPL_COMMAND=$(PYTHON) $(CRAZYFLIE_BASE)/tools/make/versionTemplate.py --crazyflie-base $(CRAZYFLIE_BASE) $< $@
 #$(BIN)/$(lastword $(subst /, ,$@))
 VTMPL_COMMAND_SILENT="  VTMPL $@"
 %.c: %.vtpl
@@ -50,7 +50,7 @@ $(PROG).bin: $(PROG).elf
 	@$(if $(QUIET), ,echo $(BIN_COMMAND$(VERBOSE)) )
 	@$(BIN_COMMAND)
 
-DFU_COMMAND=$(PYTHON2) $(CRAZYFLIE_BASE)/tools/make/dfu-convert.py -b $(LOAD_ADDRESS):$< $@
+DFU_COMMAND=$(PYTHON) $(CRAZYFLIE_BASE)/tools/make/dfu-convert.py -b $(LOAD_ADDRESS):$< $@
 DFU_COMMAND_SILENT="  DFUse $@"
 $(PROG).dfu: $(PROG).bin
 	@$(if $(QUIET), ,echo $(DFU_COMMAND$(VERBOSE)) )


### PR DESCRIPTION
This PR modifies the Makefile so that it does not require Python 2.x for the build process any more. Python 2.x has reached its end of life in Jan 2020, and the build process works just fine with Python 3.x, so I don't think there's a need to force the user to install Python 2.x.

(I have recently uninstalled Python 2.x from my Mac, that's how I stumbled upon this).