### PR TITLE
traj_eval_zero() in pptraj

### DIFF
--- a/src/modules/interface/pptraj.h
+++ b/src/modules/interface/pptraj.h
@@ -124,6 +124,9 @@ struct traj_eval
 	float yaw;
 };
 
+// a traj_eval with all zero members.
+struct traj_eval traj_eval_zero(void);
+
 // a special value of traj_eval that indicates an invalid result.
 struct traj_eval traj_eval_invalid(void);
 

--- a/src/modules/src/pptraj.c
+++ b/src/modules/src/pptraj.c
@@ -265,6 +265,18 @@ float poly4d_max_accel_approx(struct poly4d const *p)
 	return amax;
 }
 
+struct traj_eval traj_eval_zero()
+{
+	struct traj_eval ev = {
+		.pos = vzero(),
+		.vel = vzero(),
+		.acc = vzero(),
+		.yaw = 0.0f,
+		.omega = vzero(),
+	};
+	return ev;
+}
+
 struct traj_eval traj_eval_invalid()
 {
 	struct traj_eval ev;


### PR DESCRIPTION
This is a trivial change. Not used anywhere in the firmware yet, but it is needed (via SWIG wrapper) for the upcoming Crazyswarm-based collision avoidance test script  (#567).