### PR TITLE
eprintf: Argument fmt should be constant

### DIFF
--- a/src/utils/interface/eprintf.h
+++ b/src/utils/interface/eprintf.h
@@ -29,7 +29,7 @@ typedef int (*putc_t)(int c);
  * @param[in] ... Parameters to print
  * @return the number of character printed
  */
-int eprintf(putc_t putcf, char * fmt, ...) 
+int eprintf(putc_t putcf, const char * fmt, ...)
     __attribute__ (( format(printf, 2, 3) ));
 
 /**
@@ -39,6 +39,6 @@ int eprintf(putc_t putcf, char * fmt, ...)
  * @param[in] ap Parameters to print
  * @return the number of character printed
  */
-int evprintf(putc_t putcf, char * fmt, va_list ap);
+int evprintf(putc_t putcf, const char * fmt, va_list ap);
 
 #endif //__EPRINTF_H__

--- a/src/utils/src/eprintf.c
+++ b/src/utils/src/eprintf.c
@@ -151,7 +151,7 @@ static int itoa16(putc_t putcf, uint64_t num, int width, char padChar)
   return len;
 }
 
-static int handleLongLong(putc_t putcf, char** fmt, unsigned long long int val, int width, char padChar)
+static int handleLongLong(putc_t putcf, const char** fmt, unsigned long long int val, int width, char padChar)
 {
   int len = 0;
 
@@ -176,7 +176,7 @@ static int handleLongLong(putc_t putcf, char** fmt, unsigned long long int val, 
   return len;
 }
 
-static int handleLong(putc_t putcf, char** fmt, unsigned long int val, int width, char padChar)
+static int handleLong(putc_t putcf, const char** fmt, unsigned long int val, int width, char padChar)
 {
   int len = 0;
 
@@ -201,7 +201,7 @@ static int handleLong(putc_t putcf, char** fmt, unsigned long int val, int width
   return len;
 }
 
-int evprintf(putc_t putcf, char * fmt, va_list ap)
+int evprintf(putc_t putcf, const char * fmt, va_list ap)
 {
   int len=0;
   float num;
@@ -305,7 +305,7 @@ int evprintf(putc_t putcf, char * fmt, va_list ap)
   return len;
 }
 
-int eprintf(putc_t putcf, char * fmt, ...)
+int eprintf(putc_t putcf, const char * fmt, ...)
 {
   va_list ap;
   int len;


### PR DESCRIPTION
This is required, otherwise, you would get, in C++ code, lot of:
```
warning: ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]
  DEBUG_PRINT("Waiting for activation ...\n");
              ^
```

More information [here](https://stackoverflow.com/a/20944858).

`printf`’s fmt argument is [constant too](https://linux.die.net/man/3/printf).

Thank you.