### PR TITLE
fix some typos in comments

### DIFF
--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -167,7 +167,7 @@ void attitudeControllerGetActuatorOutput(int16_t* roll, int16_t* pitch, int16_t*
  */ 
 LOG_GROUP_START(pid_attitude)
 /**
- * @brief Propertional output roll
+ * @brief Proportional output roll
  */
 LOG_ADD(LOG_FLOAT, roll_outP, &pidRoll.outP)
 /**
@@ -179,11 +179,11 @@ LOG_ADD(LOG_FLOAT, roll_outI, &pidRoll.outI)
  */
 LOG_ADD(LOG_FLOAT, roll_outD, &pidRoll.outD)
 /**
- * @brief Propertional output pitch
+ * @brief Proportional output pitch
  */
 LOG_ADD(LOG_FLOAT, pitch_outP, &pidPitch.outP)
 /**
- * @brief Intergral output pitch
+ * @brief Integral output pitch
  */
 LOG_ADD(LOG_FLOAT, pitch_outI, &pidPitch.outI)
 /**
@@ -191,7 +191,7 @@ LOG_ADD(LOG_FLOAT, pitch_outI, &pidPitch.outI)
  */
 LOG_ADD(LOG_FLOAT, pitch_outD, &pidPitch.outD)
 /**
- * @brief Propertional output yaw
+ * @brief Proportional output yaw
  */
 LOG_ADD(LOG_FLOAT, yaw_outP, &pidYaw.outP)
 /**
@@ -209,11 +209,11 @@ LOG_GROUP_STOP(pid_attitude)
  */
 LOG_GROUP_START(pid_rate)
 /**
- * @brief Propertional output roll rate
+ * @brief Proportional output roll rate
  */
 LOG_ADD(LOG_FLOAT, roll_outP, &pidRollRate.outP)
 /**
- * @brief Intergral output roll rate
+ * @brief Integral output roll rate
  */
 LOG_ADD(LOG_FLOAT, roll_outI, &pidRollRate.outI)
 /**
@@ -221,11 +221,11 @@ LOG_ADD(LOG_FLOAT, roll_outI, &pidRollRate.outI)
  */
 LOG_ADD(LOG_FLOAT, roll_outD, &pidRollRate.outD)
 /**
- * @brief Propertional output pitch rate
+ * @brief Proportional output pitch rate
  */
 LOG_ADD(LOG_FLOAT, pitch_outP, &pidPitchRate.outP)
 /**
- * @brief Intergral output pitch rate
+ * @brief Integral output pitch rate
  */
 LOG_ADD(LOG_FLOAT, pitch_outI, &pidPitchRate.outI)
 /**
@@ -233,11 +233,11 @@ LOG_ADD(LOG_FLOAT, pitch_outI, &pidPitchRate.outI)
  */
 LOG_ADD(LOG_FLOAT, pitch_outD, &pidPitchRate.outD)
 /**
- * @brief Propertional output yaw rate
+ * @brief Proportional output yaw rate
  */
 LOG_ADD(LOG_FLOAT, yaw_outP, &pidYawRate.outP)
 /**
- * @brief Intergral output yaw rate
+ * @brief Integral output yaw rate
  */
 LOG_ADD(LOG_FLOAT, yaw_outI, &pidYawRate.outI)
 /**
@@ -253,11 +253,11 @@ LOG_GROUP_STOP(pid_rate)
  */
 PARAM_GROUP_START(pid_attitude)
 /**
- * @brief Propertional gain for the PID roll controller
+ * @brief Proportional gain for the PID roll controller
  */
 PARAM_ADD(PARAM_FLOAT, roll_kp, &pidRoll.kp)
 /**
- * @brief Intergral gain for the PID roll controller
+ * @brief Integral gain for the PID roll controller
  */
 PARAM_ADD(PARAM_FLOAT, roll_ki, &pidRoll.ki)
 /**
@@ -265,11 +265,11 @@ PARAM_ADD(PARAM_FLOAT, roll_ki, &pidRoll.ki)
  */
 PARAM_ADD(PARAM_FLOAT, roll_kd, &pidRoll.kd)
 /**
- * @brief Propertional gain for the PID pitch controller
+ * @brief Proportional gain for the PID pitch controller
  */
 PARAM_ADD(PARAM_FLOAT, pitch_kp, &pidPitch.kp)
 /**
- * @brief Intergral gain for the PID pitch controller
+ * @brief Integral gain for the PID pitch controller
  */
 PARAM_ADD(PARAM_FLOAT, pitch_ki, &pidPitch.ki)
 /**
@@ -277,11 +277,11 @@ PARAM_ADD(PARAM_FLOAT, pitch_ki, &pidPitch.ki)
  */
 PARAM_ADD(PARAM_FLOAT, pitch_kd, &pidPitch.kd)
 /**
- * @brief Propertional gain for the PID yaw controller
+ * @brief Proportional gain for the PID yaw controller
  */
 PARAM_ADD(PARAM_FLOAT, yaw_kp, &pidYaw.kp)
 /**
- * @brief Intergral gain for the PID yaw controller
+ * @brief Integral gain for the PID yaw controller
  */
 PARAM_ADD(PARAM_FLOAT, yaw_ki, &pidYaw.ki)
 /**
@@ -291,17 +291,16 @@ PARAM_ADD(PARAM_FLOAT, yaw_kd, &pidYaw.kd)
 PARAM_GROUP_STOP(pid_attitude)
 
 /**
- * Tuning settings for the gains of the PID
- * controller for the rate angels of the Crazyflie which consists
- * of the Yaw Pitch and Roll rates 
+ * Tuning settings for the gains of the PID controller for the rate angles of
+ * the Crazyflie, which consists of the yaw, pitch and roll rates 
  */
 PARAM_GROUP_START(pid_rate)
 /**
- * @brief Propertional gain for the PID roll rate controller
+ * @brief Proportional gain for the PID roll rate controller
  */
 PARAM_ADD(PARAM_FLOAT, roll_kp, &pidRollRate.kp)
 /**
- * @brief Intergral gain for the PID roll rate controller
+ * @brief Integral gain for the PID roll rate controller
  */
 PARAM_ADD(PARAM_FLOAT, roll_ki, &pidRollRate.ki)
 /**
@@ -309,11 +308,11 @@ PARAM_ADD(PARAM_FLOAT, roll_ki, &pidRollRate.ki)
  */
 PARAM_ADD(PARAM_FLOAT, roll_kd, &pidRollRate.kd)
 /**
- * @brief Propertional gain for the PID pitch rate controller
+ * @brief Proportional gain for the PID pitch rate controller
  */
 PARAM_ADD(PARAM_FLOAT, pitch_kp, &pidPitchRate.kp)
 /**
- * @brief Intergral gain for the PID pitch rate controller
+ * @brief Integral gain for the PID pitch rate controller
  */
 PARAM_ADD(PARAM_FLOAT, pitch_ki, &pidPitchRate.ki)
 /**
@@ -321,11 +320,11 @@ PARAM_ADD(PARAM_FLOAT, pitch_ki, &pidPitchRate.ki)
  */
 PARAM_ADD(PARAM_FLOAT, pitch_kd, &pidPitchRate.kd)
 /**
- * @brief Propertional gain for the PID yaw rate controller
+ * @brief Proportional gain for the PID yaw rate controller
  */
 PARAM_ADD(PARAM_FLOAT, yaw_kp, &pidYawRate.kp)
 /**
- * @brief Intergral gain for the PID yaw rate controller
+ * @brief Integral gain for the PID yaw rate controller
  */
 PARAM_ADD(PARAM_FLOAT, yaw_ki, &pidYawRate.ki)
 /**

--- a/src/modules/src/controller_indi.c
+++ b/src/modules/src/controller_indi.c
@@ -370,15 +370,15 @@ PARAM_ADD(PARAM_FLOAT, thrust_threshold, &thrust_threshold)
  */
 PARAM_ADD(PARAM_FLOAT, bound_ctrl_input, &bound_control_input)
 /**
- * @brief INDI  Attitude Roll control Propertional Gain
+ * @brief INDI  Attitude Roll control proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, roll_kp, &roll_kp)
 /**
- * @brief INDI Attitude Pitch control Propertional Gain
+ * @brief INDI Attitude Pitch control proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, pitch_kp, &pitch_kp)
 /**
- * @brief INDI Attitude Yaw control Propertional Gain
+ * @brief INDI Attitude Yaw control proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, yaw_kp, &yaw_kp)
 /**

--- a/src/modules/src/position_controller_indi.c
+++ b/src/modules/src/position_controller_indi.c
@@ -279,28 +279,28 @@ void positionControllerINDI(const sensorData_t *sensors,
 PARAM_GROUP_START(posCtrlIndi)
 
 /**
- * @brief INDI position controller X propertional gain
+ * @brief INDI position controller X proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, K_xi_x, &K_xi_x)
 /**
- * @brief INDI position controller Y propertional gain
+ * @brief INDI position controller Y proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, K_xi_y, &K_xi_y)
 /**
- * @brief INDI position controller Z propertional gain
+ * @brief INDI position controller Z proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, K_xi_z, &K_xi_z)
 
 /**
- * @brief INDI velocity controller X propertional gain
+ * @brief INDI velocity controller X proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, K_dxi_x, &K_dxi_x)
 /**
- * @brief INDI velocity controller Y propertional gain
+ * @brief INDI velocity controller Y proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, K_dxi_y, &K_dxi_y)
 /**
- * @brief INDI velocity controller Z propertional gain
+ * @brief INDI velocity controller Z proportional gain
  */
 PARAM_ADD(PARAM_FLOAT, K_dxi_z, &K_dxi_z)
 

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -271,11 +271,11 @@ LOG_ADD(LOG_FLOAT, targetY, &this.pidY.pid.desired)
 LOG_ADD(LOG_FLOAT, targetZ, &this.pidZ.pid.desired)
 
 /**
- * @brief PID propertional output position x
+ * @brief PID proportional output position x
  */
 LOG_ADD(LOG_FLOAT, Xp, &this.pidX.pid.outP)
 /**
- * @brief PID Intergral output position x
+ * @brief PID Integral output position x
  */
 LOG_ADD(LOG_FLOAT, Xi, &this.pidX.pid.outI)
 /**
@@ -284,11 +284,11 @@ LOG_ADD(LOG_FLOAT, Xi, &this.pidX.pid.outI)
 LOG_ADD(LOG_FLOAT, Xd, &this.pidX.pid.outD)
 
 /**
- * @brief PID propertional output position y
+ * @brief PID proportional output position y
  */
 LOG_ADD(LOG_FLOAT, Yp, &this.pidY.pid.outP)
 /**
- * @brief PID Intergral output position y
+ * @brief PID Integral output position y
  */
 LOG_ADD(LOG_FLOAT, Yi, &this.pidY.pid.outI)
 /**
@@ -297,11 +297,11 @@ LOG_ADD(LOG_FLOAT, Yi, &this.pidY.pid.outI)
 LOG_ADD(LOG_FLOAT, Yd, &this.pidY.pid.outD)
 
 /**
- * @brief PID propertional output position z
+ * @brief PID proportional output position z
  */
 LOG_ADD(LOG_FLOAT, Zp, &this.pidZ.pid.outP)
 /**
- * @brief PID Intergral output position z
+ * @brief PID Integral output position z
  */
 LOG_ADD(LOG_FLOAT, Zi, &this.pidZ.pid.outI)
 /**
@@ -310,11 +310,11 @@ LOG_ADD(LOG_FLOAT, Zi, &this.pidZ.pid.outI)
 LOG_ADD(LOG_FLOAT, Zd, &this.pidZ.pid.outD)
 
 /**
- * @brief PID propertional output velocity x
+ * @brief PID proportional output velocity x
  */
 LOG_ADD(LOG_FLOAT, VXp, &this.pidVX.pid.outP)
 /**
- * @brief PID intergral output velocity x
+ * @brief PID integral output velocity x
  */
 LOG_ADD(LOG_FLOAT, VXi, &this.pidVX.pid.outI)
 /**
@@ -323,11 +323,11 @@ LOG_ADD(LOG_FLOAT, VXi, &this.pidVX.pid.outI)
 LOG_ADD(LOG_FLOAT, VXd, &this.pidVX.pid.outD)
 
 /**
- * @brief PID propertional output velocity z
+ * @brief PID proportional output velocity z
  */
 LOG_ADD(LOG_FLOAT, VZp, &this.pidVZ.pid.outP)
 /**
- * @brief PID intergral output velocity z
+ * @brief PID integral output velocity z
  */
 LOG_ADD(LOG_FLOAT, VZi, &this.pidVZ.pid.outI)
 /**
@@ -345,11 +345,11 @@ LOG_GROUP_STOP(posCtl)
  */
 PARAM_GROUP_START(velCtlPid)
 /**
- * @brief Propertional gain for the velocity PID in the body X direction
+ * @brief Proportional gain for the velocity PID in the body X direction
  */
 PARAM_ADD(PARAM_FLOAT, vxKp, &this.pidVX.pid.kp)
 /**
- * @brief Intergral gain for the velocity PID in the body X direction
+ * @brief Integral gain for the velocity PID in the body X direction
  */
 PARAM_ADD(PARAM_FLOAT, vxKi, &this.pidVX.pid.ki)
 /**
@@ -358,11 +358,11 @@ PARAM_ADD(PARAM_FLOAT, vxKi, &this.pidVX.pid.ki)
 PARAM_ADD(PARAM_FLOAT, vxKd, &this.pidVX.pid.kd)
 
 /**
- * @brief Propertional gain for the velocity PID in the body Y direction
+ * @brief Proportional gain for the velocity PID in the body Y direction
  */
 PARAM_ADD(PARAM_FLOAT, vyKp, &this.pidVY.pid.kp)
 /**
- * @brief Intergral gain for the velocity PID in the body Y direction
+ * @brief Integral gain for the velocity PID in the body Y direction
  */
 PARAM_ADD(PARAM_FLOAT, vyKi, &this.pidVY.pid.ki)
 /**
@@ -371,11 +371,11 @@ PARAM_ADD(PARAM_FLOAT, vyKi, &this.pidVY.pid.ki)
 PARAM_ADD(PARAM_FLOAT, vyKd, &this.pidVY.pid.kd)
 
 /**
- * @brief Propertional gain for the velocity PID in the body Z direction
+ * @brief Proportional gain for the velocity PID in the body Z direction
  */
 PARAM_ADD(PARAM_FLOAT, vzKp, &this.pidVZ.pid.kp)
 /**
- * @brief Intergral gain for the velocity PID in the body Z direction
+ * @brief Integral gain for the velocity PID in the body Z direction
  */
 PARAM_ADD(PARAM_FLOAT, vzKi, &this.pidVZ.pid.ki)
 /**
@@ -393,11 +393,11 @@ PARAM_GROUP_STOP(velCtlPid)
  */
 PARAM_GROUP_START(posCtlPid)
 /**
- * @brief Propertional gain for the position PID in the global X direction
+ * @brief Proportional gain for the position PID in the global X direction
  */
 PARAM_ADD(PARAM_FLOAT, xKp, &this.pidX.pid.kp)
 /**
- * @brief Propertional gain for the position PID in the global X direction
+ * @brief Proportional gain for the position PID in the global X direction
  */
 PARAM_ADD(PARAM_FLOAT, xKi, &this.pidX.pid.ki)
 /**
@@ -406,11 +406,11 @@ PARAM_ADD(PARAM_FLOAT, xKi, &this.pidX.pid.ki)
 PARAM_ADD(PARAM_FLOAT, xKd, &this.pidX.pid.kd)
 
 /**
- * @brief Propertional gain for the position PID in the global Y direction
+ * @brief Proportional gain for the position PID in the global Y direction
  */
 PARAM_ADD(PARAM_FLOAT, yKp, &this.pidY.pid.kp)
 /**
- * @brief Intergral gain for the position PID in the global Y direction
+ * @brief Integral gain for the position PID in the global Y direction
  */
 PARAM_ADD(PARAM_FLOAT, yKi, &this.pidY.pid.ki)
 /**
@@ -419,11 +419,11 @@ PARAM_ADD(PARAM_FLOAT, yKi, &this.pidY.pid.ki)
 PARAM_ADD(PARAM_FLOAT, yKd, &this.pidY.pid.kd)
 
 /**
- * @brief Propertional gain for the position PID in the global Z direction
+ * @brief Proportional gain for the position PID in the global Z direction
  */
 PARAM_ADD(PARAM_FLOAT, zKp, &this.pidZ.pid.kp)
 /**
- * @brief Intergral gain for the position PID in the global Z direction
+ * @brief Integral gain for the position PID in the global Z direction
  */
 PARAM_ADD(PARAM_FLOAT, zKi, &this.pidZ.pid.ki)
 /**

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -327,7 +327,7 @@ PARAM_ADD_CORE(PARAM_UINT8, estimator, &estimatorType)
  */
 PARAM_ADD_CORE(PARAM_UINT8, controller, &controllerType)
 /**
- * @brief If set to nonzero will turn of power
+ * @brief If set to nonzero will turn off power
  */
 PARAM_ADD_CORE(PARAM_UINT8, stop, &emergencyStop)
 PARAM_GROUP_STOP(stabilizer)

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -133,11 +133,11 @@ LOG_GROUP_START(sys)
  */
 LOG_ADD_CORE(LOG_UINT8, canfly, &canFly)
 /**
- * @brief Nonzero if the system think it is flying
+ * @brief Nonzero if the system thinks it is flying
  */
 LOG_ADD_CORE(LOG_UINT8, isFlying, &isFlying)
 /**
- * @brief Nonzero if the system think it is tumbled/crashed
+ * @brief Nonzero if the system thinks it is tumbled/crashed
  */
 LOG_ADD_CORE(LOG_UINT8, isTumbled, &isTumbled)
 LOG_GROUP_STOP(sys)


### PR DESCRIPTION
This PR fixes some typos in the documentation snippets of the parameters / log variables.