### PR TITLE
Added crtpCommanderHighLevelIsTrajectoryDefined()

### DIFF
--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -128,6 +128,13 @@ void crtpCommanderHighLevelStop();
 void crtpCommanderHighLevelGoTo(const float x, const float y, const float z, const float yaw, const float duration_s, const bool relative);
 
 /**
+ * @brief Returns whether the trajectory with the given ID is defined
+ *
+ * @param trajectoryId The id of the trajectory
+ */
+bool crtpCommanderHighLevelIsTrajectoryDefined(uint8_t trajectoryId);
+
+/**
  * @brief starts executing a specified trajectory
  *
  * @param trajectoryId id of the trajectory (previously defined by define_trajectory)

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -718,6 +718,14 @@ void crtpCommanderHighLevelGoTo(const float x, const float y, const float z, con
   handleCommand(COMMAND_GO_TO, (const uint8_t*)&data);
 }
 
+bool crtpCommanderHighLevelIsTrajectoryDefined(uint8_t trajectoryId)
+{
+  return (
+    trajectoryId < NUM_TRAJECTORY_DEFINITIONS &&
+    trajectory_descriptions[trajectoryId].trajectoryLocation != TRAJECTORY_LOCATION_INVALID
+  );
+}
+
 void crtpCommanderHighLevelStartTrajectory(const uint8_t trajectoryId, const float timeScale, const bool relative, const bool reversed)
 {
   struct data_start_trajectory data =


### PR DESCRIPTION
This PR extends the public API of the high-level commander with a function that allows the app layer to determine whether the trajectory at a given trajectory slot is defined.

This could be used by apps that are supposed to start flying a trajectory that is to be uploaded by the user to wait until the trajectory is indeed defined by the user via CRTP commands.