### PR TITLE
Clean .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/libdw1000"]
 	path = vendor/libdw1000
-	url = https://github.com/bitcraze/libdw1000
+	url = https://github.com/bitcraze/libdw1000.git
 [submodule "vendor/unity"]
 	path = vendor/unity
 	url = https://github.com/throwtheswitch/unity.git
@@ -9,8 +9,7 @@
 	url = https://github.com/throwtheswitch/cmock.git
 [submodule "vendor/CMSIS"]
 	path = vendor/CMSIS
-	url = https://github.com/ARM-software/CMSIS
+	url = https://github.com/ARM-software/CMSIS.git
 [submodule "vendor/FreeRTOS"]
 	path = vendor/FreeRTOS
-	url = https://github.com/FreeRTOS/FreeRTOS-Kernel
-	branch = V10.2.1-convergence-FreeRTOS-Source
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git


### PR DESCRIPTION
If I’m not wrong, branch `V10.2.1-convergence-FreeRTOS-Source` does not exist: https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/V10.2.1-convergence-FreeRTOS-Source.
Also, the urls should end with `.git`.