### PR TITLE
Change crtpSendPacket->crtpSendPacketBlock for request/respond CRTP msg

### DIFF
--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -393,7 +393,7 @@ void crtpCommanderHighLevelTask(void * prm)
     //answer
     p.data[3] = ret;
     p.size = 4;
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
   }
 }
 

--- a/src/modules/src/crtp_localization_service.c
+++ b/src/modules/src/crtp_localization_service.c
@@ -215,6 +215,7 @@ static void lpsShortLppPacketHandler(CRTPPacket* pk) {
     pk->size = 3;
     pk->data[0] = LPS_SHORT_LPP_PACKET;
     pk->data[2] = success?1:0;
+    // This is best effort, i.e. the blocking version is not needed
     crtpSendPacket(pk);
   }
 }
@@ -251,7 +252,7 @@ static void lhPersistDataWorker(void* arg) {
     .data = {LH_PERSIST_DATA, result}
   };
 
-  crtpSendPacket(&response);
+  crtpSendPacketBlock(&response);
 }
 
 static void lhPersistDataHandler(CRTPPacket* pk) {
@@ -328,6 +329,7 @@ void locSrvSendRangeFloat(uint8_t id, float range)
       pkRange.port = CRTP_PORT_LOCALIZATION;
       pkRange.channel = GENERIC_TYPE;
       pkRange.size = sizeof(rangePacket);
+      // This is best effort, i.e. the blocking version is not needed
       crtpSendPacket(&pkRange);
       rangeIndex = 0;
     }
@@ -356,6 +358,7 @@ void locSrvSendLighthouseAngle(int basestation, pulseProcessorResult_t* angles)
     LhAngle.port = CRTP_PORT_LOCALIZATION;
     LhAngle.channel = GENERIC_TYPE;
     LhAngle.size = sizeof(anglePacket);
+    // This is best effort, i.e. the blocking version is not needed
     crtpSendPacket(&LhAngle);
   }
 }

--- a/src/modules/src/info.c
+++ b/src/modules/src/info.c
@@ -94,7 +94,7 @@ void infoTask(void *param)
             strcpy((char*)&p.data[3], "CrazyFlie");
 
             p.size = 3+strlen("CrazyFlie");
-            crtpSendPacket(&p);
+            crtpSendPacketBlock(&p);
           } else if (p.data[0] == infoVersion) {
             i=1;
 
@@ -115,12 +115,12 @@ void infoTask(void *param)
             if (i<31) p.data[i++] = V_MODIFIED?'M':'C';
 
             p.size = (i<31)?i:31;
-            crtpSendPacket(&p);
+            crtpSendPacketBlock(&p);
           } else if (p.data[0] == infoCpuId) {
             memcpy((char*)&p.data[1], (char*)CpuId, 12);
 
             p.size = 13;
-            crtpSendPacket(&p);
+            crtpSendPacketBlock(&p);
           }
 
           break;
@@ -132,21 +132,21 @@ void infoTask(void *param)
             memcpy(&p.data[1], (char*)&value, 4);
 
             p.size = 5;
-            crtpSendPacket(&p);
+            crtpSendPacketBlock(&p);
           } else if (p.data[0] == batteryMax) {
             float value = pmGetBatteryVoltageMax();
 
             memcpy(&p.data[1], (char*)&value, 4);
 
             p.size = 5;
-            crtpSendPacket(&p);
+            crtpSendPacketBlock(&p);
           } else if (p.data[0] == batteryMin) {
             float value = pmGetBatteryVoltageMin();
 
             memcpy(&p.data[1], (char*)&value, 4);
 
             p.size = 5;
-            crtpSendPacket(&p);
+            crtpSendPacketBlock(&p);
           }
           break;
         default:
@@ -168,7 +168,7 @@ void infoTask(void *param)
         memcpy(&p.data[1], (char*)&value, 4);
 
         p.size = 5;
-        crtpSendPacket(&p);
+        crtpSendPacketBlock(&p);
       }
     }
 

--- a/src/modules/src/log.c
+++ b/src/modules/src/log.c
@@ -276,7 +276,7 @@ void logTOCProcess(int command)
     memcpy(&p.data[2], &logsCrc, 4);
     p.data[6]=LOG_MAX_BLOCKS;
     p.data[7]=LOG_MAX_OPS;
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
     break;
   case CMD_GET_ITEM:  //Get log variable
     LOG_DEBUG("Packet is TOC_GET_ITEM Id: %d\n", p.data[1]);
@@ -308,13 +308,13 @@ void logTOCProcess(int command)
       ASSERT(p.size <= CRTP_MAX_DATA_SIZE); // Too long! The name of the group or the parameter may be too long.
       memcpy(p.data+3, group, strlen(group)+1);
       memcpy(p.data+3+strlen(group)+1, logs[ptr].name, strlen(logs[ptr].name)+1);
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     } else {
       LOG_DEBUG("    Index out of range!");
       p.header=CRTP_HEADER(CRTP_PORT_LOG, TOC_CH);
       p.data[0]=CMD_GET_ITEM;
       p.size=1;
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     }
     break;
   case CMD_GET_INFO_V2: //Get info packet about the log implementation
@@ -328,7 +328,7 @@ void logTOCProcess(int command)
     memcpy(&p.data[3], &logsCrc, 4);
     p.data[7]=LOG_MAX_BLOCKS;
     p.data[8]=LOG_MAX_OPS;
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
     break;
   case CMD_GET_ITEM_V2:  //Get log variable
     memcpy(&logId, &p.data[1], 2);
@@ -361,13 +361,13 @@ void logTOCProcess(int command)
       ASSERT(p.size <= CRTP_MAX_DATA_SIZE); // Too long! The name of the group or the parameter may be too long.
       memcpy(p.data+4, group, strlen(group)+1);
       memcpy(p.data+4+strlen(group)+1, logs[ptr].name, strlen(logs[ptr].name)+1);
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     } else {
       LOG_DEBUG("    Index out of range!");
       p.header=CRTP_HEADER(CRTP_PORT_LOG, TOC_CH);
       p.data[0]=CMD_GET_ITEM_V2;
       p.size=1;
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     }
     break;
   }
@@ -417,7 +417,7 @@ void logControlProcess()
   //Commands answer
   p.data[2] = ret;
   p.size = 3;
-  crtpSendPacket(&p);
+  crtpSendPacketBlock(&p);
 }
 
 static int logCreateBlock(unsigned char id, struct ops_setting * settings, int len)
@@ -865,6 +865,7 @@ void logRunBlock(void * arg)
   }
   else
   {
+    // No need to block here, since logging is not guaranteed
     crtpSendPacket(&pk);
   }
 }

--- a/src/modules/src/mem.c
+++ b/src/modules/src/mem.c
@@ -180,14 +180,14 @@ static void memSettingsProcess(CRTPPacket* p) {
   switch (p->data[0]) {
     case MEM_CMD_GET_NBR:
       createNbrResponse(p);
-      crtpSendPacket(p);
+      crtpSendPacketBlock(p);
       break;
 
     case MEM_CMD_GET_INFO:
       {
         uint8_t memId = p->data[1];
         createInfoResponse(p, memId);
-        crtpSendPacket(p);
+        crtpSendPacketBlock(p);
       }
       break;
 
@@ -263,7 +263,7 @@ static void memReadProcess(CRTPPacket* p) {
     p->size = 6;
   }
 
-  crtpSendPacket(p);
+  crtpSendPacketBlock(p);
 }
 
 static void memWriteProcess(CRTPPacket* p) {
@@ -292,7 +292,7 @@ static void memWriteProcess(CRTPPacket* p) {
   p->data[5] = result ? STATUS_OK : EIO;
   p->size = 6;
 
-  crtpSendPacket(p);
+  crtpSendPacketBlock(p);
 }
 
 /**

--- a/src/modules/src/param.c
+++ b/src/modules/src/param.c
@@ -202,7 +202,7 @@ void paramTask(void * prm)
 
         p.data[1+strlen(group)+1+strlen(name)+1] = error;
         p.size = 1+strlen(group)+1+strlen(name)+1+1;
-        crtpSendPacket(&p);
+        crtpSendPacketBlock(&p);
       }
     }
 	}
@@ -230,7 +230,7 @@ void paramTOCProcess(int command)
       p.data[1]=255;
     }
     memcpy(&p.data[2], &paramsCrc, 4);
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
     break;
   case CMD_GET_ITEM:  //Get param variable
     for (ptr=0; ptr<paramsLen; ptr++) //Ptr points a group
@@ -260,12 +260,12 @@ void paramTOCProcess(int command)
       ASSERT(p.size <= CRTP_MAX_DATA_SIZE); // Too long! The name of the group or the parameter may be too long.
       memcpy(p.data+3, group, strlen(group)+1);
       memcpy(p.data+3+strlen(group)+1, params[ptr].name, strlen(params[ptr].name)+1);
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     } else {
       p.header=CRTP_HEADER(CRTP_PORT_PARAM, TOC_CH);
       p.data[0]=CMD_GET_ITEM;
       p.size=1;
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     }
     break;
   case CMD_GET_INFO_V2: //Get info packet about the param implementation
@@ -276,7 +276,7 @@ void paramTOCProcess(int command)
     p.data[0]=CMD_GET_INFO_V2;
     memcpy(&p.data[1], &paramsCount, 2);
     memcpy(&p.data[3], &paramsCrc, 4);
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
     useV2 = true;
     break;
   case CMD_GET_ITEM_V2:  //Get param variable
@@ -308,12 +308,12 @@ void paramTOCProcess(int command)
       ASSERT(p.size <= CRTP_MAX_DATA_SIZE); // Too long! The name of the group or the parameter may be too long.
       memcpy(p.data+4, group, strlen(group)+1);
       memcpy(p.data+4+strlen(group)+1, params[ptr].name, strlen(params[ptr].name)+1);
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     } else {
       p.header=CRTP_HEADER(CRTP_PORT_PARAM, TOC_CH);
       p.data[0]=CMD_GET_ITEM_V2;
       p.size=1;
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
     }
     break;
   }
@@ -334,7 +334,7 @@ static void paramWriteProcess()
       p.data[2] = ENOENT;
       p.size = 3;
 
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
       return;
     }
 
@@ -357,7 +357,7 @@ static void paramWriteProcess()
         break;
     }
 
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
   } else {
     int ident = p.data[0];
     void* valptr = &p.data[1];
@@ -371,7 +371,7 @@ static void paramWriteProcess()
       p.data[2] = ENOENT;
       p.size = 3;
 
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
       return;
     }
 
@@ -394,7 +394,7 @@ static void paramWriteProcess()
         break;
     }
 
-    crtpSendPacket(&p);
+    crtpSendPacketBlock(&p);
   }
 }
 
@@ -460,7 +460,7 @@ static void paramReadProcess()
       p.data[2] = ENOENT;
       p.size = 3;
 
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
       return;
     }
 
@@ -495,7 +495,7 @@ static void paramReadProcess()
       p.data[2] = ENOENT;
       p.size = 3;
 
-      crtpSendPacket(&p);
+      crtpSendPacketBlock(&p);
       return;
     }
 
@@ -521,7 +521,7 @@ static void paramReadProcess()
     }
   }
 
-  crtpSendPacket(&p);
+  crtpSendPacketBlock(&p);
 }
 
 static int variableGetIndex(int id)
@@ -729,7 +729,7 @@ void paramSetInt(paramVarId_t varid, int valuei)
   }
 
 #ifndef SILENT_PARAM_UPDATES
-  crtpSendPacket(&pk);
+  crtpSendPacketBlock(&pk);
 #endif
 }
 
@@ -752,6 +752,6 @@ void paramSetFloat(paramVarId_t varid, float valuef)
   }
 
 #ifndef SILENT_PARAM_UPDATES
-  crtpSendPacket(&pk);
+  crtpSendPacketBlock(&pk);
 #endif
 }


### PR DESCRIPTION
For many CRTP calls, the client expects a response eventually. Using
crtpSendPacket has the risk that a response might not be send if the
queue is full. In these cases, it is better to temporarily block the
task and wait for the queue to become empty.

Part of fixes for issue #681.