### PR TITLE
Lighthouse crossing beam: improve result quality

### DIFF
--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -218,22 +218,25 @@ static float sweepStd = 0.0004;
 static float sweepStdLh2 = 0.001;
 
 static vec3d position;
+static vec3d positionLog;
 static float deltaLog;
 
 static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulseProcessorResult_t* angles, int baseStation) {
   memset(&ext_pos, 0, sizeof(ext_pos));
-  int sensorsUsed = 0;
+  uint8_t sensorsUsed = 0;
+  float deltaSum = 0;
   float delta;
 
   // Average over all sensors with valid data
   for (size_t sensor = 0; sensor < PULSE_PROCESSOR_N_SENSORS; sensor++) {
+      // LH2 angles are converted to LH1 angles, so it is OK to use sensorMeasurementsLh1
       pulseProcessorBaseStationMeasuremnt_t* bs0Measurement = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[0];
       pulseProcessorBaseStationMeasuremnt_t* bs1Measurement = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[1];
 
       if (bs0Measurement->validCount == PULSE_PROCESSOR_N_SWEEPS && bs1Measurement->validCount == PULSE_PROCESSOR_N_SWEEPS) {
         lighthouseGeometryGetPositionFromRayIntersection(state->bsGeometry, bs0Measurement->correctedAngles, bs1Measurement->correctedAngles, position, &delta);
 
-        deltaLog = delta;
+        deltaSum += delta;
 
         ext_pos.x += position[0];
         ext_pos.y += position[1];
@@ -241,17 +244,30 @@ static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulsePr
         sensorsUsed++;
 
         STATS_CNT_RATE_EVENT(&positionRate);
-      }
+    }
   }
 
-  ext_pos.x /= sensorsUsed;
-  ext_pos.y /= sensorsUsed;
-  ext_pos.z /= sensorsUsed;
+  // Only use measurement if we got all sensors, otherwise we would need to know the exact orientation
+  // of the Crazyflie in the world frame in order to correctly estimate the position
+  // We shouldn't use the kalman filter here, since crossing beam method should not make any assumptions about
+  // robot dynamics.
+  if (sensorsUsed == PULSE_PROCESSOR_N_SENSORS) {
+    deltaLog = deltaSum / sensorsUsed;
+    ext_pos.x /= sensorsUsed;
+    ext_pos.y /= sensorsUsed;
+    ext_pos.z /= sensorsUsed;
 
-  // Make sure we feed sane data into the estimator
-  if (isfinite(ext_pos.pos[0]) && isfinite(ext_pos.pos[1]) && isfinite(ext_pos.pos[2])) {
-    ext_pos.stdDev = 0.01;
-    estimatorEnqueuePosition(&ext_pos);
+    positionLog[0] = ext_pos.x;
+    positionLog[1] = ext_pos.y;
+    positionLog[2] = ext_pos.z;
+
+    // Make sure we feed sane data into the estimator
+    if (isfinite(ext_pos.pos[0]) && isfinite(ext_pos.pos[1]) && isfinite(ext_pos.pos[2])) {
+      ext_pos.stdDev = 0.01;
+      estimatorEnqueuePosition(&ext_pos);
+    }
+  } else {
+    deltaLog = 0;
   }
 }
 
@@ -416,6 +432,8 @@ void lighthousePositionEstimatePoseCrossingBeams(const pulseProcessor_t *state, 
   if (state->bsGeometry[0].valid && state->bsGeometry[1].valid) {
     estimatePositionCrossingBeams(state, angles, baseStation);
     estimateYaw(state, angles, baseStation);
+  } else {
+    deltaLog = 0;
   }
 }
 
@@ -432,9 +450,9 @@ STATS_CNT_RATE_LOG_ADD(posRt, &positionRate)
 STATS_CNT_RATE_LOG_ADD(estBs0Rt, &estBs0Rate)
 STATS_CNT_RATE_LOG_ADD(estBs1Rt, &estBs1Rate)
 
-LOG_ADD(LOG_FLOAT, x, &position[0])
-LOG_ADD(LOG_FLOAT, y, &position[1])
-LOG_ADD(LOG_FLOAT, z, &position[2])
+LOG_ADD(LOG_FLOAT, x, &positionLog[0])
+LOG_ADD(LOG_FLOAT, y, &positionLog[1])
+LOG_ADD(LOG_FLOAT, z, &positionLog[2])
 
 LOG_ADD(LOG_FLOAT, delta, &deltaLog)
 


### PR DESCRIPTION
The previous code reported the position of a single sensor in
lighthouse.{x,y,z}, rather than the position w.r.t. the center of mass
of the Crazyflie. This new code now averages over all sensors.

The lighthouse.delta variable gives an indication of the quality of the
result. This indication does not correlate with absolute accuracy (when
measured using a motion capture system as ground truth). However, it
provides a helpful indication on whether lighthouse.{x,y,z} is valid
(deltaLog>0) or not (deltaLog == 0).