### PR TITLE
allow modifying the name of the compiled binary by setting PROG in the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ ifeq ($(LTO), 1)
 endif
 
 #Program name
-PROG = $(PLATFORM)
+PROG ?= $(PLATFORM)
 #Where to compile the .o
 BIN = bin
 VPATH += $(BIN)


### PR DESCRIPTION
This PR adds support for overriding the name of the compiled firmware binary by setting `PROG` from the command line or from another Makefile; e.g., one can now do fancy stuff this:

```sh
PROG=crazyflie-firmware-$(git describe) make
```

This will build the firmware in a way that the name of the Git revision is included in the filename. This is useful for archival purposes. One other possible use-case is that when compiling a Crazyflie app, you can override the name of the firmware in the app makefile so you can easily identify which app was built in a particular binary.
