### PR TITLE
Event trigger accuracy improvements.

### DIFF
--- a/docs/userguides/decks/micro-sd-card-deck.md
+++ b/docs/userguides/decks/micro-sd-card-deck.md
@@ -52,7 +52,7 @@ The `config.txt` file will be read only once on startup, therefore make sure tha
 
 ## Data Analysis
 
-For performance reasons the logfile is a binary file, using the following format:
+For performance reasons the logfile is a binary file, using the following format (version 2):
 
 ```
 uint8_t 0xBC header
@@ -65,7 +65,7 @@ for each event type:
    varname1(vartype1)<null>varname2(vartype2)<null>...<null>varnameN(vartypeN)<null>
 for each event:
    uint16_t event_id
-   uint32_t timestamp (FreeRTOS ticks in ms)
+   uint64_t timestamp (in microseconds)
    data (length defined by TOC event type)
 ```
 

--- a/src/deck/drivers/interface/usddeck.h
+++ b/src/deck/drivers/interface/usddeck.h
@@ -8,7 +8,7 @@ enum usddeckLoggingMode_e
 {
   usddeckLoggingMode_Disabled = 0,
   usddeckLoggingMode_SynchronousStabilizer,
-  usddeckLoggingMode_Asyncronous,
+  usddeckLoggingMode_Asynchronous,
 };
 
 // returns true if logging is enabled

--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -428,7 +428,11 @@ static void usdInit(DeckInfo *info)
 
 static void usddeckWriteEventData(const usdLogEventConfig_t* cfg, const uint8_t* payload, uint8_t payloadSize)
 {
-  uint32_t ticks = xTaskGetTickCount();
+  uint64_t ticks = usecTimestamp();
+
+  if (!enableLogging) {
+    return;
+  }
 
   ++usdLogStats.eventsRequested;
 
@@ -446,7 +450,7 @@ static void usddeckWriteEventData(const usdLogEventConfig_t* cfg, const uint8_t*
     /* write data into buffer */
     uint16_t event_id = cfg->eventId;
     ringBuffer_push(&logBuffer, &event_id, sizeof(event_id));
-    ringBuffer_push(&logBuffer, &ticks, 4);
+    ringBuffer_push(&logBuffer, &ticks, sizeof(ticks));
     if (payloadSize) {
       ringBuffer_push(&logBuffer, payload, payloadSize);
     }
@@ -646,7 +650,7 @@ static void usdLogTask(void* prm)
         vTaskResume(xHandleWriteTask);
       }
 
-      if (enableLogging && usdLogConfig.mode == usddeckLoggingMode_Asyncronous) {
+      if (enableLogging && usdLogConfig.mode == usddeckLoggingMode_Asynchronous) {
         usddeckTriggerLogging();
       }
       lastEnableLogging = enableLogging;
@@ -787,7 +791,7 @@ static void usdWriteTask(void* prm)
         uint8_t magic = 0xBC;
         usdWriteData(&magic, sizeof(magic));
         
-        uint16_t version = 1;
+        uint16_t version = 2;
         usdWriteData(&version, sizeof(version));
 
         uint16_t numEventTypes = usdLogConfig.numEventConfigs;
@@ -902,6 +906,21 @@ static void usdWriteTask(void* prm)
             xSemaphoreGive(logBufferMutex);
           }
         }
+        // write everything that's still in the buffer
+        xSemaphoreTake(logBufferMutex, portMAX_DELAY);
+        while (true) {
+          const uint8_t *buf;
+          uint16_t size;
+          bool hasData = ringBuffer_pop_start(&logBuffer, &buf, &size);
+          if (hasData) {
+            usdWriteData(buf, size);
+            ringBuffer_pop_done(&logBuffer);
+          } else {
+            break;
+          }
+        }
+        xSemaphoreGive(logBufferMutex);
+
         // write CRC
         uint32_t crcValue = crc32Out(&crcContext);
         usdWriteData(&crcValue, sizeof(crcValue));
@@ -978,6 +997,7 @@ PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, bcUSD, &isInit)
 PARAM_GROUP_STOP(deck)
 
 PARAM_GROUP_START(usd)
+PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, canLog, &initSuccess)
 PARAM_ADD(PARAM_UINT8, logging, &enableLogging) /* use to start/stop logging*/
 PARAM_GROUP_STOP(usd)
 

--- a/src/modules/interface/eventtrigger.h
+++ b/src/modules/interface/eventtrigger.h
@@ -84,26 +84,28 @@ static const eventtrigger myEventTrigger = {
 
 /* The same code above can be generated using the following macro:
 
-EVENTTRIGGER(myEvent, UINT8, var1, UINT32, var2)
+EVENTTRIGGER(myEvent, uint8, var1, uint32, var2)
 
 To debug/develop the macros, a good way is to create a new file "etdbg.c" with the following content
 and then execute "gcc -E etdbg.c":
 
 #include "src/modules/interface/eventtrigger.h"
-EVENTTRIGGER(myEvent, UINT8, var1, UINT32, var2)
+EVENTTRIGGER(myEvent, uint8, var1, uint32, var2)
 */
 
 #ifndef UNIT_TEST_MODE
 
 /* Macro magic, see https://codecraft.co/2014/11/25/variadic-macros-tricks/ */
-#define _GET_NTH_ARG(_1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
+#define _GET_NTH_ARG(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, N, ...) N
 #define _fe_0(_call, ...)
 #define _fe_2(_call, k, v, ...) _call(k, v) _fe_0(_call, __VA_ARGS__)
 #define _fe_4(_call, k, v, ...) _call(k, v) _fe_2(_call, __VA_ARGS__)
 #define _fe_6(_call, k, v, ...) _call(k, v) _fe_4(_call, __VA_ARGS__)
 #define _fe_8(_call, k, v, ...) _call(k, v) _fe_6(_call, __VA_ARGS__)
+#define _fe_10(_call, k, v, ...) _call(k, v) _fe_8(_call, __VA_ARGS__)
 #define CALL_MACRO_FOR_EACH_PAIR(x, ...)                \
     _GET_NTH_ARG("ignored", ##__VA_ARGS__,              \
+    _fe_10, _invalid_,                                   \
     _fe_8, _invalid_,                                   \
     _fe_6, _invalid_,                                   \
     _fe_4, _invalid_,                                   \
@@ -112,6 +114,7 @@ EVENTTRIGGER(myEvent, UINT8, var1, UINT32, var2)
     (x, ##__VA_ARGS__)
 #define CALL_MACRO_IF_EMPTY(TRUE_MACRO, FALSE_MACRO, NAME, ...) \
     _GET_NTH_ARG("ignored", ##__VA_ARGS__,                      \
+        TRUE_MACRO, _invalid_,                                  \
         TRUE_MACRO, _invalid_,                                  \
         TRUE_MACRO, _invalid_,                                  \
         TRUE_MACRO, _invalid_,                                  \

--- a/tools/usdlog/cfusdlog.py
+++ b/tools/usdlog/cfusdlog.py
@@ -31,8 +31,8 @@ def decode(filename):
 
     # check version
     version, num_event_types = struct.unpack('HH', data[1:5])
-    if version != 1:
-        print("Unsupported version!")
+    if version != 1 and version != 2:
+        print("Unsupported version!", version)
         return
 
     result = dict()
@@ -65,8 +65,13 @@ def decode(filename):
             }
 
     while idx < len(data) - 4:
-        event_id, timestamp, = struct.unpack('<HI', data[idx:idx+6])
-        idx += 6
+        if version == 1:
+            event_id, timestamp, = struct.unpack('<HI', data[idx:idx+6])
+            idx += 6
+        elif version == 2:
+            event_id, timestamp, = struct.unpack('<HQ', data[idx:idx+10])
+            timestamp = timestamp / 1000.0
+            idx += 10
         event = event_by_id[event_id]
         fmtStr = event['fmtStr']
         eventData = struct.unpack(fmtStr, data[idx:idx+event['numBytes']])


### PR DESCRIPTION
* introduces version 2 of the recorded binary file, which uses a
  microsecond timestamp, rather than a millisecond timestamp. Older
  version-1 files can still be decoded in the same way as before.
* introduces usd.canLog readonly parameter to check if uSD card is
  inserted and configuration file is valid.
* support for more payload variables for event triggers.
* reduction of data loss when starting/stopping logging.