### PR TITLE
Enable development of deck drivers in Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ current_platform.mk
 
 /docs/.jekyll-metadata
 docs/.jekyll-cache
+
+Cargo.lock

--- a/src/deck/core/rust/.cargo/config
+++ b/src/deck/core/rust/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/src/deck/core/rust/Cargo.toml
+++ b/src/deck/core/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust_drivers"
+version = "0.1.0"
+authors = ["Jonas Danielsson <jonas@bitcraze.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+bindgen = "0.53.1"
+
+[dependencies]
+cty = "0.2.1"

--- a/src/deck/core/rust/build.rs
+++ b/src/deck/core/rust/build.rs
@@ -1,0 +1,42 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    let target = env::var("TARGET").unwrap();
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .use_core()
+        .ctypes_prefix("cty")
+        .header("wrapper.h")
+        .clang_args(&["-target", &target])
+        // Set the include paths
+        .clang_arg("-I../../interface")
+        .clang_arg("-I../../../modules/interface")
+        .clang_arg("-I../../../hal/interface")
+        .clang_arg("-I../../../drivers/interface")
+        .clang_arg("-I../../../utils/interface/")
+        .clang_arg("-I../../../utils/interface/lighthouse")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("deck_bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/src/deck/core/rust/src/lib.rs
+++ b/src/deck/core/rust/src/lib.rs
@@ -1,0 +1,75 @@
+#![no_std]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!(concat!(env!("OUT_DIR"), "/deck_bindings.rs"));
+
+//
+// Below is a redefinition of the DeckDriver in order to mark it as thread safe
+// so that we can use a pointer to it as a global static at a certain link
+// section.
+//
+// We also need to set the RequiredEstimator field to be u16, since the
+// firmware has short enums.
+//
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct ConstDeckMemDef(pub *const deckMemDef_s);
+unsafe impl Sync for ConstDeckMemDef {}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct DriverName(pub *const cty::c_char);
+unsafe impl Sync for DriverName {}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct deck_driver_unsafe {
+    pub vid: u8,
+    pub pid: u8,
+    pub name: DriverName,
+    pub usedPeriph: u32,
+    pub usedGpio: u32,
+    pub requiredEstimator: u16,
+    pub requiredLowInterferenceRadioMode: bool,
+    pub memoryDef: ConstDeckMemDef,
+    pub init: unsafe extern "C" fn(arg1: *mut deckInfo_s),
+    pub test: unsafe extern "C" fn() -> bool,
+}
+
+pub type RustDeckDriver = deck_driver_unsafe;
+
+#[repr(C)]
+pub struct ConstDeckDriver(pub *const RustDeckDriver);
+unsafe impl Sync for ConstDeckDriver {}
+
+//
+// This macro places a pointer to a RustDeckDriver at a certain link section
+// and marks it as used so that is not cleaned away. The first argument is the
+// struct to point at and the other is an ident that needs to be globally
+// unique.
+//
+#[macro_export]
+macro_rules! deck_driver {
+    ($name:ident, $driver:ident) => {
+        #[no_mangle]
+        #[link_section = concat!(".deckDriver.", stringify!($name))]
+        #[used]
+        static $driver: ConstDeckDriver = ConstDeckDriver(&$name as *const _);
+    };
+}
+
+#[panic_handler]
+fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[macro_export]
+macro_rules! console_print {
+    ($msg:expr) => {
+        unsafe {
+            eprintf(Some(consolePutchar), $msg);
+        }
+    };
+}

--- a/src/deck/core/rust/wrapper.h
+++ b/src/deck/core/rust/wrapper.h
@@ -1,0 +1,2 @@
+#include <deck_core.h>
+#include <console.h>

--- a/src/deck/drivers/rust/rust_example/.cargo/config
+++ b/src/deck/drivers/rust/rust_example/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabihf"

--- a/src/deck/drivers/rust/rust_example/Cargo.toml
+++ b/src/deck/drivers/rust/rust_example/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rust_example"
+version = "0.1.0"
+authors = ["Jonas Danielsson <jonas@bitcraze.io>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust_drivers = { path = "../../../core/rust" }
+cty = "0.2.1"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/src/deck/drivers/rust/rust_example/src/lib.rs
+++ b/src/deck/drivers/rust/rust_example/src/lib.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![feature(extended_key_value_attributes)]
+
+use rust_drivers::*;
+
+#[no_mangle]
+pub extern "C" fn rustExampleInit(_info: *mut DeckInfo) {
+    console_print!(b"Hello from rustExampleDriver init\n\0".as_ptr() as *const cty::c_char);
+}
+
+#[no_mangle]
+pub extern "C" fn rustExampleTest() -> bool {
+    console_print!(b"Hello from rustExampleDriver test\n\0".as_ptr() as *const cty::c_char);
+    true
+}
+
+#[no_mangle]
+static rust_example: RustDeckDriver = RustDeckDriver {
+    name: DriverName(b"rustExampleDriver\0".as_ptr() as *const cty::c_char),
+    init: rustExampleInit,
+    test: rustExampleTest,
+    usedPeriph: 0,
+    usedGpio: 0,
+    requiredEstimator: 0,
+    requiredLowInterferenceRadioMode: false,
+    vid: 0xDE,
+    pid: 0xAD,
+    memoryDef: ConstDeckMemDef(core::ptr::null() as *const DeckMemDef_t),
+};
+
+deck_driver!(rust_example, RustExampleDriver);

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -1,0 +1,29 @@
+# Part of CrazyFlie  Makefile
+# Copyright (c) 2021 Bitcraze AB
+
+RUST_DECK_DRIVERS_PATH = $(CRAZYFLIE_BASE)/src/deck/drivers/rust
+
+ifeq ($(RUST_DECK_DRIVERS_ENABLED), 1)
+# This function generates a target for a deck driver written in
+# rust. It must be located at $(RUST_DECK_DRIVERS_PATH) and the name
+# of the directory must be the name of the Cargo project.
+define rust-driver-target
+cargo_args = --target thumbv7em-none-eabihf --manifest-path=$(1)/Cargo.toml
+rustc_args = -C opt-level=3 --emit=obj
+
+$(BIN)/$(notdir $(1)).o: $(1)/src/lib.rs
+	cargo rustc $$(cargo_args) -- $$(rustc_args)
+	@##
+	@## Make sure we copy the latest version (rustc adds a hash to the name for
+	@## each new object file).
+	@##
+	@cp `ls -t $(1)/target/*/*/deps/$(notdir $(1))*.o | head -n1` $$@
+
+PROJ_OBJ += $(notdir $(1)).o
+endef
+
+# For each of the drivers found in $(RUST_DECK_DRIVERS_PATH) we will
+# generate a make target for them with the function defined above.
+drivers = $(wildcard $(RUST_DECK_DRIVERS_PATH)/*)
+$(foreach d,$(drivers),$(eval $(call rust-driver-target,$(d))))
+endif

--- a/tools/make/targets.mk
+++ b/tools/make/targets.mk
@@ -11,6 +11,8 @@ ifeq ($(V),0)
   QUIET=1
 endif
 
+-include $(CRAZYFLIE_BASE)/tools/make/rust.mk
+
 target = @$(if $(QUIET), ,echo $($1_COMMAND$(VERBOSE)) ); @$($1_COMMAND)
 
 VTMPL_COMMAND=$(PYTHON) $(CRAZYFLIE_BASE)/tools/make/versionTemplate.py --crazyflie-base $(CRAZYFLIE_BASE) $< $@


### PR DESCRIPTION
With these commits we enable someone to write a deck driver using Rust.

The result of the example driver:
```
#![no_std]
#![feature(extended_key_value_attributes)]

use rust_drivers::*;

#[no_mangle]
pub extern "C" fn rustExampleInit(_info: *mut DeckInfo) {
    console_print!(b"Hello from rustExampleDriver init\n\0".as_ptr() as *const cty::c_char);
}

#[no_mangle]
pub extern "C" fn rustExampleTest() -> bool {
    console_print!(b"Hello from rustExampleDriver test\n\0".as_ptr() as *const cty::c_char);
    true
}

#[no_mangle]
static rust_example: RustDeckDriver = RustDeckDriver {
    name: DriverName(b"rustExampleDriver\0".as_ptr() as *const cty::c_char),
    init: rustExampleInit,
    test: rustExampleTest,
    usedPeriph: 0,
    usedGpio: 0,
    requiredEstimator: 0,
    requiredLowInterferenceRadioMode: false,
    vid: 0xDE,
    pid: 0xAD,
    memoryDef: ConstDeckMemDef(core::ptr::null() as *const DeckMemDef_t),
};

deck_driver!(rust_example, RustExampleDriver);
```
And forcing rustExampleDriver using `DECK_FORCE` is:
![hello](https://user-images.githubusercontent.com/974401/114136854-a3feb200-990b-11eb-94cd-f1b874eebf64.png)

The rust project in `src/deck/core/rust` uses `bindgen` to generate bindings for the headers specified and the driver itself lives in `src/deck/drivers/rust_example`.