### PR TITLE
Remove information about last control command from state estimator

### DIFF
--- a/src/modules/interface/estimator.h
+++ b/src/modules/interface/estimator.h
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2011-2016 Bitcraze AB
+ * Copyright (C) 2011-2021 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,8 +23,7 @@
  *
  * estimator.h - State estimator interface
  */
-#ifndef __ESTIMATOR_H__
-#define __ESTIMATOR_H__
+#pragma once
 
 #include "stabilizer_types.h"
 
@@ -38,7 +37,7 @@ typedef enum {
 void stateEstimatorInit(StateEstimatorType estimator);
 bool stateEstimatorTest(void);
 void stateEstimatorSwitchTo(StateEstimatorType estimator);
-void stateEstimator(state_t *state, sensorData_t *sensors, control_t *control, const uint32_t tick);
+void stateEstimator(state_t *state, sensorData_t *sensors, const uint32_t tick);
 StateEstimatorType getStateEstimator(void);
 const char* stateEstimatorGetName();
 
@@ -52,5 +51,3 @@ bool estimatorEnqueueAbsoluteHeight(const heightMeasurement_t *height);
 bool estimatorEnqueueFlow(const flowMeasurement_t *flow);
 bool estimatorEnqueueYawError(const yawErrorMeasurement_t *error);
 bool estimatorEnqueueSweepAngles(const sweepAngleMeasurement_t *angles);
-
-#endif //__ESTIMATOR_H__

--- a/src/modules/interface/estimator_complementary.h
+++ b/src/modules/interface/estimator_complementary.h
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2011-2016 Bitcraze AB
+ * Copyright (C) 2011-2021 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,15 +23,12 @@
  *
  * estimator_complementary.h - Complementary estimator interfaced
  */
-#ifndef __ESTIMATOR_COMPLEMENTARY_H__
-#define __ESTIMATOR_COMPLEMENTARY_H__
+#pragma once
 
 #include "stabilizer_types.h"
 
 void estimatorComplementaryInit(void);
 bool estimatorComplementaryTest(void);
-void estimatorComplementary(state_t *state, sensorData_t *sensors, control_t *control, const uint32_t tick);
+void estimatorComplementary(state_t *state, sensorData_t *sensors, const uint32_t tick);
 
 bool estimatorComplementaryEnqueueTOF(const tofMeasurement_t *tof);
-
-#endif //__ESTIMATOR_COMPLEMENTARY_H__

--- a/src/modules/interface/estimator_kalman.h
+++ b/src/modules/interface/estimator_kalman.h
@@ -59,7 +59,7 @@
 
 void estimatorKalmanInit(void);
 bool estimatorKalmanTest(void);
-void estimatorKalman(state_t *state, sensorData_t *sensors, control_t *control, const uint32_t tick);
+void estimatorKalman(state_t *state, sensorData_t *sensors, const uint32_t tick);
 
 
 void estimatorKalmanTaskInit();

--- a/src/modules/interface/kalman_core/kalman_core.h
+++ b/src/modules/interface/kalman_core/kalman_core.h
@@ -108,7 +108,7 @@ void kalmanCoreUpdateWithBaro(kalmanCoreData_t* this, float baroAsl, bool quadIs
  *
  * The filter progresses as:
  *  - Predicting the current state forward */
-void kalmanCorePredict(kalmanCoreData_t* this, float thrust, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying);
+void kalmanCorePredict(kalmanCoreData_t* this, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying);
 
 void kalmanCoreAddProcessNoise(kalmanCoreData_t* this, float dt);
 

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -16,7 +16,7 @@ typedef struct {
   void (*init)(void);
   void (*deinit)(void);
   bool (*test)(void);
-  void (*update)(state_t *state, sensorData_t *sensors, control_t *control, const uint32_t tick);
+  void (*update)(state_t *state, sensorData_t *sensors, const uint32_t tick);
   const char* name;
   bool (*estimatorEnqueueTDOA)(const tdoaMeasurement_t *uwb);
   bool (*estimatorEnqueuePosition)(const positionMeasurement_t *pos);
@@ -131,8 +131,8 @@ bool stateEstimatorTest(void) {
   return estimatorFunctions[currentEstimator].test();
 }
 
-void stateEstimator(state_t *state, sensorData_t *sensors, control_t *control, const uint32_t tick) {
-  estimatorFunctions[currentEstimator].update(state, sensors, control, tick);
+void stateEstimator(state_t *state, sensorData_t *sensors, const uint32_t tick) {
+  estimatorFunctions[currentEstimator].update(state, sensors, tick);
 }
 
 const char* stateEstimatorGetName() {

--- a/src/modules/src/estimator_complementary.c
+++ b/src/modules/src/estimator_complementary.c
@@ -68,7 +68,7 @@ bool estimatorComplementaryTest(void)
   return pass;
 }
 
-void estimatorComplementary(state_t *state, sensorData_t *sensorData, control_t *control, const uint32_t tick)
+void estimatorComplementary(state_t *state, sensorData_t *sensorData, const uint32_t tick)
 {
   sensorsAcquire(sensorData, tick); // Read sensors at full rate (1000Hz)
   if (RATE_DO_EXECUTE(ATTITUDE_UPDATE_RATE, tick)) {

--- a/src/modules/src/estimator_kalman.c
+++ b/src/modules/src/estimator_kalman.c
@@ -188,22 +188,10 @@ static StaticSemaphore_t dataMutexBuffer;
 
 
 /**
- * Constants used in the estimator
- */
-
-//thrust is thrust mapped for 65536 <==> 60 GRAMS!
-#define CONTROL_TO_ACC (GRAVITY_MAGNITUDE*60.0f/(CF_MASS*1000.0f)/65536.0f)
-
-
-/**
  * Tuning parameters
  */
 #define PREDICT_RATE RATE_100_HZ // this is slower than the IMU update rate of 500Hz
 #define BARO_RATE RATE_25_HZ
-
-// the point at which the dynamics change from stationary to flying
-#define IN_FLIGHT_THRUST_THRESHOLD (GRAVITY_MAGNITUDE*0.1f)
-#define IN_FLIGHT_TIME_THRESHOLD (500)
 
 // The bounds on the covariance, these shouldn't be hit, but sometimes are... why?
 #define MAX_COVARIANCE (100)
@@ -231,11 +219,9 @@ NO_DMA_CCM_SAFE_ZERO_INIT static kalmanCoreData_t coreData;
 static bool isInit = false;
 
 static Axis3f accAccumulator;
-static float thrustAccumulator;
 static Axis3f gyroAccumulator;
 static float baroAslAccumulator;
 static uint32_t accAccumulatorCount;
-static uint32_t thrustAccumulatorCount;
 static uint32_t gyroAccumulatorCount;
 static uint32_t baroAccumulatorCount;
 static bool quadIsFlying = false;
@@ -422,7 +408,7 @@ static void kalmanTask(void* parameters) {
   }
 }
 
-void estimatorKalman(state_t *state, sensorData_t *sensors, control_t *control, const uint32_t tick)
+void estimatorKalman(state_t *state, sensorData_t *sensors, const uint32_t tick)
 {
   // This function is called from the stabilizer loop. It is important that this call returns
   // as quickly as possible. The dataMutex must only be locked short periods by the task.
@@ -445,10 +431,6 @@ void estimatorKalman(state_t *state, sensorData_t *sensors, control_t *control, 
     gyroAccumulatorCount++;
   }
 
-  // Average the thrust command from the last time steps, generated externally by the controller
-  thrustAccumulator += control->thrust;
-  thrustAccumulatorCount++;
-
   // Average barometer data
   if (useBaroUpdate) {
     if (sensorsReadBaro(&sensors->baro)) {
@@ -470,8 +452,7 @@ void estimatorKalman(state_t *state, sensorData_t *sensors, control_t *control, 
 
 static bool predictStateForward(uint32_t osTick, float dt) {
   if (gyroAccumulatorCount == 0
-      || accAccumulatorCount == 0
-      || thrustAccumulatorCount == 0)
+      || accAccumulatorCount == 0)
   {
     return false;
   }
@@ -490,20 +471,15 @@ static bool predictStateForward(uint32_t osTick, float dt) {
   accAverage.y = accAccumulator.y * GRAVITY_MAGNITUDE / accAccumulatorCount;
   accAverage.z = accAccumulator.z * GRAVITY_MAGNITUDE / accAccumulatorCount;
 
-  // thrust is in grams, we need ms^-2
-  float thrustAverage = thrustAccumulator * CONTROL_TO_ACC / thrustAccumulatorCount;
-
   accAccumulator = (Axis3f){.axis={0}};
   accAccumulatorCount = 0;
   gyroAccumulator = (Axis3f){.axis={0}};
   gyroAccumulatorCount = 0;
-  thrustAccumulator = 0;
-  thrustAccumulatorCount = 0;
 
   xSemaphoreGive(dataMutex);
 
   quadIsFlying = supervisorIsFlying();
-  kalmanCorePredict(&coreData, thrustAverage, &accAverage, &gyroAverage, dt, quadIsFlying);
+  kalmanCorePredict(&coreData, &accAverage, &gyroAverage, dt, quadIsFlying);
 
   return true;
 }
@@ -594,12 +570,10 @@ void estimatorKalmanInit(void) {
   xSemaphoreTake(dataMutex, portMAX_DELAY);
   accAccumulator = (Axis3f){.axis={0}};
   gyroAccumulator = (Axis3f){.axis={0}};
-  thrustAccumulator = 0;
   baroAslAccumulator = 0;
 
   accAccumulatorCount = 0;
   gyroAccumulatorCount = 0;
-  thrustAccumulatorCount = 0;
   baroAccumulatorCount = 0;
   xSemaphoreGive(dataMutex);
 

--- a/src/modules/src/kalman_core/kalman_core.c
+++ b/src/modules/src/kalman_core/kalman_core.c
@@ -291,7 +291,7 @@ void kalmanCoreUpdateWithBaro(kalmanCoreData_t* this, float baroAsl, bool quadIs
   kalmanCoreScalarUpdate(this, &H, meas - this->S[KC_STATE_Z], measNoiseBaro);
 }
 
-void kalmanCorePredict(kalmanCoreData_t* this, float cmdThrust, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying)
+void kalmanCorePredict(kalmanCoreData_t* this, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying)
 {
   /* Here we discretize (euler forward) and linearise the quadrocopter dynamics in order
    * to push the covariance forward.
@@ -442,10 +442,7 @@ void kalmanCorePredict(kalmanCoreData_t* this, float cmdThrust, Axis3f *acc, Axi
 
   if (quadIsFlying) // only acceleration in z direction
   {
-    // TODO: In the next lines, can either use cmdThrust/mass, or acc->z. Need to test which is more reliable.
-    // cmdThrust's error comes from poorly calibrated mass, and inexact cmdThrust -> thrust map
-    // acc->z's error comes from measurement noise and accelerometer scaling
-    // float zacc = cmdThrust;
+    // Use accelerometer and not commanded thrust, as this has proper physical units
     zacc = acc->z;
 
     // position updates in the body frame (will be rotated to inertial frame)

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -242,7 +242,7 @@ static void stabilizerTask(void* param)
         controllerType = getControllerType();
       }
 
-      stateEstimator(&state, &sensorData, &control, tick);
+      stateEstimator(&state, &sensorData, tick);
       compressState();
 
       commanderGetSetpoint(&setpoint, &state);


### PR DESCRIPTION
The state estimator should only get raw sensor measurements as input.
Previously, the last control command was needed to determine if the CF
is flying or not. Since #723 (introduction of the supervisor module),
this is handled in a better way.