### PR TITLE
FatFS: Fix Clang build (typedef redefinition with different types)

### DIFF
--- a/src/lib/FatFS/ff.h
+++ b/src/lib/FatFS/ff.h
@@ -33,29 +33,7 @@ extern "C" {
 #endif
 
 
-/* Integer types used for FatFs API */
-
-#if defined(_WIN32) /* Main development platform */
-#define FF_INTDEF 2
-#include <windows.h>
-typedef unsigned __int64 QWORD;
-#elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(__cplusplus)  /* C99 or later */
-#define FF_INTDEF 2
-#include <stdint.h>
-typedef unsigned int  UINT; /* int must be 16-bit or 32-bit */
-typedef unsigned char BYTE; /* char must be 8-bit */
-typedef uint16_t    WORD; /* 16-bit unsigned integer */
-typedef uint32_t    DWORD;  /* 32-bit unsigned integer */
-typedef uint64_t    QWORD;  /* 64-bit unsigned integer */
-typedef WORD      WCHAR;  /* UTF-16 character type */
-#else   /* Earlier than C99 */
-#define FF_INTDEF 1
-typedef unsigned int  UINT; /* int must be 16-bit or 32-bit */
-typedef unsigned char BYTE; /* char must be 8-bit */
-typedef unsigned short  WORD; /* 16-bit unsigned integer */
-typedef unsigned long DWORD;  /* 32-bit unsigned integer */
-typedef WORD      WCHAR;  /* UTF-16 character type */
-#endif
+#include "integer.h"
 
 
 /* Definitions of volume management */
@@ -108,7 +86,7 @@ typedef char TCHAR;
 /* Type of file size and LBA variables */
 
 #if FF_FS_EXFAT
-#if FF_INTDEF != 2
+#ifdef FF_QWORD_UNSUPPORTED
 #error exFAT feature wants C99 or later
 #endif
 typedef QWORD FSIZE_t;

--- a/src/lib/FatFS/integer.h
+++ b/src/lib/FatFS/integer.h
@@ -1,38 +1,44 @@
-/*-------------------------------------------*/
-/* Integer type definitions for FatFs module */
-/*-------------------------------------------*/
+/*-------------------------------------------*
+ * Integer type definitions for FatFs module *
+ *-------------------------------------------*/
 
 #ifndef _FF_INTEGER
 #define _FF_INTEGER
 
-#ifdef _WIN32	/* FatFs development platform */
+/* Integer types used for FatFs API */
+
+#ifdef _WIN32
 
 #include <windows.h>
-#include <tchar.h>
 typedef unsigned __int64 QWORD;
 
+#else
 
-#else			/* Embedded platform */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(__cplusplus)
 
-/* These types MUST be 16-bit or 32-bit */
-typedef int				INT;
-typedef unsigned int	UINT;
+#include <stdint.h>
+typedef uint8_t   BYTE; /* MUST be 8-bit */
+typedef uint16_t  WORD; /* MUST be 16-bit */
+typedef uint32_t DWORD; /* MUST be 32-bit */
+typedef uint64_t QWORD; /* MUST be 64-bit */
 
-/* This type MUST be 8-bit */
-typedef unsigned char	BYTE;
+#else
 
-/* These types MUST be 16-bit */
-typedef short			SHORT;
-typedef unsigned short	WORD;
-typedef unsigned short	WCHAR;
-
-/* These types MUST be 32-bit */
-typedef long			LONG;
-typedef unsigned long	DWORD;
-
-/* This type MUST be 64-bit (Remove this for C89 compatibility) */
-typedef unsigned long long QWORD;
+typedef unsigned char       BYTE; /* MUST be 8-bit */
+typedef unsigned short      WORD; /* MUST be 16-bit */
+typedef unsigned long      DWORD; /* MUST be 32-bit */
+/* No QWORD because 'unsigned long long' not part of ANSI C89 / ISO C90 */
+#define FF_QWORD_UNSUPPORTED
 
 #endif
 
+typedef WORD WCHAR; /* UTF-16 character type */
+
+typedef          short SHORT;
+typedef          int     INT;
+typedef unsigned int    UINT;
+typedef          long   LONG;
+
 #endif
+
+#endif /* _FF_INTEGER */


### PR DESCRIPTION
Hi.
I’m trying to build the firmware using Clang.
I faced one trivial issue:
```
In file included from ./src/deck/drivers/src/usddeck.c:48:
In file included from ./src/drivers/interface/fatfs_sd.h:10:
In file included from ./src/drivers/interface/diskio.h:9:
./src/lib/FatFS/integer.h:31:23: error: typedef redefinition with different types ('unsigned long' vs 'uint32_t' (aka 'unsigned int'))
typedef unsigned long   DWORD;
                        ^
./src/lib/FatFS/ff.h:48:21: note: previous definition is here
typedef uint32_t    DWORD;  /* 32-bit unsigned integer */
                    ^
```
The issue is that both `ff.h` and `integer.h` define the same types.
This patch fixes it.