### PR TITLE
Unify state estimator sensor data queues and move them to estimator.c

### DIFF
--- a/src/hal/interface/sensors_mpu9250_lps25h.h
+++ b/src/hal/interface/sensors_mpu9250_lps25h.h
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2018 Bitcraze AB
+ * Copyright (C) 2018-2021 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,8 +23,7 @@
  *
  */
 
-#ifndef __SENSORS_MPU9250_LPS25H_H__
-#define __SENSORS_MPU9250_LPS25H_H__
+#pragma once
 
 #include "sensors.h"
 
@@ -39,5 +38,3 @@ bool sensorsMpu9250Lps25hReadAcc(Axis3f *acc);
 bool sensorsMpu9250Lps25hReadMag(Axis3f *mag);
 bool sensorsMpu9250Lps25hReadBaro(baro_t *baro);
 void sensorsMpu9250Lps25hSetAccMode(accModes accMode);
-
-#endif // __SENSORS_MPU9250_LPS25H_H__

--- a/src/modules/interface/estimator.h
+++ b/src/modules/interface/estimator.h
@@ -34,20 +34,123 @@ typedef enum {
   StateEstimatorTypeCount,
 } StateEstimatorType;
 
+typedef enum {
+  MeasurementTypeTDOA,
+  MeasurementTypePosition,
+  MeasurementTypePose,
+  MeasurementTypeDistance,
+  MeasurementTypeTOF,
+  MeasurementTypeAbsoluteHeight,
+  MeasurementTypeFlow,
+  MeasurementTypeYawError,
+  MeasurementTypeSweepAngle,
+  MeasurementTypeGyroscope,
+  MeasurementTypeAcceleration,
+  MeasurementTypeBarometer,
+} MeasurementType;
+
+typedef struct
+{
+  MeasurementType type;
+  union
+  {
+    tdoaMeasurement_t tdoa;
+    positionMeasurement_t position;
+    poseMeasurement_t pose;
+    distanceMeasurement_t distance;
+    tofMeasurement_t tof;
+    heightMeasurement_t height;
+    flowMeasurement_t flow;
+    yawErrorMeasurement_t yawError;
+    sweepAngleMeasurement_t sweepAngle;
+    gyroscopeMeasurement_t gyroscope;
+    accelerationMeasurement_t acceleration;
+    barometerMeasurement_t barometer;
+  } data;
+} measurement_t;
+
 void stateEstimatorInit(StateEstimatorType estimator);
 bool stateEstimatorTest(void);
 void stateEstimatorSwitchTo(StateEstimatorType estimator);
-void stateEstimator(state_t *state, sensorData_t *sensors, const uint32_t tick);
+void stateEstimator(state_t *state, const uint32_t tick);
 StateEstimatorType getStateEstimator(void);
 const char* stateEstimatorGetName();
 
-// Support to incorporate additional sensors into the state estimate via the following functions:
-bool estimatorEnqueueTDOA(const tdoaMeasurement_t *uwb);
-bool estimatorEnqueuePosition(const positionMeasurement_t *pos);
-bool estimatorEnqueuePose(const poseMeasurement_t *pose);
-bool estimatorEnqueueDistance(const distanceMeasurement_t *dist);
-bool estimatorEnqueueTOF(const tofMeasurement_t *tof);
-bool estimatorEnqueueAbsoluteHeight(const heightMeasurement_t *height);
-bool estimatorEnqueueFlow(const flowMeasurement_t *flow);
-bool estimatorEnqueueYawError(const yawErrorMeasurement_t *error);
-bool estimatorEnqueueSweepAngles(const sweepAngleMeasurement_t *angles);
+// Support to incorporate additional sensors into the state estimate via the following functions
+void estimatorEnqueue(const measurement_t *measurement);
+
+// These helper functions simplify the caller code, but cause additional memory copies
+static inline void estimatorEnqueueTDOA(const tdoaMeasurement_t *tdoa)
+{
+  measurement_t m;
+  m.type = MeasurementTypeTDOA;
+  m.data.tdoa = *tdoa;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueuePosition(const positionMeasurement_t *position)
+{
+  measurement_t m;
+  m.type = MeasurementTypePosition;
+  m.data.position = *position;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueuePose(const poseMeasurement_t *pose)
+{
+  measurement_t m;
+  m.type = MeasurementTypePose;
+  m.data.pose = *pose;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueDistance(const distanceMeasurement_t *distance)
+{
+  measurement_t m;
+  m.type = MeasurementTypeDistance;
+  m.data.distance = *distance;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueTOF(const tofMeasurement_t *tof)
+{
+  measurement_t m;
+  m.type = MeasurementTypeTOF;
+  m.data.tof = *tof;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueAbsoluteHeight(const heightMeasurement_t *height)
+{
+  measurement_t m;
+  m.type = MeasurementTypeAbsoluteHeight;
+  m.data.height = *height;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueFlow(const flowMeasurement_t *flow)
+{
+  measurement_t m;
+  m.type = MeasurementTypeFlow;
+  m.data.flow = *flow;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueYawError(const yawErrorMeasurement_t *yawError)
+{
+  measurement_t m;
+  m.type = MeasurementTypeYawError;
+  m.data.yawError = *yawError;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueSweepAngles(const sweepAngleMeasurement_t *sweepAngle)
+{
+  measurement_t m;
+  m.type = MeasurementTypeSweepAngle;
+  m.data.sweepAngle = *sweepAngle;
+  estimatorEnqueue(&m);
+}
+
+// Helper function for state estimators
+bool estimatorDequeue(measurement_t *measurement);

--- a/src/modules/interface/estimator_complementary.h
+++ b/src/modules/interface/estimator_complementary.h
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * estimator_complementary.h - Complementary estimator interfaced
+ * estimator_complementary.h - Complementary estimator interface
  */
 #pragma once
 
@@ -29,6 +29,6 @@
 
 void estimatorComplementaryInit(void);
 bool estimatorComplementaryTest(void);
-void estimatorComplementary(state_t *state, sensorData_t *sensors, const uint32_t tick);
+void estimatorComplementary(state_t *state, const uint32_t tick);
 
 bool estimatorComplementaryEnqueueTOF(const tofMeasurement_t *tof);

--- a/src/modules/interface/estimator_kalman.h
+++ b/src/modules/interface/estimator_kalman.h
@@ -51,32 +51,17 @@
  * ============================================================================
  */
 
-#ifndef __ESTIMATOR_KALMAN_H__
-#define __ESTIMATOR_KALMAN_H__
+#pragma once
 
 #include <stdint.h>
 #include "stabilizer_types.h"
 
 void estimatorKalmanInit(void);
 bool estimatorKalmanTest(void);
-void estimatorKalman(state_t *state, sensorData_t *sensors, const uint32_t tick);
-
+void estimatorKalman(state_t *state, const uint32_t tick);
 
 void estimatorKalmanTaskInit();
 bool estimatorKalmanTaskTest();
-
-/**
- * The filter supports the incorporation of additional sensors into the state estimate via the following functions:
- */
-bool estimatorKalmanEnqueueTDOA(const tdoaMeasurement_t *uwb);
-bool estimatorKalmanEnqueuePosition(const positionMeasurement_t *pos);
-bool estimatorKalmanEnqueuePose(const poseMeasurement_t *pose);
-bool estimatorKalmanEnqueueDistance(const distanceMeasurement_t *dist);
-bool estimatorKalmanEnqueueTOF(const tofMeasurement_t *tof);
-bool estimatorKalmanEnqueueAbsoluteHeight(const heightMeasurement_t *height);
-bool estimatorKalmanEnqueueFlow(const flowMeasurement_t *flow);
-bool estimatorKalmanEnqueueYawError(const yawErrorMeasurement_t* error);
-bool estimatorKalmanEnqueueSweepAngles(const sweepAngleMeasurement_t *angles);
 
 void estimatorKalmanGetEstimatedPos(point_t* pos);
 
@@ -84,5 +69,3 @@ void estimatorKalmanGetEstimatedPos(point_t* pos);
  * Copies 9 floats representing the current state rotation matrix
  */
 void estimatorKalmanGetEstimatedRot(float * rotationMatrix);
-
-#endif // __ESTIMATOR_KALMAN_H__

--- a/src/modules/interface/position_estimator.h
+++ b/src/modules/interface/position_estimator.h
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2016 Bitcraze AB
+ * Copyright (C) 2016-2021 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,12 +23,9 @@
  *
  *
  */
-#ifndef POSITION_ESTIMATOR_H_
-#define POSITION_ESTIMATOR_H_
+#pragma once
 
 #include "stabilizer_types.h"
 
-void positionEstimate(state_t* estimate, const sensorData_t* sensorData, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick);
+void positionEstimate(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick);
 void positionUpdateVelocity(float accWZ, float dt);
-
-#endif /* POSITION_ESTIMATOR_H_ */

--- a/src/modules/interface/range.h
+++ b/src/modules/interface/range.h
@@ -59,6 +59,5 @@ float rangeGet(rangeDirection_t direction);
  * @param dstance Distance to the ground (m)
  * @param stdDev The standard deviation of the range sample
  * @param timeStamp The time when the range was sampled (in sys ticks)
- * @return true if the sample was successfuly enqueued
  */
-bool rangeEnqueueDownRangeInEstimator(float distance, float stdDev, uint32_t timeStamp);
+void rangeEnqueueDownRangeInEstimator(float distance, float stdDev, uint32_t timeStamp);

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -259,6 +259,25 @@ typedef struct {
   lighthouseCalibrationMeasurementModel_t calibrationMeasurementModel;
 } sweepAngleMeasurement_t;
 
+/** gyroscope measurement */
+typedef struct
+{
+  Axis3f gyro; // deg/s, for legacy reasons
+} gyroscopeMeasurement_t;
+
+/** accelerometer measurement */
+typedef struct
+{
+  Axis3f acc; // Gs, for legacy reasons
+} accelerationMeasurement_t;
+
+/** barometer measurement */
+typedef struct
+{
+  baro_t baro; // for legacy reasons
+} barometerMeasurement_t;
+
+
 // Frequencies to bo used with the RATE_DO_EXECUTE_HZ macro. Do NOT use an arbitrary number.
 #define RATE_1000_HZ 1000
 #define RATE_500_HZ 500

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -1,3 +1,7 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "static_mem.h"
+
 #define DEBUG_MODULE "ESTIMATOR"
 #include "debug.h"
 
@@ -5,9 +9,22 @@
 #include "estimator.h"
 #include "estimator_complementary.h"
 #include "estimator_kalman.h"
+#include "log.h"
+#include "statsCnt.h"
+
 
 #define DEFAULT_ESTIMATOR complementaryEstimator
 static StateEstimatorType currentEstimator = anyEstimator;
+
+
+#define MEASUREMENTS_QUEUE_SIZE (20)
+static xQueueHandle measurementsQueue;
+STATIC_MEM_QUEUE_ALLOC(measurementsQueue, MEASUREMENTS_QUEUE_SIZE, sizeof(measurement_t));
+
+// Statistics
+#define ONE_SECOND 1000
+static STATS_CNT_RATE_DEFINE(measurementAppendedCounter, ONE_SECOND);
+static STATS_CNT_RATE_DEFINE(measurementNotAppendedCounter, ONE_SECOND);
 
 static void initEstimator(const StateEstimatorType estimator);
 static void deinitEstimator(const StateEstimatorType estimator);
@@ -16,17 +33,8 @@ typedef struct {
   void (*init)(void);
   void (*deinit)(void);
   bool (*test)(void);
-  void (*update)(state_t *state, sensorData_t *sensors, const uint32_t tick);
+  void (*update)(state_t *state, const uint32_t tick);
   const char* name;
-  bool (*estimatorEnqueueTDOA)(const tdoaMeasurement_t *uwb);
-  bool (*estimatorEnqueuePosition)(const positionMeasurement_t *pos);
-  bool (*estimatorEnqueuePose)(const poseMeasurement_t *pose);
-  bool (*estimatorEnqueueDistance)(const distanceMeasurement_t *dist);
-  bool (*estimatorEnqueueTOF)(const tofMeasurement_t *tof);
-  bool (*estimatorEnqueueAbsoluteHeight)(const heightMeasurement_t *height);
-  bool (*estimatorEnqueueFlow)(const flowMeasurement_t *flow);
-  bool (*estimatorEnqueueYawError)(const yawErrorMeasurement_t *error);
-  bool (*estimatorEnqueueSweepAngles)(const sweepAngleMeasurement_t *angles);
 } EstimatorFcns;
 
 #define NOT_IMPLEMENTED ((void*)0)
@@ -38,15 +46,6 @@ static EstimatorFcns estimatorFunctions[] = {
         .test = NOT_IMPLEMENTED,
         .update = NOT_IMPLEMENTED,
         .name = "None",
-        .estimatorEnqueueTDOA = NOT_IMPLEMENTED,
-        .estimatorEnqueuePosition = NOT_IMPLEMENTED,
-        .estimatorEnqueuePose = NOT_IMPLEMENTED,
-        .estimatorEnqueueDistance = NOT_IMPLEMENTED,
-        .estimatorEnqueueTOF = NOT_IMPLEMENTED,
-        .estimatorEnqueueAbsoluteHeight = NOT_IMPLEMENTED,
-        .estimatorEnqueueFlow = NOT_IMPLEMENTED,
-        .estimatorEnqueueYawError = NOT_IMPLEMENTED,
-        .estimatorEnqueueSweepAngles = NOT_IMPLEMENTED,
     }, // Any estimator
     {
         .init = estimatorComplementaryInit,
@@ -54,15 +53,6 @@ static EstimatorFcns estimatorFunctions[] = {
         .test = estimatorComplementaryTest,
         .update = estimatorComplementary,
         .name = "Complementary",
-        .estimatorEnqueueTDOA = NOT_IMPLEMENTED,
-        .estimatorEnqueuePosition = NOT_IMPLEMENTED,
-        .estimatorEnqueuePose = NOT_IMPLEMENTED,
-        .estimatorEnqueueDistance = NOT_IMPLEMENTED,
-        .estimatorEnqueueTOF = estimatorComplementaryEnqueueTOF,
-        .estimatorEnqueueAbsoluteHeight = NOT_IMPLEMENTED,
-        .estimatorEnqueueFlow = NOT_IMPLEMENTED,
-        .estimatorEnqueueYawError = NOT_IMPLEMENTED,
-        .estimatorEnqueueSweepAngles = NOT_IMPLEMENTED,
     },
     {
         .init = estimatorKalmanInit,
@@ -70,19 +60,11 @@ static EstimatorFcns estimatorFunctions[] = {
         .test = estimatorKalmanTest,
         .update = estimatorKalman,
         .name = "Kalman",
-        .estimatorEnqueueTDOA = estimatorKalmanEnqueueTDOA,
-        .estimatorEnqueuePosition = estimatorKalmanEnqueuePosition,
-        .estimatorEnqueuePose = estimatorKalmanEnqueuePose,
-        .estimatorEnqueueDistance = estimatorKalmanEnqueueDistance,
-        .estimatorEnqueueTOF = estimatorKalmanEnqueueTOF,
-        .estimatorEnqueueAbsoluteHeight = estimatorKalmanEnqueueAbsoluteHeight,
-        .estimatorEnqueueFlow = estimatorKalmanEnqueueFlow,
-        .estimatorEnqueueYawError = estimatorKalmanEnqueueYawError,
-        .estimatorEnqueueSweepAngles = estimatorKalmanEnqueueSweepAngles,
     },
 };
 
 void stateEstimatorInit(StateEstimatorType estimator) {
+  measurementsQueue = STATIC_MEM_QUEUE_CREATE(measurementsQueue);
   stateEstimatorSwitchTo(estimator);
 }
 
@@ -131,8 +113,8 @@ bool stateEstimatorTest(void) {
   return estimatorFunctions[currentEstimator].test();
 }
 
-void stateEstimator(state_t *state, sensorData_t *sensors, const uint32_t tick) {
-  estimatorFunctions[currentEstimator].update(state, sensors, tick);
+void stateEstimator(state_t *state, const uint32_t tick) {
+  estimatorFunctions[currentEstimator].update(state, tick);
 }
 
 const char* stateEstimatorGetName() {
@@ -140,74 +122,35 @@ const char* stateEstimatorGetName() {
 }
 
 
-bool estimatorEnqueueTDOA(const tdoaMeasurement_t *uwb) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueTDOA) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueTDOA(uwb);
+void estimatorEnqueue(const measurement_t *measurement) {
+  if (!measurementsQueue) {
+    return;
   }
 
-  return false;
-}
-
-bool estimatorEnqueueYawError(const yawErrorMeasurement_t* error) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueYawError) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueYawError(error);
+  portBASE_TYPE result;
+  bool isInInterrupt = (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
+  if (isInInterrupt) {
+    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+    result = xQueueSendFromISR(measurementsQueue, measurement, &xHigherPriorityTaskWoken);
+    if (xHigherPriorityTaskWoken == pdTRUE) {
+      portYIELD();
+    }
+  } else {
+    result = xQueueSend(measurementsQueue, measurement, 0);
   }
 
-  return false;
-}
-
-bool estimatorEnqueuePosition(const positionMeasurement_t *pos) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueuePosition) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueuePosition(pos);
+  if (result == pdTRUE) {
+    STATS_CNT_RATE_EVENT(&measurementAppendedCounter);
+  } else {
+    STATS_CNT_RATE_EVENT(&measurementNotAppendedCounter);
   }
-
-  return false;
 }
 
-bool estimatorEnqueuePose(const poseMeasurement_t *pose) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueuePose) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueuePose(pose);
-  }
-
-  return false;
+bool estimatorDequeue(measurement_t *measurement) {
+  return pdTRUE == xQueueReceive(measurementsQueue, measurement, 0);
 }
 
-bool estimatorEnqueueDistance(const distanceMeasurement_t *dist) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueDistance) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueDistance(dist);
-  }
-
-  return false;
-}
-
-bool estimatorEnqueueTOF(const tofMeasurement_t *tof) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueTOF) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueTOF(tof);
-  }
-
-  return false;
-}
-
-bool estimatorEnqueueAbsoluteHeight(const heightMeasurement_t *height) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueAbsoluteHeight) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueAbsoluteHeight(height);
-  }
-
-  return false;
-}
-
-bool estimatorEnqueueFlow(const flowMeasurement_t *flow) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueFlow) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueFlow(flow);
-  }
-
-  return false;
-}
-
-bool estimatorEnqueueSweepAngles(const sweepAngleMeasurement_t *angles) {
-  if (estimatorFunctions[currentEstimator].estimatorEnqueueSweepAngles) {
-    return estimatorFunctions[currentEstimator].estimatorEnqueueSweepAngles(angles);
-  }
-
-  return false;
-}
+LOG_GROUP_START(estimator)
+  STATS_CNT_RATE_LOG_ADD(rtApnd, &measurementAppendedCounter)
+  STATS_CNT_RATE_LOG_ADD(rtRej, &measurementNotAppendedCounter)
+LOG_GROUP_STOP(estimator)

--- a/src/modules/src/estimator_complementary.c
+++ b/src/modules/src/estimator_complementary.c
@@ -38,24 +38,20 @@
 #include "stabilizer_types.h"
 #include "static_mem.h"
 
+static Axis3f gyro;
+static Axis3f acc;
+static baro_t baro;
+static tofMeasurement_t tof;
+
 #define ATTITUDE_UPDATE_RATE RATE_250_HZ
 #define ATTITUDE_UPDATE_DT 1.0/ATTITUDE_UPDATE_RATE
 
 #define POS_UPDATE_RATE RATE_100_HZ
 #define POS_UPDATE_DT 1.0/POS_UPDATE_RATE
 
-static bool latestTofMeasurement(tofMeasurement_t* tofMeasurement);
-
-// Measurements of TOF from laser sensor
-#define TOF_QUEUE_LENGTH (1)
-static xQueueHandle tofDataQueue;
-STATIC_MEM_QUEUE_ALLOC(tofDataQueue, TOF_QUEUE_LENGTH, sizeof(tofMeasurement_t));
-
-
-void estimatorComplementaryInit(void)
+    void
+    estimatorComplementaryInit(void)
 {
-  tofDataQueue = STATIC_MEM_QUEUE_CREATE(tofDataQueue);
-
   sensfusion6Init();
 }
 
@@ -68,13 +64,35 @@ bool estimatorComplementaryTest(void)
   return pass;
 }
 
-void estimatorComplementary(state_t *state, sensorData_t *sensorData, const uint32_t tick)
+void estimatorComplementary(state_t *state, const uint32_t tick)
 {
-  sensorsAcquire(sensorData, tick); // Read sensors at full rate (1000Hz)
+  // Pull the latest sensors values of interest; discard the rest
+  measurement_t m;
+  while (estimatorDequeue(&m)) {
+    switch (m.type)
+    {
+    case MeasurementTypeGyroscope:
+      gyro = m.data.gyroscope.gyro;
+      break;
+    case MeasurementTypeAcceleration:
+      acc = m.data.acceleration.acc;
+      break;
+    case MeasurementTypeBarometer:
+      baro = m.data.barometer.baro;
+      break;
+    case MeasurementTypeTOF:
+      tof = m.data.tof;
+      break;
+    default:
+      break;
+    }
+  }
+
+  // Update filter
   if (RATE_DO_EXECUTE(ATTITUDE_UPDATE_RATE, tick)) {
-    sensfusion6UpdateQ(sensorData->gyro.x, sensorData->gyro.y, sensorData->gyro.z,
-                       sensorData->acc.x, sensorData->acc.y, sensorData->acc.z,
-                       ATTITUDE_UPDATE_DT);
+    sensfusion6UpdateQ(gyro.x, gyro.y, gyro.z,
+                        acc.x, acc.y, acc.z,
+                        ATTITUDE_UPDATE_DT);
 
     // Save attitude, adjusted for the legacy CF2 body coordinate system
     sensfusion6GetEulerRPY(&state->attitude.roll, &state->attitude.pitch, &state->attitude.yaw);
@@ -87,46 +105,14 @@ void estimatorComplementary(state_t *state, sensorData_t *sensorData, const uint
       &state->attitudeQuaternion.z,
       &state->attitudeQuaternion.w);
 
-    state->acc.z = sensfusion6GetAccZWithoutGravity(sensorData->acc.x,
-                                                    sensorData->acc.y,
-                                                    sensorData->acc.z);
+    state->acc.z = sensfusion6GetAccZWithoutGravity(acc.x,
+                                                    acc.y,
+                                                    acc.z);
 
     positionUpdateVelocity(state->acc.z, ATTITUDE_UPDATE_DT);
   }
 
   if (RATE_DO_EXECUTE(POS_UPDATE_RATE, tick)) {
-    tofMeasurement_t tofMeasurement;
-
-    latestTofMeasurement(&tofMeasurement);
-    positionEstimate(state, sensorData, &tofMeasurement, POS_UPDATE_DT, tick);
+    positionEstimate(state, &baro, &tof, POS_UPDATE_DT, tick);
   }
-}
-
-static bool latestTofMeasurement(tofMeasurement_t* tofMeasurement) {
-  return xQueuePeek(tofDataQueue, tofMeasurement, 0) == pdTRUE;
-}
-
-static bool overwriteMeasurement(xQueueHandle queue, void *measurement)
-{
-  portBASE_TYPE result;
-  bool isInInterrupt = (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
-
-  if (isInInterrupt) {
-    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
-    result = xQueueOverwriteFromISR(queue, measurement, &xHigherPriorityTaskWoken);
-    if(xHigherPriorityTaskWoken == pdTRUE)
-    {
-      portYIELD();
-    }
-  } else {
-    result = xQueueOverwrite(queue, measurement);
-  }
-  return (result==pdTRUE);
-}
-
-
-bool estimatorComplementaryEnqueueTOF(const tofMeasurement_t *tof)
-{
-  // A distance (distance) [m] to the ground along the z_B axis.
-  return overwriteMeasurement(tofDataQueue, (void *)tof);
 }

--- a/src/modules/src/position_estimator_altitude.c
+++ b/src/modules/src/position_estimator_altitude.c
@@ -58,18 +58,18 @@ static struct selfState_s state = {
   .estimatedVZ = 0.0f,
 };
 
-static void positionEstimateInternal(state_t* estimate, const sensorData_t* sensorData, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick, struct selfState_s* state);
+static void positionEstimateInternal(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick, struct selfState_s* state);
 static void positionUpdateVelocityInternal(float accWZ, float dt, struct selfState_s* state);
 
-void positionEstimate(state_t* estimate, const sensorData_t* sensorData, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick) {
-  positionEstimateInternal(estimate, sensorData, tofMeasurement, dt, tick, &state);
+void positionEstimate(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick) {
+  positionEstimateInternal(estimate, baro, tofMeasurement, dt, tick, &state);
 }
 
 void positionUpdateVelocity(float accWZ, float dt) {
   positionUpdateVelocityInternal(accWZ, dt, &state);
 }
 
-static void positionEstimateInternal(state_t* estimate, const sensorData_t* sensorData, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick, struct selfState_s* state) {
+static void positionEstimateInternal(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick, struct selfState_s* state) {
   float filteredZ;
   static float prev_estimatedZ = 0;
   static bool surfaceFollowingMode = false;
@@ -94,11 +94,11 @@ static void positionEstimateInternal(state_t* estimate, const sensorData_t* sens
   } else {
     // FIXME: A bit of an hack to init IIR filter
     if (state->estimatedZ == 0.0f) {
-      filteredZ = sensorData->baro.asl;
+      filteredZ = baro->asl;
     } else {
       // IIR filter asl
       filteredZ = (state->estAlphaAsl       ) * state->estimatedZ +
-                  (1.0f - state->estAlphaAsl) * sensorData->baro.asl;
+                  (1.0f - state->estAlphaAsl) * baro->asl;
     }
     // Use asl as base and add velocity changes.
     state->estimatedZ = filteredZ + (state->velocityFactor * state->velocityZ * dt);

--- a/src/modules/src/range.c
+++ b/src/modules/src/range.c
@@ -48,13 +48,12 @@ float rangeGet(rangeDirection_t direction)
   return ranges[direction];
 }
 
-bool rangeEnqueueDownRangeInEstimator(float distance, float stdDev, uint32_t timeStamp) {
+void rangeEnqueueDownRangeInEstimator(float distance, float stdDev, uint32_t timeStamp) {
   tofMeasurement_t tofData;
   tofData.timestamp = timeStamp;
   tofData.distance = distance;
   tofData.stdDev = stdDev;
-
-  return estimatorEnqueueTOF(&tofData);
+  estimatorEnqueueTOF(&tofData);
 }
 
 LOG_GROUP_START(range)

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -237,10 +237,11 @@ static void stabilizerTask(void* param)
   while(1) {
     // The sensor should unlock at 1kHz
     sensorsWaitDataReady();
+    
+    // update sensorData struct (for logging variables)
+    sensorsAcquire(&sensorData, tick);
 
-    if (healthShallWeRunTest())
-    {
-      sensorsAcquire(&sensorData, tick);
+    if (healthShallWeRunTest()) {
       healthRunTests(&sensorData);
     } else {
       // allow to update estimator dynamically
@@ -254,7 +255,7 @@ static void stabilizerTask(void* param)
         controllerType = getControllerType();
       }
 
-      stateEstimator(&state, &sensorData, tick);
+      stateEstimator(&state, tick);
       compressState();
 
       commanderGetSetpoint(&setpoint, &state);


### PR DESCRIPTION
* IMU data is now pushed to the estimator, rather than pulled for
  consistency.
* The many different estimator queues are now unified into one
  queue of a dynamic union type.
* The latest sensorData is still filled in stabilizer for health check
  and logging.

Addresses issues #722 and #616.