### PR TITLE
added link to configure_build.md for clarification

### DIFF
--- a/docs/functional-areas/lighthouse_overview.md
+++ b/docs/functional-areas/lighthouse_overview.md
@@ -40,6 +40,7 @@ Compile the Crazyflie firmware with lighthouse support and flash the Crazyflie. 
 make
 make cload
 ```
+See [configure_build.md](/building-and-flashing/configure_build/) for more information about the config.mk file.
 
 Mount the Lighthouse deck on the Crazyflie, and place it on the floor where you want your the origin of your coordinate system, and turn it on. The Crazyflie should be oriented in the direction you want the X-axis.
 


### PR DESCRIPTION
I added a reference to the configure_build.md because i remembered that i had some trouble finding the correct information when I was working with this part of the docs. 
So I thought it could help to have it there.