### PR TITLE
Added takeoff/land with average velocity commands to public API of the HL commander

### DIFF
--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -82,6 +82,17 @@ bool crtpCommanderHighLevelIsStopped();
 void crtpCommanderHighLevelTakeoff(const float absoluteHeight_m, const float duration_s);
 
 /**
+ * @brief vertical takeoff from current x-y position to given absolute or relative
+ * height with given velocity
+ *
+ * @param height_m         absolute or relative target height (m)
+ * @param velocity_m_s     takeoff velocity (m/s)
+ * @param relative         whether the height is relative to the current position
+ */
+void crtpCommanderHighLevelTakeoffWithVelocity(const float height_m, const float velocity_m_s, bool relative);
+
+
+/**
  * @brief vertical takeoff from current x-y position to given height
  *
  * @param absoluteHeight_m absolute target height (m)
@@ -97,6 +108,16 @@ void crtpCommanderHighLevelTakeoffYaw(const float absoluteHeight_m, const float 
  * @param duration_s       time it should take until target height is reached (s)
  */
 void crtpCommanderHighLevelLand(const float absoluteHeight_m, const float duration_s);
+
+/**
+ * @brief vertical land from current x-y position to given absolute or relative
+ * height with given velocity
+ *
+ * @param height_m         absolute or relative target height (m)
+ * @param velocity_m_s     landing velocity (m/s)
+ * @param relative         whether the height is relative to the current position
+ */
+void crtpCommanderHighLevelLandWithVelocity(const float height_m, const float velocity_m_s, bool relative);
 
 /**
  * @brief vertical land from current x-y position to given height

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -665,6 +665,20 @@ void crtpCommanderHighLevelTakeoffYaw(const float absoluteHeight_m, const float 
   handleCommand(COMMAND_TAKEOFF_2, (const uint8_t*)&data);
 }
 
+void crtpCommanderHighLevelTakeoffWithVelocity(const float height_m, const float velocity_m_s, bool relative)
+{
+  struct data_takeoff_with_velocity data =
+  {
+    .height = height_m,
+    .heightIsRelative = relative,
+    .velocity = velocity_m_s,
+    .useCurrentYaw = true,
+    .groupMask = ALL_GROUPS,
+  };
+
+  handleCommand(COMMAND_TAKEOFF_WITH_VELOCITY, (const uint8_t*)&data);
+}
+
 void crtpCommanderHighLevelLand(const float absoluteHeight_m, const float duration_s)
 {
   struct data_land_2 data =
@@ -676,6 +690,20 @@ void crtpCommanderHighLevelLand(const float absoluteHeight_m, const float durati
   };
 
   handleCommand(COMMAND_LAND_2, (const uint8_t*)&data);
+}
+
+void crtpCommanderHighLevelLandWithVelocity(const float height_m, const float velocity_m_s, bool relative)
+{
+  struct data_land_with_velocity data =
+  {
+    .height = height_m,
+    .heightIsRelative = relative,
+    .velocity = velocity_m_s,
+    .useCurrentYaw = true,
+    .groupMask = ALL_GROUPS,
+  };
+
+  handleCommand(COMMAND_LAND_WITH_VELOCITY, (const uint8_t*)&data);
 }
 
 void crtpCommanderHighLevelLandYaw(const float absoluteHeight_m, const float duration_s, const float yaw)


### PR DESCRIPTION
The public API of the HL commander missed the entry points for the "takeoff with average velocity" and "land with average velocity" commands. Now they are there.