### PR TITLE
flowdeck_v1v2: Fail test if init failed

### DIFF
--- a/src/deck/drivers/src/flowdeck_v1v2.c
+++ b/src/deck/drivers/src/flowdeck_v1v2.c
@@ -184,6 +184,7 @@ static bool flowdeck1Test()
 {
   if (!isInit1) {
     DEBUG_PRINT("Error while initializing the PMW3901 sensor\n");
+    return false;
   }
 
   // Test the VL53L0 driver
@@ -229,6 +230,7 @@ static bool flowdeck2Test()
 {
   if (!isInit2) {
     DEBUG_PRINT("Error while initializing the PMW3901 sensor\n");
+    return false;
   }
 
   // Test the VL53L1 driver


### PR DESCRIPTION
Right now the self test can pass even if we have a faulty flow deck, as
long as the zRanger test passes.
