### PR TITLE
#592: Lighthouse reflection handling

### DIFF
--- a/src/modules/src/lighthouse/lighthouse_core.c
+++ b/src/modules/src/lighthouse/lighthouse_core.c
@@ -196,10 +196,10 @@ static void usePulseResult(pulseProcessor_t *appState, pulseProcessorResult_t* a
 
     switch(estimationMethod) {
       case 0:
-        usePulseResultCrossingBeams(appState, angles, basestation, axis);
+        usePulseResultCrossingBeams(appState, angles, basestation);
         break;
       case 1:
-        usePulseResultSweeps(appState, angles, basestation, axis);
+        usePulseResultSweeps(appState, angles, basestation);
         break;
       default:
         break;
@@ -359,6 +359,11 @@ LOG_ADD(LOG_FLOAT, rawAngle0xlh2, &angles.sensorMeasurementsLh2[0].baseStatonMea
 LOG_ADD(LOG_FLOAT, rawAngle0ylh2, &angles.sensorMeasurementsLh2[0].baseStatonMeasurements[0].angles[1])
 LOG_ADD(LOG_FLOAT, rawAngle1xlh2, &angles.sensorMeasurementsLh2[0].baseStatonMeasurements[1].angles[0])
 LOG_ADD(LOG_FLOAT, rawAngle1ylh2, &angles.sensorMeasurementsLh2[0].baseStatonMeasurements[1].angles[1])
+
+LOG_ADD(LOG_UINT32, time0x_0, &angles.sensorMeasurementsLh1[1].baseStatonMeasurements[0].timestampsHistory[1][0])
+LOG_ADD(LOG_UINT32, time0x_1, &angles.sensorMeasurementsLh1[1].baseStatonMeasurements[0].timestampsHistory[1][1])
+LOG_ADD(LOG_UINT32, time0x_2, &angles.sensorMeasurementsLh1[1].baseStatonMeasurements[0].timestampsHistory[1][2])
+LOG_ADD(LOG_UINT32, time0x_3, &angles.sensorMeasurementsLh1[1].baseStatonMeasurements[0].timestampsHistory[1][3])
 
 STATS_CNT_RATE_LOG_ADD(serRt, &serialFrameRate)
 STATS_CNT_RATE_LOG_ADD(frmRt, &frameRate)

--- a/src/modules/src/lighthouse/lighthouse_core.c
+++ b/src/modules/src/lighthouse/lighthouse_core.c
@@ -196,10 +196,10 @@ static void usePulseResult(pulseProcessor_t *appState, pulseProcessorResult_t* a
 
     switch(estimationMethod) {
       case 0:
-        usePulseResultCrossingBeams(appState, angles, basestation);
+        usePulseResultCrossingBeams(appState, angles, basestation, axis);
         break;
       case 1:
-        usePulseResultSweeps(appState, angles, basestation);
+        usePulseResultSweeps(appState, angles, basestation, axis);
         break;
       default:
         break;

--- a/src/utils/interface/lighthouse/pulse_processor.h
+++ b/src/utils/interface/lighthouse/pulse_processor.h
@@ -36,6 +36,7 @@
 #include "lighthouse_calibration.h"
 
 #define PULSE_PROCESSOR_N_SWEEPS 2
+#define PULSE_PROCESSOR_N_SWEEPS_PER_FRAME 4
 #define PULSE_PROCESSOR_N_BASE_STATIONS 2
 #define PULSE_PROCESSOR_N_SENSORS 4
 #define PULSE_PROCRSSOR_N_CONCURRENT_BLOCKS 2
@@ -155,6 +156,7 @@ typedef struct {
   // Sweep timestamps
   struct {
     uint32_t timestamp;
+    uint32_t timestamps[PULSE_PROCESSOR_N_SWEEPS_PER_FRAME];
     SweepStorageState_t state;
   } sweeps[PULSE_PROCESSOR_N_SENSORS];
   bool sweepDataStored;
@@ -228,6 +230,7 @@ typedef struct pulseProcessor_s {
 typedef struct {
   float angles[PULSE_PROCESSOR_N_SWEEPS];
   float correctedAngles[PULSE_PROCESSOR_N_SWEEPS];
+  uint32_t timestampsHistory[PULSE_PROCESSOR_N_SWEEPS][PULSE_PROCESSOR_N_SWEEPS_PER_FRAME];
   int validCount;
 } pulseProcessorBaseStationMeasuremnt_t;
 

--- a/src/utils/src/lighthouse/pulse_processor_v1.c
+++ b/src/utils/src/lighthouse/pulse_processor_v1.c
@@ -288,6 +288,7 @@ static bool processPreviousFrame(pulseProcessorV1_t *stateV1, pulseProcessorResu
           float center = frameWidth/4.0f;
           float angle = (delta - center)*2*(float)M_PI/frameWidth;
           bsMeasurement->angles[*axis] = angle;
+          bsMeasurement->timestampsHistory[*axis][0] = delta;
           bsMeasurement->validCount++;
           anglesMeasured = true;
         }


### PR DESCRIPTION
When only one sweep is detected in the frame, then nothing will be adapted. But if multiple sweeps are detected, this is probably because of a reflection of the sweep. In that case we check what sweep is closest to the previous calculated angle and choose that. 

caveat: once the sweep is lost (so the sweep isn't seen once), then we have no fallback and can only reset when only one sweep is in the frame anymore. So this algo works as longs as he has vision of the bs. Cannot be started when the system already has already multiple sweeps.