### PR TITLE
stabilizer: Update log documentation on IMU sensors

### DIFF
--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -493,7 +493,13 @@ LOG_ADD(LOG_UINT32, intToOut, &inToOutLatency)
 LOG_GROUP_STOP(stabilizer)
 
 /**
- * Log group for accelerometer sensor measurement. Compensated for a miss-aligned by gravity at startup.
+ * Log group for accelerometer sensor measurement, based on body frame.
+ * Compensated for a miss-alignment by gravity at startup.
+ *
+ * For data on measurement noise please see information from the sensor
+ * manufacturer. To see what accelerometer sensor is in your Crazyflie or Bolt
+ * please check documentation on the Bitcraze webpage or check the parameter
+ * group `imu_sensors`.
  */
 LOG_GROUP_START(acc)
 
@@ -522,7 +528,12 @@ LOG_GROUP_STOP(accSec)
 #endif
 
 /**
- * Log group for the barometer
+ * Log group for the barometer.
+ *
+ * For data on measurement noise please see information from the sensor
+ * manufacturer. To see what barometer sensor is in your Crazyflie or Bolt
+ * please check documentation on the Bitcraze webpage or check the parameter
+ * group `imu_sensors`.
  */
 LOG_GROUP_START(baro)
 
@@ -544,6 +555,11 @@ LOG_GROUP_STOP(baro)
 
 /**
  * Log group for gyroscopes.
+ *
+ * For data on measurement noise please see information from the sensor
+ * manufacturer. To see what gyroscope sensor is in your Crazyflie or Bolt
+ * please check documentation on the Bitcraze webpage or check the parameter
+ * group `imu_sensors`.
  */
 LOG_GROUP_START(gyro)
 


### PR DESCRIPTION
This was provoced by a [comment](https://github.com/bitcraze/crazyflie-firmware/commit/4c2b1a57e8a40697efe9c28da43ebf85c9dcb38c#commitcomment-53198019) on a commit about documentation on the (acc) log group.