### PR TITLE
add peer_localization to store the position of other crazyflies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ PROJ_OBJ += range.o app_handler.o static_mem.o
 
 # Stabilizer modules
 PROJ_OBJ += commander.o crtp_commander.o crtp_commander_rpyt.o
-PROJ_OBJ += crtp_commander_generic.o crtp_localization_service.o
+PROJ_OBJ += crtp_commander_generic.o crtp_localization_service.o peer_localization.o
 PROJ_OBJ += attitude_pid_controller.o sensfusion6.o stabilizer.o
 PROJ_OBJ += position_estimator_altitude.o position_controller_pid.o
 PROJ_OBJ += estimator.o estimator_complementary.o

--- a/src/modules/interface/peer_localization.h
+++ b/src/modules/interface/peer_localization.h
@@ -1,0 +1,21 @@
+#ifndef __PEER_LOCALIZATION_H__
+#define __PEER_LOCALIZATION_H__
+
+#include <stdbool.h>
+#include "math3d.h"
+#include "stabilizer_types.h"
+
+void peerLocalizationInit();
+bool peerLocalizationTest();
+
+typedef struct peerLocalizationOtherPosition_s {
+  uint8_t id; // CF id
+  point_t pos; // position and timestamp in m
+} peerLocalizationOtherPosition_t;
+
+bool peerLocalizationTellPosition(int id, positionMeasurement_t const *pos);
+bool peerLocalizationIsIDActive(uint8_t id);
+peerLocalizationOtherPosition_t *peerLocalizationGetPositionByID(uint8_t id);
+peerLocalizationOtherPosition_t *peerLocalizationGetPositionByIdx(uint8_t idx);
+
+#endif // __PEER_LOCALIZATION_H__

--- a/src/modules/src/peer_localization.c
+++ b/src/modules/src/peer_localization.c
@@ -1,0 +1,64 @@
+#include "config.h"
+#include "debug.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "peer_localization.h"
+
+#define NUM_MAX_NEIGHBORS 10
+
+void peerLocalizationInit()
+{
+  //all other_positions[in].id will be set to zero due to static initialization.  
+  //If we ever switch to dynamic allocation, we need to set them to zero explicitly
+}
+
+bool peerLocalizationTest()
+{
+  return true;
+}
+
+// array of other's position
+static peerLocalizationOtherPosition_t other_positions[NUM_MAX_NEIGHBORS];
+
+bool peerLocalizationTellPosition(int cfid, positionMeasurement_t const *pos)
+{
+  for (uint8_t i = 0; i < NUM_MAX_NEIGHBORS; ++i) {
+    if (other_positions[i].id == 0 || other_positions[i].id == cfid) {
+      other_positions[i].id = cfid;
+      other_positions[i].pos.x = pos->x;
+      other_positions[i].pos.y = pos->y;
+      other_positions[i].pos.z = pos->z;
+      other_positions[i].pos.timestamp = xTaskGetTickCount();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool peerLocalizationIsIDActive(uint8_t cfid)
+{
+  for (uint8_t i = 0; i < NUM_MAX_NEIGHBORS; ++i) {
+    if (other_positions[i].id == cfid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+peerLocalizationOtherPosition_t *peerLocalizationGetPositionByID(uint8_t cfid)
+{
+  for (uint8_t i = 0; i < NUM_MAX_NEIGHBORS; ++i) {
+    if (other_positions[i].id == cfid) {
+      return &other_positions[i];
+    }
+  }
+  return NULL;
+}
+
+peerLocalizationOtherPosition_t *peerLocalizationGetPositionByIdx(uint8_t idx)
+{
+  if (idx < NUM_MAX_NEIGHBORS) {
+    return &other_positions[idx];
+  }
+  return NULL;
+}

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -66,6 +66,7 @@
 #include "extrx.h"
 #include "app.h"
 #include "static_mem.h"
+#include "peer_localization.h"
 
 /* Private variable */
 static bool selftestPassed;
@@ -123,6 +124,7 @@ void systemInit(void)
   ledseqInit();
   pmInit();
   buzzerInit();
+  peerLocalizationInit();
 
 #ifdef APP_ENABLED
   appInit();
@@ -194,6 +196,7 @@ void systemTask(void *arg)
   pass &= soundTest();
   pass &= memTest();
   pass &= watchdogNormalStartTest();
+  pass &= peerLocalizationTest();
 
   //Start the firmware
   if(pass)


### PR DESCRIPTION
#567 In our discussion about implementing the collision avoidance, @krichardsson suggests that we put the position of other crazyflies in its own module. @jpreiss 