### PR TITLE
disable MISC_VALUE_UPDATED CRTP messages on-demand with a compile-time switch

### DIFF
--- a/src/modules/src/param.c
+++ b/src/modules/src/param.c
@@ -728,7 +728,9 @@ void paramSetInt(paramVarId_t varid, int valuei)
       break;
   }
 
+#ifndef SILENT_PARAM_UPDATES
   crtpSendPacket(&pk);
+#endif
 }
 
 void paramSetFloat(paramVarId_t varid, float valuef)
@@ -748,5 +750,8 @@ void paramSetFloat(paramVarId_t varid, float valuef)
       memcpy(&pk.data[2], &valuef, 4);
       pk.size += 4;
   }
+
+#ifndef SILENT_PARAM_UPDATES
   crtpSendPacket(&pk);
+#endif
 }

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -44,6 +44,9 @@
 ## Set LED Rings to use less more LEDs (only if board is modified)
 # CFLAGS += -DLED_RING_NBR_LEDS=24
 
+## Do not send CRTP messages when parameter values are updated
+# CFLAGS += -DSILENT_PARAM_UPDATES
+
 ## Turn on monitoring of queue usages
 # CFLAGS += -DDEBUG_QUEUE_MONITOR
 


### PR DESCRIPTION
As discussed with @krichardsson .

This PR allows the user to prevent the Crazyflie from dispatching MISC_VALUE_UPDATED messages on the CRTP param port when a parameter value is updated from within the firmware (i.e. not from the GCS via a CRTP command). It can help to reduce radio traffic generated by certain Crazyflie apps if the app updates many parameter values frequently; for instance, when the app drives the color of the LED ring in a tight loop.

This is an advanced feature and it breaks synchronization of parameter values between a GCS and the drone if the GCS relies on local caching of parameter values.