### PR TITLE
Barometer based altitude hold

### DIFF
--- a/src/modules/interface/pid.h
+++ b/src/modules/interface/pid.h
@@ -198,6 +198,6 @@ void pidSetDt(PidObject* pid, const float dt);
  * @param[in] cutoffFreq   Frequency to set the low pass filter cutoff at
  * @param[in] enableDFilter Enable setting for the D lowpass filter
 */
-void filterReset(PidObject* pid, const float samplingRate, const float cutoffFreq, bool enableDFilter)
+void filterReset(PidObject* pid, const float samplingRate, const float cutoffFreq, bool enableDFilter);
 
 #endif /* PID_H_ */

--- a/src/modules/interface/pid.h
+++ b/src/modules/interface/pid.h
@@ -189,4 +189,15 @@ void pidSetKd(PidObject* pid, const float kd);
  * @param[in] dt    Delta time
  */
 void pidSetDt(PidObject* pid, const float dt);
+
+/**
+ * Reset the Dfilter and set cutoff frequency
+ *
+ * @param[out] pid   A pointer to the pid object to initialize.
+ * @param[in] samplingRate Frequency the update will be called
+ * @param[in] cutoffFreq   Frequency to set the low pass filter cutoff at
+ * @param[in] enableDFilter Enable setting for the D lowpass filter
+*/
+void filterReset(PidObject* pid, const float samplingRate, const float cutoffFreq, bool enableDFilter)
+
 #endif /* PID_H_ */

--- a/src/modules/interface/position_controller.h
+++ b/src/modules/interface/position_controller.h
@@ -32,7 +32,7 @@
 // a 3D position setpoint
 void positionControllerInit();
 void positionControllerResetAllPID();
-void positionControllerResetAllfilters()
+void positionControllerResetAllfilters();
 void positionController(float* thrust, attitude_t *attitude, setpoint_t *setpoint,
                                                              const state_t *state);
 void velocityController(float* thrust, attitude_t *attitude, setpoint_t *setpoint,

--- a/src/modules/interface/position_controller.h
+++ b/src/modules/interface/position_controller.h
@@ -32,6 +32,7 @@
 // a 3D position setpoint
 void positionControllerInit();
 void positionControllerResetAllPID();
+void positionControllerResetAllfilters()
 void positionController(float* thrust, attitude_t *attitude, setpoint_t *setpoint,
                                                              const state_t *state);
 void velocityController(float* thrust, attitude_t *attitude, setpoint_t *setpoint,

--- a/src/modules/src/pid.c
+++ b/src/modules/src/pid.c
@@ -25,6 +25,10 @@
  * pid.c - implementation of the PID regulator
  */
 
+#ifdef IMPROVED_BARO_Z_HOLD
+#define PID_FILTER_ALL
+#endif
+
 #include "pid.h"
 #include "num.h"
 #include <math.h>
@@ -66,7 +70,7 @@ float pidUpdate(PidObject* pid, const float measured, const bool updateError)
     output += pid->outP;
 
     float deriv = (pid->error - pid->prevError) / pid->dt;
-    #ifdef IMPROVED_BARO_Z_HOLD
+    #ifdef PID_FILTER_ALL
       pid->deriv = deriv;
     #else
       if (pid->enableDFilter){
@@ -93,7 +97,7 @@ float pidUpdate(PidObject* pid, const float measured, const bool updateError)
     pid->outI = pid->ki * pid->integ;
     output += pid->outI;
     
-    #ifdef IMPROVED_BARO_Z_HOLD
+    #ifdef PID_FILTER_ALL
       //filter complete output instead of only D component to compensate for increased noise from increased barometer influence
       if (pid->enableDFilter)
       {

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -74,7 +74,9 @@ static const float thrustScale = 1000.0f;
 
 #define DT (float)(1.0f/POSITION_RATE)
 #define POSITION_LPF_CUTOFF_FREQ 20.0f
+#define ZVELOCITY_LPF_CUTOFF_FREQ 0.7f
 #define POSITION_LPF_ENABLE true
+
 
 #ifndef UNIT_TEST
 static struct this_s this = {
@@ -98,9 +100,9 @@ static struct this_s this = {
 
   .pidVZ = {
     .init = {
-      .kp = 25,
-      .ki = 15,
-      .kd = 0,
+      .kp = 3.0f,
+      .ki = 1.0f,
+      .kd = 1.5f, //kd can be lowered for improved stability, but results in slower response time.
     },
     .pid.dt = DT,
   },
@@ -132,7 +134,7 @@ static struct this_s this = {
     .pid.dt = DT,
   },
 
-  .thrustBase = 36000,
+  .thrustBase = 38000,
   .thrustMin  = 20000,
 };
 #endif
@@ -151,7 +153,7 @@ void positionControllerInit()
   pidInit(&this.pidVY.pid, this.pidVY.setpoint, this.pidVY.init.kp, this.pidVY.init.ki, this.pidVY.init.kd,
       this.pidVY.pid.dt, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
   pidInit(&this.pidVZ.pid, this.pidVZ.setpoint, this.pidVZ.init.kp, this.pidVZ.init.ki, this.pidVZ.init.kd,
-      this.pidVZ.pid.dt, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+      this.pidVZ.pid.dt, POSITION_RATE, ZVELOCITY_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
 }
 
 static float runPid(float input, struct pidAxis_s *axis, float setpoint, float dt) {
@@ -231,6 +233,15 @@ void positionControllerResetAllPID()
   pidReset(&this.pidVX.pid);
   pidReset(&this.pidVY.pid);
   pidReset(&this.pidVZ.pid);
+}
+
+void positionControllerResetAllfilters() {
+  filterReset(&this.pidX.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  filterReset(&this.pidY.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  filterReset(&this.pidZ.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  filterReset(&this.pidVX.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  filterReset(&this.pidVY.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  filterReset(&this.pidVZ.pid, POSITION_RATE, ZVELOCITY_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
 }
 
 /**

--- a/src/modules/src/position_estimator_altitude.c
+++ b/src/modules/src/position_estimator_altitude.c
@@ -51,7 +51,11 @@ static struct selfState_s state = {
   .estimatedZ = 0.0f,
   .velocityZ = 0.0f,
   .estAlphaZrange = 0.90f,
-  .estAlphaAsl = 0.90f,
+  #ifdef IMPROVED_BARO_Z_HOLD
+    .estAlphaAsl = 0.90f,
+  #else
+    .estAlphaAsl = 0.997f,
+  #endif
   .velocityFactor = 1.0f,
   .vAccDeadband = 0.04f,
   .velZAlpha = 0.995f,
@@ -100,8 +104,12 @@ static void positionEstimateInternal(state_t* estimate, const baro_t* baro, cons
       filteredZ = (state->estAlphaAsl       ) * state->estimatedZ +
                   (1.0f - state->estAlphaAsl) * baro->asl;
     }
-    // Use asl as base and add velocity changes.
-    state->estimatedZ = filteredZ;// +(state->velocityFactor * state->velocityZ * dt);
+    #ifdef IMPROVED_BARO_Z_HOLD
+      state->estimatedZ = filteredZ;
+    #else
+      // Use asl as base and add velocity changes.
+      state->estimatedZ = filteredZ + (state->velocityFactor * state->velocityZ * dt);
+    #endif
   }
 
   estimate->position.x = 0.0f;

--- a/src/modules/src/position_estimator_altitude.c
+++ b/src/modules/src/position_estimator_altitude.c
@@ -51,11 +51,7 @@ static struct selfState_s state = {
   .estimatedZ = 0.0f,
   .velocityZ = 0.0f,
   .estAlphaZrange = 0.90f,
-  #ifdef IMPROVED_BARO_Z_HOLD
-    .estAlphaAsl = 0.90f,
-  #else
-    .estAlphaAsl = 0.997f,
-  #endif
+  .estAlphaAsl = 0.90f,
   .velocityFactor = 1.0f,
   .vAccDeadband = 0.04f,
   .velZAlpha = 0.995f,

--- a/src/modules/src/position_estimator_altitude.c
+++ b/src/modules/src/position_estimator_altitude.c
@@ -51,7 +51,7 @@ static struct selfState_s state = {
   .estimatedZ = 0.0f,
   .velocityZ = 0.0f,
   .estAlphaZrange = 0.90f,
-  .estAlphaAsl = 0.997f,
+  .estAlphaAsl = 0.90f,
   .velocityFactor = 1.0f,
   .vAccDeadband = 0.04f,
   .velZAlpha = 0.995f,
@@ -101,7 +101,7 @@ static void positionEstimateInternal(state_t* estimate, const baro_t* baro, cons
                   (1.0f - state->estAlphaAsl) * baro->asl;
     }
     // Use asl as base and add velocity changes.
-    state->estimatedZ = filteredZ + (state->velocityFactor * state->velocityZ * dt);
+    state->estimatedZ = filteredZ;// +(state->velocityFactor * state->velocityZ * dt);
   }
 
   estimate->position.x = 0.0f;


### PR DESCRIPTION
Improved Altitude hold assisted mode using only the barometer and the complementary filter.
Using more of the barometer data in the estimation which results in a noisier estimation but better response for the PID.
Moved the D-filter from only the D component of the PID to the entire output. This is done to counteract the noise generated by the increased barometer influence which causes the P to also be noisy. Both the filter and PID are reset on initiating the assisted mode. Tweaked PID vallues and D-filter cutoff frequency for VZ to increase performance.

These PID changes do have an influence on the unassisted thrust output as well, might need to put them behind a define flag.