### PR TITLE
Fix issue where logGetVarId returns a groupId rather than a varId.

### DIFF
--- a/src/modules/src/log.c
+++ b/src/modules/src/log.c
@@ -972,9 +972,10 @@ logVarId_t logGetVarId(char* group, char* name)
   for(i=0; i<logsLen; i++)
   {
     if (logs[i].type & LOG_GROUP) {
-      if (logs[i].type & LOG_START)
+      if (logs[i].type & LOG_START) {
         currgroup = logs[i].name;
-    } if ((!strcmp(group, currgroup)) && (!strcmp(name, logs[i].name))) {
+      }
+    } else if ((!strcmp(group, currgroup)) && (!strcmp(name, logs[i].name))) {
       varId = (logVarId_t)i;
       return varId;
     }


### PR DESCRIPTION
If the variable is called the same as the group, the current function
returns the group, rather than the actually variable. For example
"motion.motion". This makes it impossible to log the variable.