### PR TITLE
Add tools/build/elf_sanity.py

### DIFF
--- a/tools/build/check_elf
+++ b/tools/build/check_elf
@@ -2,4 +2,4 @@
 set -e
 
 scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-python3 ${scriptDir}/elf_sanity.py ${scriptDir}/../../cf2.elf
+python3 ${scriptDir}/elf_sanity.py ${scriptDir}/../../*.elf

--- a/tools/build/check_elf
+++ b/tools/build/check_elf
@@ -2,7 +2,4 @@
 set -e
 
 scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
-${scriptDir}/test "${@}"
-${scriptDir}/make "${@}"
-${scriptDir}/check_elf
+python3 ${scriptDir}/elf_sanity.py ${scriptDir}/../../cf2.elf

--- a/tools/build/elf_sanity.py
+++ b/tools/build/elf_sanity.py
@@ -142,14 +142,15 @@ def check_structs(stream, what: str) -> dict:
             name = '%s.%s' % (current_group, name)
             if name in name_type_dict:
                 print('%sDuplicate parameter detected!%s (%s)' %
-                      (Colors.RED, Colors.END, name))
+                      (Colors.RED, Colors.END, name), file=sys.stderr)
                 sys.exit(1)
             else:
                 name_type_dict[name] = t
 
             if len(name) > name_maxlen:
                 print('%sName too long!%s (%s > %d)' %
-                      (Colors.RED, Colors.END, name, name_maxlen))
+                      (Colors.RED, Colors.END, name, name_maxlen),
+                      file=sys.stderr)
                 sys.exit(1)
 
         offset += struct_len

--- a/tools/build/elf_sanity.py
+++ b/tools/build/elf_sanity.py
@@ -2,7 +2,18 @@ import argparse
 import struct
 import sys
 
-from elftools.elf.elffile import ELFFile
+try:
+    from elftools.elf.elffile import ELFFile
+except ImportError:
+    print('pytelftools missing, install to run this script', file=sys.stderr)
+    print('https://github.com/eliben/pyelftools#installing', file=sys.stderr)
+    sys.exit(1)
+
+
+class Colors:
+    BLUE = '\033[94m'
+    GREEN = '\033[92m'
+    END = '\033[0m'
 
 
 param_type_to_str_dict = {
@@ -57,6 +68,10 @@ def process_file(filename, list_params: bool, list_logs: bool):
             for key in sorted(logs.keys()):
                 t = logs[key]
                 print('{:25}\t{}'.format(key, log_type_to_str(t)))
+
+        n_logs = Colors.GREEN + str(len(logs.keys())) + Colors.END
+        n_params = Colors.BLUE + str(len(parameters.keys())) + Colors.END
+        print('{} parameters and {} log vars in elf'.format(n_params, n_logs))
 
 
 def get_offset_of(elf, addr):

--- a/tools/build/elf_sanity.py
+++ b/tools/build/elf_sanity.py
@@ -11,6 +11,7 @@ except ImportError:
 
 
 class Colors:
+    RED = '\033[91m'
     BLUE = '\033[94m'
     GREEN = '\033[92m'
     END = '\033[0m'
@@ -140,13 +141,15 @@ def check_structs(stream, what: str) -> dict:
         elif t & group_bit == 0:
             name = '%s.%s' % (current_group, name)
             if name in name_type_dict:
-                print('duplicate parameter detected: %s' % name)
+                print('%sDuplicate parameter detected!%s (%s)' %
+                      (Colors.RED, Colors.END, name))
                 sys.exit(1)
             else:
                 name_type_dict[name] = t
 
             if len(name) > name_maxlen:
-                print('name too long (%s > %d)' % (name, name_maxlen))
+                print('%sName too long!%s (%s > %d)' %
+                      (Colors.RED, Colors.END, name, name_maxlen))
                 sys.exit(1)
 
         offset += struct_len

--- a/tools/build/elf_sanity.py
+++ b/tools/build/elf_sanity.py
@@ -1,0 +1,97 @@
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+
+
+PARAM_NAME_MAXLEN = 25
+PARAM_SIZE = 12
+PARAM_GROUP = 0x1 << 7
+PARAM_START = 0x1
+
+
+def process_file(filename):
+    with open(filename, 'rb') as f:
+        check_params(f)
+
+
+def get_offset_of(elf, addr):
+    for seg in elf.iter_segments():
+        if seg.header['p_type'] != 'PT_LOAD':
+            continue
+
+        # If the symbol is inside the range of a LOADed segment, calculate the
+        # file offset by subtracting the virtual start address and adding the
+        # file offset of the loaded section(s)
+        if addr >= seg['p_vaddr'] and addr < seg['p_vaddr'] + seg['p_filesz']:
+            return addr - seg['p_vaddr'] + seg['p_offset']
+
+    return None
+
+
+def get_offset_of_symbol(elf, name):
+    section = elf.get_section_by_name('.symtab')
+    sym = section.get_symbol_by_name(name)[0]
+    if not sym:
+        print('symbol %s not found' % name, file=sys.stderr)
+        sys.exit(1)
+
+    return get_offset_of(elf, sym['st_value'])
+
+
+def check_params(stream):
+    elf = ELFFile(stream)
+    offset = get_offset_of_symbol(elf, '_param_start')
+    stop_offset = get_offset_of_symbol(elf, '_param_stop')
+
+    parameters = {}
+
+    while offset < stop_offset:
+        elf.stream.seek(offset)
+        #
+        # Parsing a parameter, first unpack the param_s struct:
+        # struct param_s {
+        #   uint8_t type;
+        #   char * name;
+        #   void * address;
+        # };
+        #
+        # We want the type and the name.
+        #
+        buffer = elf.stream.read(PARAM_SIZE)
+        t, addr = struct.unpack('@Bxxxixxxx', buffer)
+        #
+        # Next, convert address of name to offset in elf
+        #
+        addr = get_offset_of(elf, addr)
+        #
+        # And read the name from that offset
+        #
+        elf.stream.seek(addr)
+        name = ''.join(iter(lambda: stream.read(1).decode('ascii'), '\x00'))
+        #
+        # Check if this is start of a group
+        #
+        if t & PARAM_GROUP != 0 and t & PARAM_START != 0:
+            current_group = name
+        elif t & PARAM_GROUP == 0:
+            name = '%s.%s' % (current_group, name)
+            if name in parameters:
+                print('duplicate parameter detected: %s' % name)
+                sys.exit(1)
+            else:
+                parameters[name] = name
+
+            if len(name) > PARAM_NAME_MAXLEN:
+                print('name of param to long (%s > %d)' %
+                      (name, PARAM_NAME_MAXLEN))
+                sys.exit(1)
+
+        offset += PARAM_SIZE
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        process_file(sys.argv[1])
+    else:
+        sys.exit(1)


### PR DESCRIPTION
This script uses pyelftools to check the elf output file.

In this first version it will make sure that the added parameters are
not duplicates and does not exceed the max length of 25 characters.

This is hard to do in compile-time with macro magic.
