### PR TITLE
Clean-up of sleepus and usecTimer.

### DIFF
--- a/src/deck/drivers/src/flowdeck_v1v2.c
+++ b/src/deck/drivers/src/flowdeck_v1v2.c
@@ -85,8 +85,6 @@ static void flowdeckTask(void *param)
 {
   systemWaitStart();
 
-  initUsecTimer();
-
   uint64_t lastTime  = usecTimestamp();
   while(1) {
     vTaskDelay(10);

--- a/src/hal/interface/usec_time.h
+++ b/src/hal/interface/usec_time.h
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2011-2013 Bitcraze AB
+ * Copyright (C) 2011-2021 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,8 +23,7 @@
  *
  * usec_time.h - Microsecond-resolution timer.
  */
-#ifndef USEC_TIME_H_
-#define USEC_TIME_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -37,5 +36,3 @@ void initUsecTimer(void);
  * Get microsecond-resolution timestamp.
  */
 uint64_t usecTimestamp(void);
-
-#endif /* USEC_TIME_H_ */

--- a/src/utils/interface/sleepus.h
+++ b/src/utils/interface/sleepus.h
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2012 BitCraze AB
+ * Copyright (C) 2012-2021 BitCraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,9 +23,7 @@
  *
  * sleepus.h: Micro second sleep
  */
-#ifndef __SLEEPNS_H__
-#define __SLEEPNS_H__
+#pragma once
+#include <stdint.h>
 
-void sleepus(uint32_t ns);
-
-#endif // __SLEEPNS_H__
+void sleepus(uint32_t us);

--- a/src/utils/src/sleepus.c
+++ b/src/utils/src/sleepus.c
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2012 BitCraze AB
+ * Copyright (C) 2012-2021 BitCraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,32 +23,12 @@
  *
  * sleepus.h: Micro second sleep
  */
-#include <stdint.h>
-#include <stdbool.h>
-
 #include "sleepus.h"
-
-#include "config.h"
-
-#include "stm32f4xx.h"
-
-#include "FreeRTOS.h"
-#include "task.h"
-
 #include "usec_time.h"
-
-#define TICK_PER_US (FREERTOS_MCU_CLOCK_HZ / (8 * 1e6))
-
-static bool isInit = false;
 
 void sleepus(uint32_t us)
 {
-  if (!isInit) {
-    initUsecTimer();
-    isInit = true;
-  }
-
   uint64_t start = usecTimestamp();
-
-  while ((start+us) > usecTimestamp());
+  while ((start+us) > usecTimestamp()) {
+  }
 }


### PR DESCRIPTION
This addresses the following:
* Ensure the usec timer is only initialized once. This is currently
  done in system.c
* Simplify the sleepus() function to avoid unnecessary usecTimer init
* Modernize/cleanup code