### PR TITLE
Enable an estimator to be added by out of tree build

### DIFF
--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -29,3 +29,4 @@
     - {page_id: systemtask}
     - {page_id: memory_management}
     - {page_id: dfu}
+    - {page_id: oot}

--- a/docs/development/oot.md
+++ b/docs/development/oot.md
@@ -1,0 +1,33 @@
+---
+title: Out of tree build
+page_id: oot
+---
+
+It is possible to have an out-of-tree build of parts of the crazyflie firmware. This enables developers to work on elements without worrrying about merging it with the full code base. 
+
+# App layer.
+Technically the app layer is an example of an out of tree build. Follow the [app layer intructions](/docs/userguides/app_layer.md) for this.
+
+# OOT extimators
+In a seperate folder make a Makefile which contain the following content:
+
+```
+OOT_ESTIMATOR = 1
+
+VPATH += src/
+PROJ_OBJ += estimator_out_of_tree.o
+
+CRAZYFLIE_BASE=[LOCATION OF THE CRAZYFLIE FIRMWARE]
+include $(CRAZYFLIE_BASE)/Makefile
+```  
+
+in estimator_out_of_tree.c in the src folder you will just need to make sure that the following functions are filled:
+
+* ```estimatorOutOfTreeInit```
+* ```test = estimatorOutOfTreeTest```
+* ```update = estimatorOutOfTree```
+* ```name = "OOT```
+
+# OOT Controllers
+
+Not yet implemented. Please request this feature in the [crazyflie-firmware issue list](https://github.com/bitcraze/crazyflie-firmware/issues)

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -76,7 +76,7 @@ static EstimatorFcns estimatorFunctions[] = {
         .update = estimatorKalman,
         .name = "Kalman",
     },
-#ifdef EXTERNAL_ESTIMATOR
+#ifdef OOT_ESTIMATOR
     {
         .init = estimatorExternalInit,
         .deinit = NOT_IMPLEMENTED,

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -76,6 +76,15 @@ static EstimatorFcns estimatorFunctions[] = {
         .update = estimatorKalman,
         .name = "Kalman",
     },
+#ifdef EXTERNAL_ESTIMATOR
+    {
+        .init = estimatorExternalInit,
+        .deinit = NOT_IMPLEMENTED,
+        .test = estimatorExternalTest,
+        .update = estimatorExternal,
+        .name = "external",
+    },
+#endif
 };
 
 void stateEstimatorInit(StateEstimatorType estimator) {


### PR DESCRIPTION
There is now a define called  EXTERNAL_ESTIMATOR which adds extra estimator functions that will be filled in by an out of tree build of another estimator. This is mostly for other people to tryout their estimator without worrying to constantly merging the latest firmware.