### PR TITLE
fix: sys.canfly variable should start from 'true' until we detect that the USB cable is connected

### DIFF
--- a/src/hal/src/pm_stm32f4.c
+++ b/src/hal/src/pm_stm32f4.c
@@ -315,6 +315,8 @@ void pmTask(void *param)
   pmSetChargeState(charge500mA);
   systemWaitStart();
 
+  systemSetCanFly(true);
+
   while(1)
   {
     vTaskDelay(100);


### PR DESCRIPTION
The Crazyflie has a neat log variable named `sys.canfly` that can be used to determine whether the USB cable is connected. Unfortunately, it starts from `false` and it does not get updated until the state of the power management subsystem changes at least once. The PM state starts from "battery", so in order to make `sys.canfly` consistent with the detected PM state, it should start from `true` and not `false` (as it is now).

This PR tries to be polite and not set `sys.canfly` to `true` until the system is started. Once it is started, it sets `sys.canfly` to `true` and enters the PM loop immediately; if the USB charger happens to be connected at boot, the first iteration will update `sys.canfly` to `false` so this is not a problem.