### PR TITLE
sensfusion6: Rename quaternion components for clarity.

### DIFF
--- a/src/modules/src/sensfusion6.c
+++ b/src/modules/src/sensfusion6.c
@@ -49,10 +49,10 @@
   float integralFBz = 0.0f;  // integral error terms scaled by Ki
 #endif
 
-float q0 = 1.0f;
-float q1 = 0.0f;
-float q2 = 0.0f;
-float q3 = 0.0f;  // quaternion of sensor frame relative to auxiliary frame
+float qw = 1.0f;
+float qx = 0.0f;
+float qy = 0.0f;
+float qz = 0.0f;  // quaternion of sensor frame relative to auxiliary frame
 
 static float gravX, gravY, gravZ; // Unit vector in the estimated gravity direction
 
@@ -108,13 +108,13 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
   float recipNorm;
   float s0, s1, s2, s3;
   float qDot1, qDot2, qDot3, qDot4;
-  float _2q0, _2q1, _2q2, _2q3, _4q0, _4q1, _4q2 ,_8q1, _8q2, q0q0, q1q1, q2q2, q3q3;
+  float _2qw, _2qx, _2qy, _2qz, _4qw, _4qx, _4qy ,_8qx, _8qy, qwqw, qxqx, qyqy, qzqz;
 
   // Rate of change of quaternion from gyroscope
-  qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-  qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
-  qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
-  qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+  qDot1 = 0.5f * (-qx * gx - qy * gy - qz * gz);
+  qDot2 = 0.5f * (qw * gx + qy * gz - qz * gy);
+  qDot3 = 0.5f * (qw * gy - qx * gz + qz * gx);
+  qDot4 = 0.5f * (qw * gz + qx * gy - qy * gx);
 
   // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
   if(!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
@@ -126,25 +126,25 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
     az *= recipNorm;
 
     // Auxiliary variables to avoid repeated arithmetic
-    _2q0 = 2.0f * q0;
-    _2q1 = 2.0f * q1;
-    _2q2 = 2.0f * q2;
-    _2q3 = 2.0f * q3;
-    _4q0 = 4.0f * q0;
-    _4q1 = 4.0f * q1;
-    _4q2 = 4.0f * q2;
-    _8q1 = 8.0f * q1;
-    _8q2 = 8.0f * q2;
-    q0q0 = q0 * q0;
-    q1q1 = q1 * q1;
-    q2q2 = q2 * q2;
-    q3q3 = q3 * q3;
+    _2qw = 2.0f * qw;
+    _2qx = 2.0f * qx;
+    _2qy = 2.0f * qy;
+    _2qz = 2.0f * qz;
+    _4qw = 4.0f * qw;
+    _4qx = 4.0f * qx;
+    _4qy = 4.0f * qy;
+    _8qx = 8.0f * qx;
+    _8qy = 8.0f * qy;
+    qwqw = qw * qw;
+    qxqx = qx * qx;
+    qyqy = qy * qy;
+    qzqz = qz * qz;
 
     // Gradient decent algorithm corrective step
-    s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
-    s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
-    s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
-    s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
+    s0 = _4qw * qyqy + _2qy * ax + _4qw * qxqx - _2qx * ay;
+    s1 = _4qx * qzqz - _2qz * ax + 4.0f * qwqw * qx - _2qw * ay - _4qx + _8qx * qxqx + _8qx * qyqy + _4qx * az;
+    s2 = 4.0f * qwqw * qy + _2qw * ax + _4qy * qzqz - _2qz * ay - _4qy + _8qy * qxqx + _8qy * qyqy + _4qy * az;
+    s3 = 4.0f * qxqx * qz - _2qx * ax + 4.0f * qyqy * qz - _2qy * ay;
     recipNorm = invSqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
     s0 *= recipNorm;
     s1 *= recipNorm;
@@ -159,17 +159,17 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
   }
 
   // Integrate rate of change of quaternion to yield quaternion
-  q0 += qDot1 * dt;
-  q1 += qDot2 * dt;
-  q2 += qDot3 * dt;
-  q3 += qDot4 * dt;
+  qw += qDot1 * dt;
+  qx += qDot2 * dt;
+  qy += qDot3 * dt;
+  qz += qDot4 * dt;
 
   // Normalise quaternion
-  recipNorm = invSqrt(q0*q0 + q1*q1 + q2*q2 + q3*q3);
-  q0 *= recipNorm;
-  q1 *= recipNorm;
-  q2 *= recipNorm;
-  q3 *= recipNorm;
+  recipNorm = invSqrt(qw*qw + qx*qx + qy*qy + qz*qz);
+  qw *= recipNorm;
+  qx *= recipNorm;
+  qy *= recipNorm;
+  qz *= recipNorm;
 }
 #else // MAHONY_QUATERNION_IMU
 // Madgwick's implementation of Mayhony's AHRS algorithm.
@@ -199,9 +199,9 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
     az *= recipNorm;
 
     // Estimated direction of gravity and vector perpendicular to magnetic flux
-    halfvx = q1 * q3 - q0 * q2;
-    halfvy = q0 * q1 + q2 * q3;
-    halfvz = q0 * q0 - 0.5f + q3 * q3;
+    halfvx = qx * qz - qw * qy;
+    halfvy = qw * qx + qy * qz;
+    halfvz = qw * qw - 0.5f + qz * qz;
 
     // Error is sum of cross product between estimated and measured direction of gravity
     halfex = (ay * halfvz - az * halfvy);
@@ -235,29 +235,29 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
   gx *= (0.5f * dt);   // pre-multiply common factors
   gy *= (0.5f * dt);
   gz *= (0.5f * dt);
-  qa = q0;
-  qb = q1;
-  qc = q2;
-  q0 += (-qb * gx - qc * gy - q3 * gz);
-  q1 += (qa * gx + qc * gz - q3 * gy);
-  q2 += (qa * gy - qb * gz + q3 * gx);
-  q3 += (qa * gz + qb * gy - qc * gx);
+  qa = qw;
+  qb = qx;
+  qc = qy;
+  qw += (-qb * gx - qc * gy - qz * gz);
+  qx += (qa * gx + qc * gz - qz * gy);
+  qy += (qa * gy - qb * gz + qz * gx);
+  qz += (qa * gz + qb * gy - qc * gx);
 
   // Normalise quaternion
-  recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-  q0 *= recipNorm;
-  q1 *= recipNorm;
-  q2 *= recipNorm;
-  q3 *= recipNorm;
+  recipNorm = invSqrt(qw * qw + qx * qx + qy * qy + qz * qz);
+  qw *= recipNorm;
+  qx *= recipNorm;
+  qy *= recipNorm;
+  qz *= recipNorm;
 }
 #endif
 
-void sensfusion6GetQuaternion(float* qx, float* qy, float* qz, float* qw)
+void sensfusion6GetQuaternion(float* q_x, float* q_y, float* q_z, float* q_w)
 {
-  *qx = q1;
-  *qy = q2;
-  *qz = q3;
-  *qw = q0;
+  *q_x = qx;
+  *q_y = qy;
+  *q_z = qz;
+  *q_w = qw;
 }
 
 void sensfusion6GetEulerRPY(float* roll, float* pitch, float* yaw)
@@ -269,7 +269,7 @@ void sensfusion6GetEulerRPY(float* roll, float* pitch, float* yaw)
   if (gx>1) gx=1;
   if (gx<-1) gx=-1;
 
-  *yaw = atan2f(2*(q0*q3 + q1*q2), q0*q0 + q1*q1 - q2*q2 - q3*q3) * 180 / M_PI_F;
+  *yaw = atan2f(2*(qw*qz + qx*qy), qw*qw + qx*qx - qy*qy - qz*qz) * 180 / M_PI_F;
   *pitch = asinf(gx) * 180 / M_PI_F; //Pitch seems to be inverted
   *roll = atan2f(gy, gz) * 180 / M_PI_F;
 }
@@ -309,16 +309,16 @@ static float sensfusion6GetAccZ(const float ax, const float ay, const float az)
 
 static void estimatedGravityDirection(float* gx, float* gy, float* gz)
 {
-  *gx = 2 * (q1 * q3 - q0 * q2);
-  *gy = 2 * (q0 * q1 + q2 * q3);
-  *gz = q0 * q0 - q1 * q1 - q2 * q2 + q3 * q3;
+  *gx = 2 * (qx * qz - qw * qy);
+  *gy = 2 * (qw * qx + qy * qz);
+  *gz = qw * qw - qx * qx - qy * qy + qz * qz;
 }
 
 LOG_GROUP_START(sensfusion6)
-  LOG_ADD(LOG_FLOAT, qw, &q0)
-  LOG_ADD(LOG_FLOAT, qx, &q1)
-  LOG_ADD(LOG_FLOAT, qy, &q2)
-  LOG_ADD(LOG_FLOAT, qz, &q3)
+  LOG_ADD(LOG_FLOAT, qw, &qw)
+  LOG_ADD(LOG_FLOAT, qx, &qx)
+  LOG_ADD(LOG_FLOAT, qy, &qy)
+  LOG_ADD(LOG_FLOAT, qz, &qz)
   LOG_ADD(LOG_FLOAT, gravityX, &gravX)
   LOG_ADD(LOG_FLOAT, gravityY, &gravY)
   LOG_ADD(LOG_FLOAT, gravityZ, &gravZ)


### PR DESCRIPTION
Fixes #654.

Notes:
* This is just search & replace.
* Later on, we can look into using math3d and its quaternion definition & helper functions, although perhaps that is too much effort for 'legacy' code.