### PR TITLE
Lighthouse2: Filter stale measurements that occur during interference

### DIFF
--- a/src/utils/interface/lighthouse/pulse_processor.h
+++ b/src/utils/interface/lighthouse/pulse_processor.h
@@ -248,6 +248,7 @@ typedef struct {
   pulseProcessorSensorMeasurement_t sensorMeasurementsLh1[PULSE_PROCESSOR_N_SENSORS];
   pulseProcessorSensorMeasurement_t sensorMeasurementsLh2[PULSE_PROCESSOR_N_SENSORS];
   lighthouseBaseStationType_t measurementType;
+  uint64_t lastUsecTimestamp[PULSE_PROCESSOR_N_BASE_STATIONS];
 } pulseProcessorResult_t;
 
 /**

--- a/test/utils/src/lighthouse/test_pulse_processor_v2.c
+++ b/test/utils/src/lighthouse/test_pulse_processor_v2.c
@@ -7,6 +7,8 @@
 
 #include "mock_ootx_decoder.h"
 #include "mock_lighthouse_calibration.h"
+#include "mock_usec_time.h"
+#include "mock_pulse_processor.h"
 
 
 // Functions under test


### PR DESCRIPTION
Since LH2 basestations are not synchronized per cable, there is a
natural interference when beams reach the sensors at the same time.
This causes stale measurements (re-using of old angles), which result
in incorrect position estimation during motion.

This change invalidates old sweeps based on the known frequency of the
LH2 laser sweeps.