### PR TITLE
Enable uart-syslink asserts in release builds.

### DIFF
--- a/src/drivers/src/uart_syslink.c
+++ b/src/drivers/src/uart_syslink.c
@@ -367,7 +367,7 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
     else
     {
       rxState = waitForFirstStart; //Checksum error
-      IF_DEBUG_ASSERT(0);
+      ASSERT(0);
     }
     break;
   case waitForChksum2:
@@ -380,13 +380,13 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
       }
       else
       {
-        IF_DEBUG_ASSERT(0); // Queue overflow
+        ASSERT(0); // Queue overflow
       }
     }
     else
     {
       rxState = waitForFirstStart; //Checksum error
-      IF_DEBUG_ASSERT(0);
+      ASSERT(0);
     }
     rxState = waitForFirstStart;
     break;


### PR DESCRIPTION
We need to be notified if this is a problem during real operation. If
we ever see cases where this is hit, proper flow control between NRF51
and STM32 are needed.

Part of fixes for issue #681.