### PR TITLE
Update lighthouse documentation to prepare for release

### DIFF
--- a/docs/functional-areas/lighthouse/index.md
+++ b/docs/functional-areas/lighthouse/index.md
@@ -9,7 +9,7 @@ The Lighthouse positioning system uses the HTC Vive base stations (aka Lighthous
 deck to achieve high precision positioning.
 
 The basics:
- * [Setting up](/docs/functional-areas/lighthouse/setting_up.md)
+ * [System overview](/docs/functional-areas/lighthouse/system_overview.md)
  * [Limitations](/docs/functional-areas/lighthouse/limitations.md)
  * [Positioning methods](/docs/functional-areas/lighthouse/positioning_methods.md)
 

--- a/docs/functional-areas/lighthouse/limitations.md
+++ b/docs/functional-areas/lighthouse/limitations.md
@@ -5,17 +5,12 @@ page_id: lh_limitations
 
 The lighthouse deck is released in early access which means that there is a couple of limitation you should be aware of:
 
-* There are currently two ways to configure the base station positions/geometry.
-  1. Hard-code the base station position in the firmware. This means that you need to re-flash your Crazyflies each time you move the basestations.
-  2. Uploded from a computer. The positions can be uploaded to the Crzyflie from a computer, but will be gone when the Crazyflie is restarted. If the ```get_bs_geometry.py``` script is executed with the ```--write``` flag, the base station positions are uploded to the Crazyflie, which can be convenient to test a system.
-* Position/gemometry handling will be improved in the future.
 * Since the deck only has horizontal sensors, the angle at which the base-stations are seen cannot be too shallow. This means that you should fly at least 40cm bellow the base-stations and that the base-stations should be placed above the flight space. This is a hardware limitation of the current deck.
-* The Crazyflie currently only supports Vive base station V1. Base station V1 are limited to two base-station per system. Base-station V2 does not have this limitation and so allows to cover much larger space. Support for the base station V2 is currently being worked-on and should be available in a future firmware update.
 
-## Experimental base station V2 support
+## State of the base station V2 support
 
-There is limited and experimenatal support for V2 base stations.
+The lighthouse V2 support is currently at a Minimum Viable Product state.
+This means that is it well supported but still has some limitation that can be lifted in future development.
 
 * 1 and 2 base stations are supported
 * The base stations must be configured to use channel 1 and 2
-* Calibration data is not read from the base stations and there might be fairly large errors in the angle calculations. For this reason it is likely that the crossing beam positioning method will work better than the default sweep method when using 2 base stations. Change by setting the ```lighthouse.method``` parameter to ```0```.

--- a/docs/functional-areas/lighthouse/system_overview.md
+++ b/docs/functional-areas/lighthouse/system_overview.md
@@ -16,7 +16,7 @@ The Crayzflie needs two pieces of system information to be able to estimate its 
 The calibration data describes slight imperfections in the the manufacturing of the base stations. The calibration data is measured in the factory and is stored in each base station. The calibration data is required to calculate the angles with a high level of accuracy.
 
 The geometry data describes the position and orientation of the base stations and is needed to understand how the measured angles relate to the global reference frame.
-The geometry data is calculated by the client using raw angles measured by the Crazyflie.
+The geometry data is calculated by the client using raw angles corrected by calibration data.
 
 Calibration and geometry data is stored in the Crazyflie to make it possible to take off and use the lighthouse system imediate after reboot.
 

--- a/docs/functional-areas/lighthouse/system_overview.md
+++ b/docs/functional-areas/lighthouse/system_overview.md
@@ -1,9 +1,7 @@
 ---
-title: Setting up the lighthouse system
-page_id: lh_setting_up
+title: Lighthouse system overview
+page_id: lh_system_overview
 ---
-
-## Prerequisites
 
 The lighthouse deck allows to use the HTC-Vive/SteamVR lighthouse tracking system to fly Crazyflies autonomously. The system works with one or two Lighthouse base stations (two recommended), both V1 and V2 are supported. It is not possible to mix V1 and V2 base stations in the same system.
 
@@ -18,84 +16,11 @@ The Crayzflie needs two pieces of system information to be able to estimate its 
 The calibration data describes slight imperfections in the the manufacturing of the base stations. The calibration data is measured in the factory and is stored in each base station. The calibration data is required to calculate the angles with a high level of accuracy.
 
 The geometry data describes the position and orientation of the base stations and is needed to understand how the measured angles relate to the global reference frame.
+The geometry data is calculated by the client using raw angles measured by the Crazyflie.
 
 Calibration and geometry data is stored in the Crazyflie to make it possible to take off and use the lighthouse system imediate after reboot.
 
 The Crazyflie must know if the system is using V1 or V2 type base stations, this is set manually from the client.
-
-## Set up procedure
-
-The following procedure assumes two base stations are used, but the instructions for one should be similar.
-
-You need the python client to complete the procedure.
-
-### 1. Configure the base stations
-
-For lighthouse V1 set up the base stations according to the HTC instructions, depending if you want to use a sync cable or not.
-
-For lighthouse V2 the base station should be configured to use channel 1 and 2, this can be done through the client:
-
-1. Connect the first base station (only one of them) to your computer via USB
-1. Open the lighthouse tab in the client
-1. Click the "Set BS channel" button
-1. In the dialog box click the "Scan basestation" button
-1. Chose channel 1
-1. Click the "Set channel" button
-1. Repeat for the other base station but configure it for channel 2
-
-It is now time to mount the base stations in your space.
-
-## 2. Update Crazyflie and lighthouse deck firmware
-
-1. In the client connect to the Crazyflie using a Crazyradio (Note: USB will not work)
-1. Click "Bootloader" in the "Connect" menu
-1. In the dialog box, in the drop down chose the latest release (the default)
-1. Click the "Program" button.
-
-The Crazyflie and the deck will be flashed with the latest firmware.
-
-Note 1: the Crazyflie will restart one or more times during the flashing process.
-
-Note 2: during the transition into the first release of the lighthouse system the default release may not contain a lighthouse deck binary.
-If this is the case, please download it manually from [github](https://github.com/bitcraze/crazyflie-release/releases) and use the
-file option in the bootloader dialog.
-## 3. Obtaining calibration data
-
-The calibration data is transmitted in the light from the base stations. The Crazyflie will receive the data and store it
-when it is complete. After startup the latest stored data will automatically be loaded from memory.
-
-The procedure is:
-
-1. Turn on the Crazyflie and put it on the floor with both base stations within range
-1. Start the python client and connect to the Crazyflie
-1. Open the lighthouse tab
-1. The "Receiving" indicators should be green, showing that both base stations are received
-1. Wait until both "Calibration" indicators turn green
-
-The calibration data has now been saved in the Crazyflie.
-
-It may take up to 30 seconds to reveive the calibration data, especially for lithghthouse V2 the process may take a while
-and can be sensitive to interference. If the calibration data is not received for both base stations, try to hold the
-Crazyflie closer to one of the base stations at a time to get a better signal.
-
-## 4. Geometry data
-
-The base station positions and orientation can be measured using a Crazyflie + lighthouse deck. The Crazyflie **must** have the correct calibration data first to get a useful result.
-
-1. Put the Crazyflie on the floor where you want the origin. Forward of the Crazyflie is the positive X-axis while
-the Y-axis points to the left. Z is up.
-1. In the lighthouse tab in the python client, make sure the calibration data has been received
-1. Click the "Manage geometry" button
-1. In the dialog box click the "Estimate Geometry" button
-1. After a while the estimated position of the base stations shoule be displayed as a list
-1. If the positions of the base stations (relative to the Crazyflie) looks reasonable click the "Write to Crazyflie" button
-
-The geometry data has now been saved in the Crazyflie and the system is ready to be used.
-
-The 3D visualization should show the two base stations and the estimated position of the Crazyflie.
-
-**Note1:** Make sure the Lighthouse deck is parallell to the floor, as the XY-plane of the coordinate system will be an extension of the deck.
-
 
 ## The number of base stations and frame synchronization
 The lighthouse deck works with one or two basestations but the estimated position will be better and more stable with two basestations. When using two basestations, one of them may be occluded temporarily, and the Crazyflie will use the other one for positioning.
@@ -111,3 +36,9 @@ The ```PULSE_PROCESSOR_N_BASE_STATIONS``` (in pulse_processor.h) determines the 
 There are currently two ways of calculating the position using the lighthouse.
 
 The first method that was implemented calculates two vectors (or beams) from the basestations, based on the sweep angles measured by the sensors on the Crazyflie. The intersection point between the beams is the position of the Crazyflie, and this point is pushed into the estimator. We call this method the “crossing beam” method. A more recent implementation pushes the sweep angles from the base stations into the estimator and lets the kalman filter calculate the position based on this information. This method is called the “sweep angle” method and also works if only one basestation is available. It is possible to change positioning method “on the fly” by setting the lighthouse.method parameter. The sweep angle method is the default.
+
+## V1 vs. V2
+
+Crazyflie support two generation of lighthouse basestation called V1 and V2.
+
+The main difference between the two versions is that lighthouse V1 is designed to work with 2 basestion sychonized either optically or via a cable, and V2 is design to work with any number of independent basestations setup on different channels.


### PR DESCRIPTION
In order to prepare for the lighthouse release, there is some documentation that needs to be updated. This includes at least:
 - [x] Removing the setting up doc (will be replaced by a getting started tutorial)
 - [x] Make a system overview page to introduce lighthouse positioning concepts and vocabulary
 - [x] Update the list of limitations
