### PR TITLE
forward declaration to avoid ARM-specific __fp16 in transitive dependency of stabilizer_types.h

### DIFF
--- a/src/utils/interface/lighthouse/lighthouse_calibration.h
+++ b/src/utils/interface/lighthouse/lighthouse_calibration.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "ootx_decoder.h"
+#include <stdbool.h>
+
+// Forward declaration from ootx_decoder.h. Avoid exposing __fp16 type, which
+// doesn't exist on x86, so this header can be compiled for Python bindings.
+struct ootxDataFrame_s;
 
 typedef struct {
   float phase;

--- a/src/utils/src/lighthouse/lighthouse_calibration.c
+++ b/src/utils/src/lighthouse/lighthouse_calibration.c
@@ -31,6 +31,7 @@
  */
 
 #include "lighthouse_calibration.h"
+#include "ootx_decoder.h"
 
 #include <math.h>
 #include "cf_math.h"


### PR DESCRIPTION
`stabilizer_types.h` now depends on `lighthouse_calibration.h`, which depends on `ootx_decoder.h`, which defines a struct containing the `__fp16` type. This type does not exist on x86, so it breaks the Crazyswarm Python bindings for `stabilizer_types.h`.

Since `lighthouse_calibration.h` only declares functions that accept a pointer to the struct containing `__fp16`, we can use a forward declaration instead.

(In contrast, making `stabilizer_types.h` not depend on `lighthouse_calibration.h` at all would require forward-declaring some nontrivial function pointer typedef.)