### PR TITLE
Makefile: Error out on missing submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,8 +370,23 @@ ifeq ($(SHELL),/bin/sh)
   COL_RESET=\033[m
 endif
 
-#################### Targets ###############################
+# This define n-thing is a standard hack to get newlines in GNU Make.
+define n
 
+
+endef
+
+# Make sure that the submodules are up to date.
+# Check if there are any files in the vendor directories, if not warn the user.
+ifeq ($(wildcard $(CRAZYFLIE_BASE)/vendor/*/*),)
+  $(error $n                                                                   \
+    The submodules does not seem to be present, consider fetching them by:$n   \
+      $$ git submodule init$n                                                  \
+      $$ git submodule update$n                                                \
+  )
+endif
+
+#################### Targets ###############################
 
 all: bin/ bin/dep bin/vendor check_submodules build
 build:


### PR DESCRIPTION
 If you, like me, fail to read the README.md properly you will get a bit of a cryptic error when trying to build.

```
   $ make
   CLEAN_VERSION
   make[1]: *** No rule to make target 'list.o', needed by 'cf2.elf'.  Stop.
   make: *** [Makefile:380: build] Error 2
```

 This does not make it super clear that it is the missing submodules that is at fault.
 This PR adds a check for the vendor submodules and will produce an error if missing, like so:

```
   $ make
   Makefile:383: ***
    The submodules does not seem to be present, consider fetching them by:
    $ git submodule init
    $ git submodule update
    .  Stop.
```