### PR TITLE
Lighthouse as groundtruth

### DIFF
--- a/docs/functional-areas/lighthouse/positioning_methods.md
+++ b/docs/functional-areas/lighthouse/positioning_methods.md
@@ -29,3 +29,9 @@ the kalman estimator to be used to improve the estimate. The measurement model i
 sensor must be located in the plane that is defined by the base station geometry and sweep angle.
 
 One base station is enough to estimate the position using this method, but more base stations adds precission and redundancy.
+
+
+## Ground truth
+
+To use the lighthouse positioning as a ground truth measurement for your research, you should put ```LIGHTHOUSE_AS_GROUNDTRUTH = 1``` in your config.mk.
+ This will default the position estimator for lighthouse to be crossing beam (which you should not change), and you will be able to get the X, Y, Z position from the logs ```lighthouse.x/.y/.z```

--- a/src/modules/src/lighthouse/lighthouse_core.c
+++ b/src/modules/src/lighthouse/lighthouse_core.c
@@ -269,7 +269,11 @@ void lighthouseCoreSetLeds(lighthouseCoreLedState_t red, lighthouseCoreLedState_
 //     estimator as pre-calculated.
 // 1 = Sweep angles pushed into the estimator. Yaw error calculated outside the estimator
 //     and pushed to the estimator as a pre-calculated value.
+#ifdef LIGHTHOUSE_AS_GROUNDTRUTH
+static uint8_t estimationMethod = 0;
+#else
 static uint8_t estimationMethod = 1;
+#endif
 
 
 static void usePulseResultCrossingBeams(pulseProcessor_t *appState, pulseProcessorResult_t* angles, int basestation) {

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -265,7 +265,9 @@ static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulsePr
     if (isfinite(ext_pos.pos[0]) && isfinite(ext_pos.pos[1]) && isfinite(ext_pos.pos[2])) {
       ext_pos.stdDev = 0.01;
       ext_pos.source = MeasurementSourceLighthouse;
+  #ifdef LIGHTHOUSE_AS_GROUNDTRUTH
       estimatorEnqueuePosition(&ext_pos);
+  #endif
     }
   } else {
     deltaLog = 0;

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -107,3 +107,7 @@
 # CFLAGS += -DSTART_DISARMED
 # IDLE motor drive when armed, 0 = 0%, 65535 = 100% (the motors runs as long as the Crazyflie is armed)
 # CFLAGS += -DDEFAULT_IDLE_THRUST=5000
+
+## Lighthouse handling
+# If lighthouse will need to act as a ground truth (so not entered in the kalman filter)
+# LIGHTHOUSE_AS_GROUNDTRUTH = 1


### PR DESCRIPTION
Added an ifdef that disables the estimator send for the crossingbeam method so that the lighthouse can be used as a ground truth by reading the xyz from the log variables. It will also default the method to be crossing beam as well. 