### PR TITLE
added support for motor test on brushless motors

### DIFF
--- a/src/drivers/interface/motors.h
+++ b/src/drivers/interface/motors.h
@@ -216,6 +216,13 @@ typedef struct
   void (*preloadConfig)(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload);
 } MotorPerifDef;
 
+typedef struct {
+  uint16_t onPeriodMsec;
+  uint16_t offPeriodMsec;
+  uint16_t varianceMeasurementStartMsec;
+  uint16_t onPeriodPWMRatio;
+} MotorHealthTestDef;
+
 /**
  * Motor mapping configurations
  */
@@ -272,6 +279,12 @@ void motorsTestTask(void* params);
  *     motorsBeep(false, 0, 0); *
  * */
 void motorsBeep(int id, bool enable, uint16_t frequency, uint16_t ratio);
+
+/**
+ * Retrieve the health test settings of the given motor. This allows us to use
+ * different health test timings and PWM ratios for brushed and brushless motors.
+ */
+const MotorHealthTestDef* motorsGetHealthTestSettings(uint32_t id);
 
 #endif /* __MOTORS_H__ */
 

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -72,7 +72,7 @@ const MotorHealthTestDef brushlessMotorHealthTestSettings = {
   /* onPeriodMsec = */ 2000,
   /* offPeriodMsec = */ 1000,
   /* varianceMeasurementStartMsec = */ 1000,
-  /* onPeriodPWMRatio = */ 0x2700,
+  /* onPeriodPWMRatio = */ 0 /* user must set health.propTestPWMRatio explicitly */
 };
 
 const MotorHealthTestDef unknownMotorHealthTestSettings = {

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -61,6 +61,27 @@ const uint32_t MOTORS[] = { MOTOR_M1, MOTOR_M2, MOTOR_M3, MOTOR_M4 };
 
 const uint16_t testsound[NBR_OF_MOTORS] = {A4, A5, F5, D5 };
 
+const MotorHealthTestDef brushedMotorHealthTestSettings = {
+  /* onPeriodMsec = */ 50,
+  /* offPeriodMsec = */ 950,
+  /* varianceMeasurementStartMsec = */ 0,
+  /* onPeriodPWMRatio = */ 0xFFFF,
+};
+
+const MotorHealthTestDef brushlessMotorHealthTestSettings = {
+  /* onPeriodMsec = */ 2000,
+  /* offPeriodMsec = */ 1000,
+  /* varianceMeasurementStartMsec = */ 1000,
+  /* onPeriodPWMRatio = */ 0x2700,
+};
+
+const MotorHealthTestDef unknownMotorHealthTestSettings = {
+  /* onPeriodMsec = */ 0,
+  /* offPeriodMseec = */ 0,
+  /* varianceMeasurementStartMsec = */ 0,
+  /* onPeriodPWMRatio = */ 0
+};
+
 static bool isInit = false;
 
 /* Private functions */
@@ -374,6 +395,27 @@ void motorsPlayMelody(uint16_t *notes)
     motorsPlayTone(note, duration);
   } while (duration != 0);
 }
+
+const MotorHealthTestDef* motorsGetHealthTestSettings(uint32_t id)
+{
+  if (id >= NBR_OF_MOTORS)
+  {
+    return &unknownMotorHealthTestSettings;
+  }
+  else if (motorMap[id]->drvType == BRUSHLESS)
+  {
+    return &brushlessMotorHealthTestSettings;
+  }
+  else if (motorMap[id]->drvType == BRUSHED)
+  {
+    return &brushedMotorHealthTestSettings;
+  }
+  else
+  {
+    return &unknownMotorHealthTestSettings;
+  }
+}
+
 /**
  * Logging variables of the motors PWM output
  */

--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -47,12 +47,16 @@
 
 #include "static_mem.h"
 
+#ifndef DEFAULT_PROP_TEST_PWM_RATIO
+#  define DEFAULT_PROP_TEST_PWM_RATIO 0
+#endif
+
 #define PROPTEST_NBR_OF_VARIANCE_VALUES   100
 
 static bool startPropTest = false;
 static bool startBatTest = false;
 
-static uint16_t propTestPWMRatio = 0;
+static uint16_t propTestPWMRatio = DEFAULT_PROP_TEST_PWM_RATIO;
 
 static uint32_t i = 0;
 NO_DMA_CCM_SAFE_ZERO_INIT static float accX[PROPTEST_NBR_OF_VARIANCE_VALUES];

--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -52,6 +52,8 @@
 static bool startPropTest = false;
 static bool startBatTest = false;
 
+static uint16_t propTestPWMRatio = 0;
+
 static uint32_t i = 0;
 NO_DMA_CCM_SAFE_ZERO_INIT static float accX[PROPTEST_NBR_OF_VARIANCE_VALUES];
 NO_DMA_CCM_SAFE_ZERO_INIT static float accY[PROPTEST_NBR_OF_VARIANCE_VALUES];
@@ -202,7 +204,7 @@ void healthRunTests(sensorData_t *sensors)
 
     if (i == 1 && healthTestSettings->onPeriodMsec > 0)
     {
-      motorsSetRatio(motorToTest, healthTestSettings->onPeriodPWMRatio);
+      motorsSetRatio(motorToTest, propTestPWMRatio > 0 ? propTestPWMRatio : healthTestSettings->onPeriodPWMRatio);
     }
     else if (i == healthTestSettings->onPeriodMsec)
     {
@@ -328,6 +330,11 @@ PARAM_ADD_CORE(PARAM_UINT8, startPropTest, &startPropTest)
  * @brief Set nonzero to initiate test of battery
  */
 PARAM_ADD_CORE(PARAM_UINT8, startBatTest, &startBatTest)
+
+/**
+ * @brief PWM ratio to use when testing propellers. Required for brushless motors.
+ */
+PARAM_ADD_CORE(PARAM_UINT16, propTestPWMRatio, &propTestPWMRatio)
 
 PARAM_GROUP_STOP(health)
 

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -107,6 +107,8 @@
 # CFLAGS += -DSTART_DISARMED
 # IDLE motor drive when armed, 0 = 0%, 65535 = 100% (the motors runs as long as the Crazyflie is armed)
 # CFLAGS += -DDEFAULT_IDLE_THRUST=5000
+# Default PWM ratio to use when testing the propellers
+# CFLAGS += -DDEFAULT_PROP_TEST_PWM_RATIO=10000
 
 ## Lighthouse handling
 # If lighthouse will need to act as a ground truth (so not entered in the kalman filter)


### PR DESCRIPTION
The "Propeller test" button on the Console tab of the Crazyflie client does not work with brushless motors at the moment because the 50 msec period during which the motor is operated at full throttle is not long enough for a brushless motor to spin up. (At least definitely not with the motors that we have here in the lab). This PR adds support for testing brushless motors by making it possible to use different spinup durations and PWM ratios, depending on whether the motor is brushed or brushless.

Notable changes in the brushless test (the brushed test remains the same):

* The motor spins for 2 seconds instead of 50 msec.
* The delay between consecutive motor tests is 1 second instead of 950 msec.
* The PWM ratio when the motor spins is approximately 15% instead of 100%.
* XY (and Z) acceleration is measured for 100 msecs; the measurement starts 1 second after spinning up the motor.

These settings are identical to what we use on our outdoor drones running ArduCopter; feel free to change the parameters if you feel fit.

The "beep-beep-beep" warning for motors that have a large XY vibration is not implemented for brushless motors yet; this could be the subject of another PR, I am soliciting feedback on this one before proceeding further.

I was a bit unsure whether the parameters of the health test should be in `motors.c` or `health.c`; right now they are in `motors.c` because this way the motor driver can keep it private whether the motor is brushed or brushless. The alternative would be to add a `motorsGetType(uint32_t id)` function that returns the type of the motor; the health module could then check whether it's brushed or brushless and we can then move the parameters there. Let me know which solution you feel more comfortable with in the long run.