### PR TITLE
break stabilizer_types dependency on ARM

### DIFF
--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -29,7 +29,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "imu_types.h"
-#include "lighthouse_geometry.h"
 
 /* Data structure used by the stabilizer subsystem.
  * All have a timestamp to be set when the data is calculated.
@@ -241,6 +240,13 @@ typedef struct {
 } yawErrorMeasurement_t;
 
 /** Sweep angle measurement */
+
+// Forward-declare math types from lighthouse_geometry.h to avoid transitive
+// dependency on arm_math.h. Necessary to allow compiling this file for PC,
+// which is useful for testing.
+typedef float vec3d[3];
+typedef float mat3d[3][3];
+
 typedef struct {
   uint32_t timestamp;
   vec3d* baseStationPos;

--- a/src/modules/src/controller_indi.c
+++ b/src/modules/src/controller_indi.c
@@ -24,6 +24,7 @@
  */
 
 #include "controller_indi.h"
+#include "math3d.h"
 
 static float thrust_threshold = 300.0f;
 static float bound_control_input = 32000.0f;
@@ -70,8 +71,8 @@ static inline void float_rates_zero(struct FloatRates *fr) {
 void indi_init_filters(void)
 {
 	// tau = 1/(2*pi*Fc)
-	float tau = 1.0f / (2.0f * PI * indi.filt_cutoff);
-	float tau_r = 1.0f / (2.0f * PI * indi.filt_cutoff_r);
+	float tau = 1.0f / (2.0f * M_PI_F * indi.filt_cutoff);
+	float tau_r = 1.0f / (2.0f * M_PI_F * indi.filt_cutoff_r);
 	float tau_axis[3] = {tau, tau, tau_r};
 	float sample_time = 1.0f / ATTITUDE_RATE;
 	// Filtering of gyroscope and actuators

--- a/src/modules/src/crtp_commander.c
+++ b/src/modules/src/crtp_commander.c
@@ -24,6 +24,7 @@
  *
  */
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "crtp_commander.h"
 

--- a/src/modules/src/position_controller_indi.c
+++ b/src/modules/src/position_controller_indi.c
@@ -26,6 +26,7 @@
 
 
 #include "position_controller_indi.h"
+#include "math3d.h"
 
 // Position controller gains
 float K_xi_x = 1.0f;
@@ -56,7 +57,7 @@ static struct IndiOuterVariables indiOuter = {
 void position_indi_init_filters(void)
 {
 	// tau = 1/(2*pi*Fc)
-	float tau = 1.0f / (2.0f * PI * indiOuter.filt_cutoff);
+	float tau = 1.0f / (2.0f * M_PI_F * indiOuter.filt_cutoff);
 	float tau_axis[3] = {tau, tau, tau};
 	float sample_time = 1.0f / ATTITUDE_RATE;
 	// Filtering of linear acceleration, attitude and thrust 
@@ -170,9 +171,9 @@ void positionControllerINDI(const sensorData_t *sensors,
 
 	// Actual attitude (in rad)
 	struct Angles att = {
-		.phi = indiOuter.attitude_f.phi/180*PI,
-		.theta = indiOuter.attitude_f.theta/180*PI,
-		.psi = indiOuter.attitude_f.psi/180*PI,
+		.phi = indiOuter.attitude_f.phi/180*M_PI_F,
+		.theta = indiOuter.attitude_f.theta/180*M_PI_F,
+		.psi = indiOuter.attitude_f.psi/180*M_PI_F,
 	};
 
 	// Compute transformation matrix from body frame (index B) into NED frame (index O)
@@ -254,12 +255,12 @@ void positionControllerINDI(const sensorData_t *sensors,
 		indiOuter.T_incremented = indiOuter.T_tilde + indiOuter.T_inner;
 
 	// Compute commanded attitude to the inner INDI
-	indiOuter.attitude_c.phi = indiOuter.attitude_f.phi + indiOuter.phi_tilde*180/PI;
-	indiOuter.attitude_c.theta = indiOuter.attitude_f.theta + indiOuter.theta_tilde*180/PI;	
+	indiOuter.attitude_c.phi = indiOuter.attitude_f.phi + indiOuter.phi_tilde*180/M_PI_F;
+	indiOuter.attitude_c.theta = indiOuter.attitude_f.theta + indiOuter.theta_tilde*180/M_PI_F;
 
 	// Clamp commands
 	indiOuter.T_incremented = clamp(indiOuter.T_incremented, MIN_THRUST, MAX_THRUST);
-	indiOuter.attitude_c.phi = clamp(indiOuter.attitude_c.phi, -10.0f, 10.0f); 	
+	indiOuter.attitude_c.phi = clamp(indiOuter.attitude_c.phi, -10.0f, 10.0f);
 	indiOuter.attitude_c.theta = clamp(indiOuter.attitude_c.theta, -10.0f, 10.0f);
 
 	// Reference values, which are passed to the inner loop INDI (attitude controller)


### PR DESCRIPTION
Compiling, testing, and debugging bits of `crazyflie-firmware` code on x86 is very useful [1]. To compile the code for #567, we need to include `stabilizer_types.h`, because the collision avoidance function operates on a `setpoint_t`. However, `stabilizer_types.h` depends on `lighthouse_geometry.h`, which includes an ARM math library.

`lighthouse_geometry.h` declares a function that accepts an `arm_math.h` type by pointer. Unfortunately, we cannot forward declare the pointed-to type because it's an anonymous struct of form
  
    typedef struct {
       ....
    } name;

These typedefs cannot be forward-declared.

It turns out that the only part of `lighthouse_geometry.h` that `stabilizer_types.h` needs is some trivial typedefs of fixed-size arrays. I felt the lowest impact fix would be to repeat those typedefs in `stabilizer_types.h`.

If the repetition is not acceptable, other options would be to put the typedefs in some other dependency-free file that `lighthouse_geometry.h` and `stabilizer_types.h` can both include, or to rewrite `lighthouse_geometry.h` to use `math3d.h` types.

The `controller_indi` implementations transitively depended on `arm_math.h`'s 32-bit pi constant. I replaced it with the one from `math3d.h`.

[1] For past modules like `pptraj.h`, the modules only depend on `math3d.h` and the standard library, so this problem doesn't exist.