### PR TITLE
docs: fix simple typo, communicaton -> communication

### DIFF
--- a/src/modules/interface/msp.h
+++ b/src/modules/interface/msp.h
@@ -25,7 +25,7 @@
  * msp.h - Definitions for the MultiWii Serial Protocol
  *
  * The MultiWii Serial Protocol is a commonly used protocol for OSDs,
- * data logging, and communicaton with a ground telemetry station.
+ * data logging, and communication with a ground telemetry station.
  * For more details, see the official MSP documentation and support thread:
  *  - http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol
  *  - http://www.multiwii.com/forum/viewtopic.php?f=8&t=1516

--- a/src/modules/src/msp.c
+++ b/src/modules/src/msp.c
@@ -24,7 +24,7 @@
  * msp.c: Implementation of the MultiWii Serial Protocol
  *
  * The MultiWii Serial Protocol is a commonly used protocol for OSDs,
- * data logging, and communicaton with a ground telemetry station.
+ * data logging, and communication with a ground telemetry station.
  * For more details, see the official MSP documentation and support thread:
  *  - http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol
  *  - http://www.multiwii.com/forum/viewtopic.php?f=8&t=1516


### PR DESCRIPTION
There is a small typo in src/modules/interface/msp.h, src/modules/src/msp.c.

Should read `communication` rather than `communicaton`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md