### PR TITLE
updated links in documentation

### DIFF
--- a/docs/building-and-flashing/flashing.md
+++ b/docs/building-and-flashing/flashing.md
@@ -27,7 +27,7 @@ Warning: if multiple Crazyflies within range are in bootloader mode the result i
 
 ### Automatically enter bootloader mode
 
-* Add the address of the crazyflie to the [`config.mk`](/building-and-flashing/configure_build/) file, for instance `CLOAD_CMDS = -w radio://0/80/2M`
+* Add the address of the crazyflie to the [`config.mk`](/docs/building-and-flashing/configure_build.md) file, for instance `CLOAD_CMDS = -w radio://0/80/2M`
 * Make sure the Crazyflie is on
 * In your terminal, run `make cload`
 
@@ -40,7 +40,7 @@ Note: this method does not work if the Crazyflie does not start, for instance if
 You need:
 
 * An ST Link V2 Debugger
-* open ocd installed ([installation intructions](/development/openocd_gdb_debugging/))
+* open ocd installed ([installation intructions](/docs/development/openocd_gdb_debugging.md))
 * The firmware has been built
 * The current working directory is the root of the frazyflie-firmware project
 

--- a/docs/development/howto.md
+++ b/docs/development/howto.md
@@ -5,7 +5,7 @@ page_id: howto
 
 This howto is going to describe step-by-step how to make and flash your
 first Crazyflie 2.X deck driver. See the deck [api documentation
-page](/userguides/deck/) for more information about the
+page](/docs/userguides/deck.md) for more information about the
 code.
 
 Development environment
@@ -133,4 +133,4 @@ $
 Now you can connect your Crazyflie with the client and see your driver
 in the console!
 
-![deck hello console](/images/deckhelloconsole.png){:align-center}
+![deck hello console](/docs/images/deckhelloconsole.png){:align-center}

--- a/docs/development/openocd_gdb_debugging.md
+++ b/docs/development/openocd_gdb_debugging.md
@@ -76,13 +76,13 @@ Now input the following settings in the debug configurations:
 
 ##### Main
 
-![stm openocd main](/images/stm_openocd_main.png)
+![stm openocd main](/docs/images/stm_openocd_main.png)
 
 Insert the filepath to the cf2.elf file to _C/C++ Application_.
 
 ##### Debugger
 
-![stm openocd debug](/images/stm_openocd_debugger.png)
+![stm openocd debug](/docs/images/stm_openocd_debugger.png)
 
 check the following settings: OpenOCD setup -\> Config options: \<code\>
 -f interface/stlink-v2.cfg -f target/stm32f4x.cfg -c init -c targets
@@ -93,7 +93,7 @@ check the following settings: OpenOCD setup -\> Config options: \<code\>
 
 ##### Startup
 
-![stm openocd startup](/images/stm_openocd_startup.png)
+![stm openocd startup](/docs/images/stm_openocd_startup.png)
 
 ##### Hit Debug!
 
@@ -171,7 +171,7 @@ Install the [extension](https://marketplace.visualstudio.com/items?itemName=maru
 
 Click on "Run", then "Add Configuration", then "Cortex Debug".
 
-![VS Code add configuration](/images/vscode_add_configuration.webp)
+![VS Code add configuration](/docs/images/vscode_add_configuration.webp)
 
 This should automatically create the needed "launch.json" file.
 
@@ -222,6 +222,6 @@ After all this, go to the Debug tab of VS Code (on the left sidebar, the icon wi
 
 If you followed everything, it should start running nicely and look a little something like this:
 
-![VS Code Cortex Debug](/images/vscode_cortex_debug.webp)
+![VS Code Cortex Debug](/docs/images/vscode_cortex_debug.webp)
 
 Notice the nice peripherals pane at the bottom, along with the variables pane at the top. Awesome, now you can code _and_ debug all within VS Code!

--- a/docs/development/serial.md
+++ b/docs/development/serial.md
@@ -17,7 +17,7 @@ Windows
 The serial number is located just after \"5740\\\", in the following
 screen it starts by 41:
 
-![windows serial](/images/windows_serial.png){:width=500x}
+![windows serial](/docs/images/windows_serial.png){:width=500x}
 
 By right-clicking on the string you can copy it.
 
@@ -30,16 +30,16 @@ Open a terminal and type (ie. cop-paste) the following command:
 
 The Crazyflie serial is then displayed (here it starts by 41):
 
-![linux serial](/images/linux_serial.png)
+![linux serial](/docs/images/linux_serial.png)
 
 Mac OS X
 --------
 
 From the \"About this mac\" menu, click on \"System reports\...\"
 
-![mac serial](/images/mac_serial_about.png){:width=400px}
+![mac serial](/docs/images/mac_serial_about.png){:width=400px}
 
 Then click on \"USB\", locate the Crazyflie 2 and the serial number can
 be copied from there
 
-![mac serial 2](/images/mac_serial.png){:width=500px}
+![mac serial 2](/docs/images/mac_serial.png){:width=500px}

--- a/docs/functional-areas/commanders_setpoints.md
+++ b/docs/functional-areas/commanders_setpoints.md
@@ -6,7 +6,7 @@ This section will go into the commander framework, which handles the setpoint of
 
 The Commander Module
 =============
-![commander framework](/images/commander_framework.png){:width="700"}
+![commander framework](/docs/images/commander_framework.png){:width="700"}
 
 The commander module handles the incoming setpoints from several sources (src/modules/src/commander.c in the [firmware](https://github.com/bitcraze/crazyflie-firmware)). A setpoint can be set directly, either through a python script using the [cflib](https://github.com/bitcraze/crazyflie-lib-python)/ [cfclient](https://github.com/bitcraze/crazyflie-clients-python) or [the app layer](/building-and-flashing/build_instructions/#out-of-tree-build) (blue pathways in the figure), or by the high-level commander module (purple pathway). The High-level commander in turn, can be controlled remotely from the python library or from inside the Crazyflie.
 
@@ -28,7 +28,7 @@ These can be controlled in different modes, namely:
     Velocity mode (modeVelocity)
     Disabled (modeDisable)
 
-![commander framework](/images/setpoint_structure.png){:width="700"}
+![commander framework](/docs/images/setpoint_structure.png){:width="700"}
 
 
 So if absolute position control is desired (go to point (1,0,1) in x,y,z), the controller will obey values given setpoint.position.xyz if setpoint.mode.xyz is set to modeAbs. If you rather want to control velocity (go 0.5 m/s in the x-direction), the controller will listen to the values given in setpoint.velocity.xyz if setpoint.mode.xyz is set to modeVel. All the attitude setpoint modes will be set then to disabled (modeDisabled). If only the attitude should be controlled, then all the position modes are set to modeDisabled. This happens for instance when you are controlling the crazyflie with a controller through the cfclient in attitude mode.
@@ -36,7 +36,7 @@ So if absolute position control is desired (go to point (1,0,1) in x,y,z), the c
 High Level Commander
 =============
 
-![high level commander](/images/high_level_commander.png){:width="700"}
+![high level commander](/docs/images/high_level_commander.png){:width="700"}
 
 As already explained before: The high level commander handles the setpoints from within the firmware based on a predefined trajectory. This was merged as part of the [Crazyswarm](https://crazyswarm.readthedocs.io/en/latest/) project of the [USC ACT lab](https://act.usc.edu/). The high-level commander uses a planner to generate smooth trajectories based on actions like ‘take off’, ‘go to’ or ‘land’ with 7th order polynomials. The planner generates a group of setpoints, which will be handled by the High level commander and send one by one to the commander framework.
 

--- a/docs/functional-areas/configure_estimator_controller.md
+++ b/docs/functional-areas/configure_estimator_controller.md
@@ -23,7 +23,7 @@ Some decks require the kalman estimator and it is automatically activated when o
 
 ### Setting default estimator at compile time
 
-It is possible to force the use of a specific estimator at compile time by setting `ESTIMATOR`, see [Configure the build](/building-and-flashing/configure_build/).
+It is possible to force the use of a specific estimator at compile time by setting `ESTIMATOR`, see [Configure the build](/docs/building-and-flashing/configure_build.md).
 
 Example:
 
@@ -45,7 +45,7 @@ The PID controller is the default controller.
 
 ### Setting at compile time
 
-It is possible to force the use of a specific controller at compile time by setting `CONTROLLER`, see [Configure the build](/building-and-flashing/configure_build/).
+It is possible to force the use of a specific controller at compile time by setting `CONTROLLER`, see [Configure the build](/docs/building-and-flashing/configure_build.md).
 
 Example:
 

--- a/docs/functional-areas/controllers.md
+++ b/docs/functional-areas/controllers.md
@@ -3,7 +3,7 @@ title: Controllers in the Crazyflie
 page_id: controllers
 ---
 
-Once the [state estimator](/functional-areas/state_estimators/) have outputed the current (estimated) situation of the crazyflie in position velocity and attitude, it is time for the controllers to keep it that way or to move the crazyflie into a new position based on a setpoint. This is an important part of the [stabilization system](/functional-areas/sensor_to_control/) in the crazyflie. 
+Once the [state estimator](/docs/functional-areas/state_estimators.md) have outputed the current (estimated) situation of the crazyflie in position velocity and attitude, it is time for the controllers to keep it that way or to move the crazyflie into a new position based on a setpoint. This is an important part of the [stabilization system](/docs/functional-areas/sensor_to_control.md) in the crazyflie. 
 
 ## Types of levels and control
 There are three levels to control in the crazyflie:
@@ -33,7 +33,7 @@ So the default settings in the Crazyflie firmware is the [proportional integral 
 
 Here is a block schematics of how the PID controllers are implemented.
 
-![cascaded pid controller](/images/cascaded_pid_controller.png){:width="700"}
+![cascaded pid controller](/docs/images/cascaded_pid_controller.png){:width="700"}
 
 Here are the different loops of the cascaded PID explained in more detail.
 
@@ -45,7 +45,7 @@ Check the implementation details in [attitude_pid_controller.c](https://github.c
 
 ### Attitude PID controller
 
-The absolute attitude PID controller is the outerloop of the attitude controller. This takes in the estimated attitude of the [state estimator](/functional-areas/state_estimators/), and takes the error of the desired attitude setpoint to control the attitude of the Crazyflie. The output is desired attitude rate which is send to the attitude rate controller. The control loop runs at 500 Hz.
+The absolute attitude PID controller is the outerloop of the attitude controller. This takes in the estimated attitude of the [state estimator](/docs/functional-areas/state_estimators.md), and takes the error of the desired attitude setpoint to control the attitude of the Crazyflie. The output is desired attitude rate which is send to the attitude rate controller. The control loop runs at 500 Hz.
 
 Check the implementation details in [attitude_pid_controller.c](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/src/attitude_pid_controller.c) in `attitudeControllerCorrectAttitudePID()`.
 
@@ -53,7 +53,7 @@ Check the implementation details in [attitude_pid_controller.c](https://github.c
 
 The most outerloop of the cascaded PID controller is the position and velocity controller. It receives position or velcoityinput from a commander which are handled, since it is possible to set in the variable `setpoint_t` which  stabilization mode to use `stab_mode_t` (either position:  `modeAbs` or `modeVelocity`). These can be found in [stabilizer_types.h](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/interface/stabilizer_types.h). The control loop runs at 100 Hz.
 
-Check the implementation details in Check the implementation details in [position_controller_pid.c](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/src/position_controller_pid.c) in `positionController()` and  `velocityController()`. 
+Check the implementation details in [position_controller_pid.c](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/src/position_controller_pid.c) in `positionController()` and  `velocityController()`. 
 
 ## Mellinger Controller
 COMING SOON!

--- a/docs/functional-areas/crtp/ctrp_log.md
+++ b/docs/functional-areas/crtp/ctrp_log.md
@@ -4,7 +4,7 @@ page_id: ctrp_log
 ---
 
 For more information on how to use this and how this is implemented have
-a look [here](/userguides/logparam/).
+a look [here](/docs/userguides/logparam.md).
 
 State machines
 ==============
@@ -12,7 +12,7 @@ State machines
 Downloading the Table Of Contents
 ---------------------------------
 
-![ctrp log](/images/ctrp_log.png)
+![ctrp log](/docs/images/ctrp_log.png)
 
 Communication protocol
 ======================

--- a/docs/functional-areas/crtp/ctrp_mem.md
+++ b/docs/functional-areas/crtp/ctrp_mem.md
@@ -26,7 +26,7 @@ Getting information and reading/writing the memories is optional for the
 clients, but the -Crazyflie Python Client- always downloads information
 about the memories on connect.
 
-![ctrp mem](/images/ctrp_mem.png)
+![ctrp mem](/docs/images/ctrp_mem.png)
 
 Communication protocol
 ======================
@@ -163,7 +163,7 @@ not contain any command byte.
 The request from host to Crazyflie:
 
 |  Byte  | Field      | Value   |Length   |Comment|
-|  ------| -----------|  ------- -------- |-------------------------------------------------|
+|  ------| -----------|  -------| -------- |-------------------------------------------------|
 |  0     | MEM\_ID    |        | 1        |A memory id that is 0 \<= id \< NBR\_OF\_MEMS |
 |  1     | MEM\_ADDR  |         |4        |The address where the first byte should be read |
 |  5     | LEN         |        |1        |The number of bytes to be read |
@@ -180,10 +180,10 @@ length to be read is valid:
 
 Where the STATUS field is:
 
-  STATUS   Comment
-  -------- ---------
-  0        \...
-  1        \....
+ | STATUS  | Comment|
+ | --------| ---------|
+ | 0       | \...|
+ | 1       | \....|
 
 Example of reading LEN=0x0F bytes from MEM\_ID=0x01 MEM\_ADDR=0x0A
 

--- a/docs/functional-areas/crtp/ctrp_parameters.md
+++ b/docs/functional-areas/crtp/ctrp_parameters.md
@@ -143,7 +143,7 @@ The following misc commands are implemented:
 |  n-(n+1)       |  NULL           | 0|
 |  (n+1)-(n+m+1) |  name           | Name of the parameter|
 |  (n+m+2)       |  NULL           | 0|
-|  (n+m+3)       |  ERROR          | 0 if the parameter has been successfully written. Other code are taken from [errno C codes](http://www.virtsync.com/c-error-codes-include-errno). |
+|  (n+m+3)       |  ERROR          | 0 if the parameter has been successfully written. Other code are taken from [errno C codes](https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html). |
 
 
 *Group* and *name* are ascii strings of size respectively *n* and *m*.

--- a/docs/functional-areas/crtp/index.md
+++ b/docs/functional-areas/crtp/index.md
@@ -49,13 +49,13 @@ Current port allocation:
 
 | **Port** |  **Target**                                                       |          **Used for**|
 | ---------| ------------------------------------------------------------------| ----------------------------------------------------------------|
-|  0       | [Console](/functional-areas/crtp/ctrp_console/)                   | Read console text that is printed to the console on the Crazyflie using consoleprintf|
-|  2       | [Parameters](/functional-areas/crtp/ctrp_parameters/)             | Get/set parameters from the Crazyflie. Parameters are defined using a [macro in the Crazyflie source-code](/userguides/logparam/)|
-|  3       | [Commander](/functional-areas/crtp/ctrp_commander/)               | Sending control set-points for the roll/pitch/yaw/thrust regulators|
-|  4       | [Memory access](/functional-areas/crtp/ctrp_mem/)                 | Accessing non-volatile memories like 1-wire and I2C (only supported for Crazyflie 2.0)|
-|  5       | [Data logging](/functional-areas/crtp/ctrp_log/)                  | Set up log blocks with variables that will be sent back to the Crazyflie at a specified period. Log variables are defined using a [macro in the Crazyflie source-code](/userguides/logparam/)|
-|  6       | [Localization](/functional-areas/crtp/ctrp_localization/)         | Packets related to localization|
-|  7       | [Generic Setpoint](/functional-areas/crtp/ctrp_generic_setpoint/) | Allows to send setpoint and control modes|
+|  0       | [Console](/docs/functional-areas/crtp/ctrp_console.md)                   | Read console text that is printed to the console on the Crazyflie using consoleprintf|
+|  2       | [Parameters](/docs/functional-areas/crtp/ctrp_parameters.md)             | Get/set parameters from the Crazyflie. Parameters are defined using a [macro in the Crazyflie source-code](/docs/userguides/logparam.md)|
+|  3       | [Commander](/docs/functional-areas/crtp/ctrp_commander.md)               | Sending control set-points for the roll/pitch/yaw/thrust regulators|
+|  4       | [Memory access](/docs/functional-areas/crtp/ctrp_mem.md)                 | Accessing non-volatile memories like 1-wire and I2C (only supported for Crazyflie 2.0)|
+|  5       | [Data logging](/docs/functional-areas/crtp/ctrp_log.md)                  | Set up log blocks with variables that will be sent back to the Crazyflie at a specified period. Log variables are defined using a [macro in the Crazyflie source-code](/docs/userguides/logparam.md)|
+|  6       | [Localization](/docs/functional-areas/crtp/ctrp_localization.md)         | Packets related to localization|
+|  7       | [Generic Setpoint](/docs/functional-areas/crtp/ctrp_generic_setpoint.md) | Allows to send setpoint and control modes|
 |  13      | Platform                                                          | Used for misc platform control, like debugging and power off|
 |  14      | Client-side debugging                                             | Debugging the UI and exists only in the Crazyflie Python API and not in the Crazyflie itself.|
 |  15      | Link layer                                                        | Used to control and query the communication link|

--- a/docs/functional-areas/deck_memory_format.md
+++ b/docs/functional-areas/deck_memory_format.md
@@ -23,15 +23,15 @@ in two part:
 Content
 -------
 
-      1. Header     1 Byte 0xEB
+      1. Header         1 Byte 0xEB
       2. UsedPins       4 Bytes
-      3. VID        1 Byte
-      4. PID        1 Byte
-      5. crc        1 Byte CRC32[0] (LSB byte) from 1 to 4.
+      3. VID            1 Byte
+      4. PID            1 Byte
+      5. crc            1 Byte CRC32[0] (LSB byte) from 1 to 4.
       6. Version        1Byte, 0 for now
       7. DataLength     1 Byte (255 max data length…)
       8. key/value data <DataLength> bytes
-      9. crc        1 Byte CRC32[0] (LSB byte) from 6 to 8
+      9. crc            1 Byte CRC32[0] (LSB byte) from 6 to 8
 
 -   The header area is from 1 to 5.
 -   The key/value area is from 6 do 9
@@ -75,10 +75,11 @@ ignored.
 
 Elements have this format:
 
-
- | **Id**      | 1Byte|
- | **length**  | 1Byte|
- | **data**     |\<length\> Bytes|
+| **Element** | No. of Bytes |
+| --- | --- |
+| **Id**      | 1Byte|
+| **length**  | 1Byte|
+| **data**     |\<length\> Bytes|
 
 
 The following elements are defined:

--- a/docs/functional-areas/lighthouse_overview.md
+++ b/docs/functional-areas/lighthouse_overview.md
@@ -15,7 +15,7 @@ The lighthouse deck allows to use the HTC-Vive/SteamVR lighthouse tracking syste
 
 After everything is setup, the computer is not required anymore: the Crazyflie will autonomously estimate its position from the lighthouse signals.
 
-In order to setup the system you must also be able to compile a custom firmware for your Crazyflie and to program your Crazyflie 2.X. To do so you can follow the [Getting started with Crazyflie 2.X](https://www.bitcraze.io/getting-started-with-the-crazyflie-2-0/) and [Getting started with development](https://www.bitcraze.io/getting-started-with-development/) guides.
+In order to setup the system you must also be able to compile a custom firmware for your Crazyflie and to program your Crazyflie 2.X. To do so you can follow the [Getting started with Crazyflie 2.X](https://www.bitcraze.io/documentation/tutorials/getting-started-with-crazyflie-2-x/) and [Getting started with development](https://www.bitcraze.io/documentation/tutorials/getting-started-with-development/) guides.
 
 ### Finding base station positions - configuring the system
 
@@ -40,6 +40,8 @@ Compile the Crazyflie firmware with lighthouse support and flash the Crazyflie. 
 make
 make cload
 ```
+
+See [configure_build.md](/docs/building-and-flashing/configure_build.md) for more information about the config.mk file.
 
 Mount the Lighthouse deck on the Crazyflie, and place it on the floor where you want your the origin of your coordinate system, and turn it on. The Crazyflie should be oriented in the direction you want the X-axis.
 

--- a/docs/functional-areas/sensor_to_control.md
+++ b/docs/functional-areas/sensor_to_control.md
@@ -11,7 +11,7 @@ by power distribution. Ofcourse, the motors have an affect on how the
 crazyflie flies and that inderectly has an effect on what the sensors
 detect in the next time step.
 
-![sensor](/images/sensors_to_motors.png){:width="700"}
+![sensor](/docs/images/sensors_to_motors.png){:width="700"}
 
 ## Modules 
 
@@ -42,7 +42,7 @@ There are 2 state estimators in the crazyflie:
 * Complementary Filter
 * Extended Kalman Filter
 
-For more indepth information about how the state estimation is implemented in the crazyflie firmware, please go to the [state estimation page](/functional-areas/state_estimators/)
+For more indepth information about how the state estimation is implemented in the crazyflie firmware, please go to the [state estimation page](/docs/functional-areas/state_estimators.md)
 
 ### State Controller
 There are 3 controllers in the crazyflie
@@ -50,12 +50,12 @@ There are 3 controllers in the crazyflie
 * INDI controller
 * Mellinger controller
 
-For more indepth information about how the controllers are implemented in the crazyflie firmware, please go to the [controllers page](/functional-areas/controllers/)
+For more indepth information about how the controllers are implemented in the crazyflie firmware, please go to the [controllers page](/docs/functional-areas/controllers.md)
 
 ### Commander Framework
 An desired state can be handled by the setpoint structure in position or atitude, which can be set by the cflib or the highlevel commander
 
-For more indepth information about how the commander framework are implemented in the crazyflie firmware, please go to the [commander page](/functional-areas/commanders_setpoints/)
+For more indepth information about how the commander framework are implemented in the crazyflie firmware, please go to the [commander page](/docs/functional-areas/commanders_setpoints.md)
 
 ### Power Distribution
 

--- a/docs/functional-areas/state_estimators.md
+++ b/docs/functional-areas/state_estimators.md
@@ -3,11 +3,11 @@ title: State estimation
 page_id: state_estimators
 ---
 
-A state estimator turns sensor signals into an estimate of the state that the crazyflie is in. This is an essential part of crazyflie's stabilizing system, as explained in the [overview page](/functional-areas/sensor_to_control/). State estimation is really important in quadrotors (and robotics in general). The Crazyflie needs to first of all know in which angles it is at (roll, pitch, yaw). If it would be flying at a few degrees slanted in roll, the crazyflie would accelerate into that direction. Therefore the controller need to know an good estimate of current angles’ state and compensate for it. For a step higher in autonomy, a good position estimate becomes important too, since you would like it to move reliably from A to B.
+A state estimator turns sensor signals into an estimate of the state that the crazyflie is in. This is an essential part of crazyflie's stabilizing system, as explained in the [overview page](/docs/functional-areas/sensor_to_control.md). State estimation is really important in quadrotors (and robotics in general). The Crazyflie needs to first of all know in which angles it is at (roll, pitch, yaw). If it would be flying at a few degrees slanted in roll, the crazyflie would accelerate into that direction. Therefore the controller need to know an good estimate of current angles’ state and compensate for it. For a step higher in autonomy, a good position estimate becomes important too, since you would like it to move reliably from A to B.
 
 ## Complementary filter
 
-![complementary filter](/images/complementary_filter.png){:width="500"}
+![complementary filter](/docs/images/complementary_filter.png){:width="500"}
 
 The complementary filter is consider a very lightweight and efficient filter which in general only uses the IMU input of the gyroscope (angle rate) and the accelerator. The estimator has been extended to also include input of the ToF distance measurement of the [Zranger deck](https://store.bitcraze.io/collections/decks/products/z-ranger-deck-v2). The estimated output is the Crazyflie’s attitude (roll, pitch, yaw) and its altitude (in the z direction). These values can be used by the controller and are meant to be used for manual control. 
 
@@ -15,7 +15,7 @@ To checkout the implementation details, please checkout the firmware in [estimat
 
 ## Extended Kalman filter
 
-![extended kalman filter](/images/extended_kalman_filter.png){:width="500"}
+![extended kalman filter](/docs/images/extended_kalman_filter.png){:width="500"}
 
 The (extended) Kalman filter (EKF) is an step up in complexity compared to the complementary filter, as it accepts more sensor inputs of both internal and external sensors. It is an recursive filter that estimates the current state of the Crazyflie based on incoming measurements (in combination with a predicted standard deviation of the noise), the measurement model and the model of the system itself. 
 
@@ -38,7 +38,7 @@ This section will explain how the signals of the sensors are transformed to stat
 
 This illustration explains how the height from the VL53L1x sensor and flow from the PMW3901 sensor are combined to calculate velocity. This has been implemented by the work of [3] and can be found in [kalman_core.c](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/src/kalman_core.c) in the function `kalmanCoreUpdateWithFlow()`.
 
-![flowdeck velocity](/images/flowdeck_velocity.png){:width="500"}
+![flowdeck velocity](/docs/images/flowdeck_velocity.png){:width="500"}
 
 #### Locodeck
 

--- a/docs/userguides/deck.md
+++ b/docs/userguides/deck.md
@@ -13,7 +13,7 @@ Crazyflie. The deck API is still in development, it will:
     (*not started yet*)
 
 If you want to get started you can follow the
-[howto](/development/howto/) to get your code
+[howto](/docs/development/howto.md) to get your code
 running.
 
 Deck drivers

--- a/docs/userguides/logparam.md
+++ b/docs/userguides/logparam.md
@@ -49,7 +49,7 @@ restrictions. There\'s one TOC for each framework, one for logging and
 one for parameters. When the client connects it will download the TOC to
 know which variables can be used. It\'s then easy to use the [Python
 API](https://github.com/bitcraze/crazyflie-lib-python) ([or another
-API](https://wiki.bitcraze.io/doc:crazyflie:api:community) for accessing them.
+API](https://www.bitcraze.io/support/external-projects/)) for accessing them.
 
 All the variables have a name and belong to a group. So in the examples
 above there\'s two groups defined: *ring* and *stabilizer*. To refer to


### PR DESCRIPTION
I was looking through the documentation and noticed that the links for the images weren't working on github so I updated them. 
While doing it I also fixed some tables and some external links.
I also added a paragraph with an internal link because I remembered that I was stuck at that point when reading the documentation on my own and that link would have helped me. 

I hope that is useful and wanted and correct.