### PR TITLE
Fix regression that caused invalid data in uSD card log files.

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -472,7 +472,7 @@ static void usddeckWriteEventData(const usdLogEventConfig_t* cfg, const uint8_t*
     vTaskResume(xHandleWriteTask);
   }
 
-  int dataSize = 2 + 4 + payloadSize + cfg->numBytes;
+  int dataSize = sizeof(cfg->eventId) + sizeof(ticks) + payloadSize + cfg->numBytes;
 
   // only write if we have enough space
   if (ringBuffer_availableSpace(&logBuffer) >= dataSize) {


### PR DESCRIPTION
This regression was introduced with 303f0736298d7ec7151ac23ebb8bb9599e019334,
where the timestamp was changed to 64bit (8 Bytes), but the dataSize
check remained for 4 bytes. Some of the ringBuffer_push calls can fail
in that case, causing invalid events in the buffer.

This fix corrects the dataSize computation from 4 bytes to sizeof(ticks)