### PR TITLE
remove unused checkStops variable from stabilizer.c, make inToOutLatency static

### DIFF
--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -59,9 +59,7 @@ static bool isInit;
 static bool emergencyStop = false;
 static int emergencyStopTimeout = EMERGENCY_STOP_TIMEOUT_DISABLED;
 
-static bool checkStops;
-
-uint32_t inToOutLatency;
+static uint32_t inToOutLatency;
 
 // State variables for the stabilizer
 static setpoint_t setpoint;
@@ -273,7 +271,6 @@ static void stabilizerTask(void* param)
       //
       supervisorUpdate(&sensorData);
 
-      checkStops = systemIsArmed();
       if (emergencyStop || (systemIsArmed() == false)) {
         powerStop();
       } else {


### PR DESCRIPTION
This PR cleans up two minor issues in `stabilizer.c` that I have stumbled upon while reviewing changes from the previous version of the firmware; in particular:

* it removes the now-unused `checkStops` variable; it used to be exposed as a log variable before the battery test was introduced, but not any more, hence the variable is not needed. (It is written but never read).

* it makes `inToOutLatency` static so it is not visible from other compilation units