### PR TITLE
Kalman filter modification for constant altitude flight 

### DIFF
--- a/src/modules/interface/estimator.h
+++ b/src/modules/interface/estimator.h
@@ -43,6 +43,7 @@ typedef enum {
   MeasurementTypePose,
   MeasurementTypeDistance,
   MeasurementTypeTOF,
+  MeasurementTypeUpTOF,
   MeasurementTypeAbsoluteHeight,
   MeasurementTypeFlow,
   MeasurementTypeYawError,
@@ -62,6 +63,7 @@ typedef struct
     poseMeasurement_t pose;
     distanceMeasurement_t distance;
     tofMeasurement_t tof;
+    tofMeasurement_t uptof;
     heightMeasurement_t height;
     flowMeasurement_t flow;
     yawErrorMeasurement_t yawError;
@@ -120,6 +122,14 @@ static inline void estimatorEnqueueTOF(const tofMeasurement_t *tof)
   measurement_t m;
   m.type = MeasurementTypeTOF;
   m.data.tof = *tof;
+  estimatorEnqueue(&m);
+}
+
+static inline void estimatorEnqueueUpTOF(const tofMeasurement_t *tof)
+{
+  measurement_t m;
+  m.type = MeasurementTypeUpTOF;
+  m.data.uptof = *tof;
   estimatorEnqueue(&m);
 }
 

--- a/src/modules/interface/kalman_core/kalman_core.h
+++ b/src/modules/interface/kalman_core/kalman_core.h
@@ -59,7 +59,7 @@
 // Indexes to access the quad's state, stored as a column vector
 typedef enum
 {
-  KC_STATE_X, KC_STATE_Y, KC_STATE_Z, KC_STATE_PX, KC_STATE_PY, KC_STATE_PZ, KC_STATE_D0, KC_STATE_D1, KC_STATE_D2, KC_STATE_DIM
+  KC_STATE_X, KC_STATE_Y, KC_STATE_Z, KC_STATE_PX, KC_STATE_PY, KC_STATE_PZ, KC_STATE_D0, KC_STATE_D1, KC_STATE_D2, KC_STATE_F, KC_STATE_R, KC_STATE_DIM
 } kalmanCoreStateIdx_t;
 
 
@@ -74,6 +74,10 @@ typedef struct {
    * - D0, D1, D2: attitude error
    *
    * For more information, refer to the paper
+   * 
+   * Add two states for better z estimation using range measurements:
+   * - F: Estimated distance from the starting z position to what is below the CF
+   * - R: Estimated distance from the starting z position to the current roof above the CF
    */
   float S[KC_STATE_DIM];
 
@@ -93,6 +97,9 @@ typedef struct {
   bool resetEstimation;
 
   float baroReferenceHeight;
+
+  // Flag to signal if R (roof height estimate) has been intialized
+  bool stateRInitialized;
 } kalmanCoreData_t;
 
 

--- a/src/modules/interface/kalman_core/mm_flow.h
+++ b/src/modules/interface/kalman_core/mm_flow.h
@@ -29,3 +29,6 @@
 
 // Measurements of flow (dnx, dny)
 void kalmanCoreUpdateWithFlow(kalmanCoreData_t* this, const flowMeasurement_t *flow, const Axis3f *gyro);
+
+// Kalman update with optical flow measurements using F (floor height estimate)
+void kalmanCoreUpdateWithFlowUsingF(kalmanCoreData_t* this, const flowMeasurement_t *flow, const Axis3f *gyro);

--- a/src/modules/interface/kalman_core/mm_tof.h
+++ b/src/modules/interface/kalman_core/mm_tof.h
@@ -29,3 +29,9 @@
 
 // Measurements of TOF from laser sensor
 void kalmanCoreUpdateWithTof(kalmanCoreData_t* this, tofMeasurement_t *tof);
+
+// Kalman update using the TOF from downward laser sensor and F (floor height estimate)
+void kalmanCoreUpdateWithTofUsingF(kalmanCoreData_t* this, tofMeasurement_t *tof);
+
+// Kalman update using the TOF from upward laser sensor and R (roof height estimate)
+void kalmanCoreUpdateWithUpTofUsingR(kalmanCoreData_t* this, tofMeasurement_t *tof);

--- a/src/modules/interface/range.h
+++ b/src/modules/interface/range.h
@@ -61,3 +61,12 @@ float rangeGet(rangeDirection_t direction);
  * @param timeStamp The time when the range was sampled (in sys ticks)
  */
 void rangeEnqueueDownRangeInEstimator(float distance, float stdDev, uint32_t timeStamp);
+
+/**
+ * Enqueue a upward range measurement for distance to the roof in the current estimator.
+ *
+ * @param distance Distance to the roof (m)
+ * @param stdDev The standard deviation of the range sample
+ * @param timeStamp The time when the range was sampled (in sys ticks)
+ */
+void rangeEnqueueUpRangeInEstimator(float distance, float stdDev, uint32_t timeStamp); 

--- a/src/modules/src/estimator_kalman.c
+++ b/src/modules/src/estimator_kalman.c
@@ -120,6 +120,9 @@ static StaticSemaphore_t dataMutexBuffer;
 static bool robustTwr = false;
 static bool robustTdoa = false;
 
+// Nonzero to take advantage of the extended state (F and R) to get a better estimate of Z
+static bool useFAndR = true;
+
 /**
  * Quadrocopter State
  *
@@ -129,6 +132,10 @@ static bool robustTdoa = false;
  * - D0, D1, D2: attitude error
  *
  * For more information, refer to the paper
+ * 
+ * Add two states for better z estimation using range measurements:
+ * - F: Estimated distance from the starting z position to what is below the CF
+ * - R: Estimated distance from the starting z position to the current roof above the CF
  */
 
 NO_DMA_CCM_SAFE_ZERO_INIT static kalmanCoreData_t coreData;
@@ -372,15 +379,34 @@ static bool updateQueuedMeasurements(const uint32_t tick) {
         doneUpdate = true;
         break;
       case MeasurementTypeTOF:
-        kalmanCoreUpdateWithTof(&coreData, &m.data.tof);
+       if(useFAndR){
+          // Tof update using the estimated height of the floor (f)
+          kalmanCoreUpdateWithTofUsingF(&coreData, &m.data.tof);
+        }else{
+          // Standard Tof update
+          kalmanCoreUpdateWithTof(&coreData, &m.data.tof);
+        }
         doneUpdate = true;
+        break;
+      case MeasurementTypeUpTOF:
+        if(useFAndR){
+          // Tof update using the upward range measurement and the estimated height of the roof (r)
+          kalmanCoreUpdateWithUpTofUsingR(&coreData, &m.data.tof);
+          doneUpdate = true;
+        }
         break;
       case MeasurementTypeAbsoluteHeight:
         kalmanCoreUpdateWithAbsoluteHeight(&coreData, &m.data.height);
         doneUpdate = true;
         break;
       case MeasurementTypeFlow:
-        kalmanCoreUpdateWithFlow(&coreData, &m.data.flow, &gyroLatest);
+        if(useFAndR){
+          // Flow update using the estimated height of the floor 
+          kalmanCoreUpdateWithFlowUsingF(&coreData, &m.data.flow, &gyroLatest);
+        }else{
+          // Standard flow update
+          kalmanCoreUpdateWithFlow(&coreData, &m.data.flow, &gyroLatest);
+        }
         doneUpdate = true;
         break;
       case MeasurementTypeYawError:
@@ -506,6 +532,14 @@ LOG_GROUP_START(kalman)
   */
   LOG_ADD(LOG_FLOAT, stateD2, &coreData.S[KC_STATE_D2])
   /**
+  * @brief Estimated floor height compared to the reference point where Z = 0
+  */  
+  LOG_ADD(LOG_FLOAT, stateF, &coreData.S[KC_STATE_F])
+  /**
+  * @brief Estimated roof height compared to the reference point where Z = 0
+  */  
+  LOG_ADD(LOG_FLOAT, stateR, &coreData.S[KC_STATE_R])
+  /**
   * @brief Covariance matrix position x
   */
   LOG_ADD(LOG_FLOAT, varX, &coreData.P[KC_STATE_X][KC_STATE_X])
@@ -541,6 +575,14 @@ LOG_GROUP_START(kalman)
   * @brief Covariance matrix attitude error yaw
   */
   LOG_ADD(LOG_FLOAT, varD2, &coreData.P[KC_STATE_D2][KC_STATE_D2])
+  /**
+  * @brief Covariance matrix floor height estimate
+  */
+  LOG_ADD(LOG_FLOAT, varF, &coreData.P[KC_STATE_F][KC_STATE_F])
+  /**
+  * @brief Covariance matrix roof height estimate
+  */
+  LOG_ADD(LOG_FLOAT, varR, &coreData.P[KC_STATE_R][KC_STATE_R])
   /**
   * @brief Estimated Attitude quarternion w
   */
@@ -593,4 +635,8 @@ PARAM_GROUP_START(kalman)
  * @brief Nonzero to use robust TWR method (default: 0)
  */
   PARAM_ADD_CORE(PARAM_UINT8, robustTwr, &robustTwr)
+/**
+ * @brief Nonzero to use F (floor height) and R (roof height) in the estimation for a better Z estimate
+ */
+  PARAM_ADD_CORE(PARAM_UINT8, useFAndR, &useFAndR)
 PARAM_GROUP_STOP(kalman)

--- a/src/modules/src/kalman_core/mm_tof.c
+++ b/src/modules/src/kalman_core/mm_tof.c
@@ -24,6 +24,15 @@
  */
 
 #include "mm_tof.h"
+#include "param.h"
+
+// Parameters for tuning the detection for f and r estimation in the Tof update.
+// Factor multipled with the standard deviation of the measurement and compared to the prediction error (This is an int because of problems with param, if it is solved then it should probably be canged to a float) 
+static int detection_factor = 10;
+// The value the variance of f or r is set to when a detection happenes. It can probably be tuned to be smaller, but there it does not really seem to matter as long as it is "large enough"
+static float variance_after_detection = 50; 
+// Flag for turning the detection on and off. Without detection f and r tend to not change, causing the same problems as when not using them at all. There could be some way to get it to work without detection, but it is not implemented.
+static bool use_detection = true;
 
 void kalmanCoreUpdateWithTof(kalmanCoreData_t* this, tofMeasurement_t *tof)
 {
@@ -51,3 +60,111 @@ void kalmanCoreUpdateWithTof(kalmanCoreData_t* this, tofMeasurement_t *tof)
     kalmanCoreScalarUpdate(this, &H, measuredDistance-predictedDistance, tof->stdDev);
   }
 }
+
+void kalmanCoreUpdateWithTofUsingF(kalmanCoreData_t* this, tofMeasurement_t *tof)
+{
+  // Updates the filter with a measured distance in the zb direction using the
+  float h[KC_STATE_DIM] = {0};
+  arm_matrix_instance_f32 H = {1, KC_STATE_DIM, h};
+
+  // Only update the filter if the measurement is reliable (\hat{h} -> infty when R[2][2] -> 0)
+  if (fabs(this->R[2][2]) > 0.1 && this->R[2][2] > 0){
+    float angle = fabsf(acosf(this->R[2][2])) - DEG_TO_RAD * (15.0f / 2.0f);
+    if (angle < 0.0f) {
+      angle = 0.0f;
+    }
+    //float predictedDistance = S[KC_STATE_Z] / cosf(angle);
+    float predictedDistance = (this->S[KC_STATE_Z]-this->S[KC_STATE_F]) / this->R[2][2];
+    float measuredDistance = tof->distance; // [m]
+
+    float error = measuredDistance-predictedDistance;
+
+    
+    if (use_detection){ 
+      float threshold = detection_factor*(tof->stdDev);
+      // If the error is very large it probably means that S[KC_STATE_F] needs to change
+      if(error*error > threshold*threshold){
+        // Give a best first guess of the new floor height and set the variance high
+        this->P[KC_STATE_F][KC_STATE_F] = variance_after_detection;
+        this->S[KC_STATE_F] = this->S[KC_STATE_Z] - measuredDistance*this->R[2][2];
+        error = 0;
+      }
+    }
+
+    //Measurement equation
+    //
+    // h = (z - f)/((R*z_b)\dot z_b) = z/cos(alpha)
+    h[KC_STATE_Z] = 1 / this->R[2][2];
+    //h[KC_STATE_Z] = 1 / cosf(angle);
+
+    h[KC_STATE_F] = -1 / this->R[2][2];
+    
+    // Scalar update
+    kalmanCoreScalarUpdate(this, &H, error, tof->stdDev);
+  }
+}
+
+void kalmanCoreUpdateWithUpTofUsingR(kalmanCoreData_t* this, tofMeasurement_t *tof)
+{
+  // Updates the filter with a measured distance in the zb direction using the
+  float h[KC_STATE_DIM] = {0};
+  arm_matrix_instance_f32 H = {1, KC_STATE_DIM, h};
+
+  // 
+  if(!this->stateRInitialized){
+    this->S[KC_STATE_R] = tof->distance - this->S[KC_STATE_Z]; // Just set it equal to the measurement
+    this->stateRInitialized = true;
+  }
+
+
+  // Only update the filter if the measurement is reliable (\hat{h} -> infty when R[2][2] -> 0)
+  if (fabs(this->R[2][2]) > 0.1 && this->R[2][2] > 0){
+    float angle = fabsf(acosf(this->R[2][2])) - DEG_TO_RAD * (15.0f / 2.0f);
+    if (angle < 0.0f) {
+      angle = 0.0f;
+    }
+    //float predictedDistance = S[KC_STATE_Z] / cosf(angle);
+    float predictedDistance = (this->S[KC_STATE_R] - this->S[KC_STATE_Z]) / this->R[2][2];
+    float measuredDistance = tof->distance; // [m]
+
+    float error = measuredDistance-predictedDistance;
+
+    if (use_detection){ 
+      float threshold = detection_factor*(tof->stdDev);
+      // If the error is very large it probably means that S[KC_STATE_R] needs to change
+      if(error*error > threshold*threshold){
+        // Give a best first guess of the new roof height and set the variance high
+        this->P[KC_STATE_R][KC_STATE_R] = variance_after_detection;
+        this->S[KC_STATE_R] = measuredDistance*this->R[2][2] + this->S[KC_STATE_Z];
+        error = 0;
+      }
+    }
+
+    //Measurement equation
+    //
+    // h = (r - z)/((R*z_b)\dot z_b) = z/cos(alpha)
+    h[KC_STATE_Z] = -1 / this->R[2][2];
+    //h[KC_STATE_Z] = -1 / cosf(angle);
+
+    h[KC_STATE_R] = 1 / this->R[2][2];
+    
+    // Scalar update
+    kalmanCoreScalarUpdate(this, &H, error, tof->stdDev);
+  }
+}
+
+PARAM_GROUP_START(kalman)
+/**
+ * @brief The error threshold in Tof measurements that cause a detection of step in F or R
+ */
+  PARAM_ADD_CORE(PARAM_UINT8, tofDetectionFactor, &detection_factor)
+ /**
+ * @brief The variance used in the covariance matrix when a detection happenes
+ */
+  //PARAM_ADD_CORE(PARAM_FLOAT, varianceAfterDetection, &variance_after_detection)
+ /**
+ * @brief Non zero to use detection in Tof measurements for changes in F or R
+ */
+  //PARAM_ADD_CORE(PARAM_UINT8, useDetection, &use_detection)
+  
+PARAM_GROUP_STOP(kalman)

--- a/src/modules/src/range.c
+++ b/src/modules/src/range.c
@@ -56,6 +56,14 @@ void rangeEnqueueDownRangeInEstimator(float distance, float stdDev, uint32_t tim
   estimatorEnqueueTOF(&tofData);
 }
 
+void rangeEnqueueUpRangeInEstimator(float distance, float stdDev, uint32_t timeStamp) {
+  tofMeasurement_t tofData;
+  tofData.timestamp = timeStamp;
+  tofData.distance = distance;
+  tofData.stdDev = stdDev;
+  estimatorEnqueueUpTOF(&tofData);
+}
+
 /**
  * Log group for the multi ranger and Z-ranger decks
  */


### PR DESCRIPTION
## Overview
This is a proposed solution for flying with constant altitude over obstacles as brought up by [this github issue](https://github.com/bitcraze/crazyflie-firmware/issues/540). The solution is based on "step detection with the zranger" as suggested in the issue, but this solution uses a bit more for example by using the upward range measurement form the multiranger for better performance. Below is a video to show how well it works when flying off a table.

![ezgif com-gif-maker(6)](https://user-images.githubusercontent.com/52509111/128857069-242fdbd3-60b3-4b19-9a02-8ebd07328026.gif)

I worked on this as part of my summer internship at [SINTEF](https://www.sintef.no/en/digital/departments-new/applied-mathematics/robotics-and-control/) as part of the [Ingenious project](https://www.sintef.no/en/projects/2019/ingenious/). 

## How it works
The state in the Kalman filter was extended with two new states. These are f ("floor height") and r ("roof height"). f is defined as the height of the object under the Crazyflie compared to the height where the z state is defined as 0. 
r is defined as the height of the object over the Crazyflie compared to the same reference height. These states are used together with downward and upward range measurements in the Kalman filter for better estimation of z. The states are illustrated below.
![z_estimation_state_drawing](https://user-images.githubusercontent.com/52509111/128855490-ee33e316-e5db-4cbe-a224-37c3b7bb2fd6.png)

Previously the downward range measurement (l_D in illustration) was used as a direct measurement of z, but with the new definitions it now is a measurement of (z - f). Similarly the upward range measurement (l_U in illustration)is a measurement of (r - z). Both of the measurements also have an effect from the angle to the floor (theta) which is used in the same way as previously, that is by dividing by R[2][2] (rotation matrix). 

However, using this directly in the Kalman filter is not enough since one is now using two measurments to estimate three states. This is handled by having the new states f and r generally not changing, meaning I assume the floor and roof is flat most of the time. However, there is a detector for both the upward and downward range measurements for detecting fast abrupt changes in the range measurements. When a fast change is detected it is assumed it is the corresponding state (f or r) that is supposed to change. Then either f or r is set to a "best first guess" and given a high variance in the covariance matrix for the Kalman filter to fine tune the estimate of the state that was changed. 

In addition to these main changes the optical flow sensor also needed a small change where the distance to the floor is no longer z, but (z - f). Here there is also a difference from the "correct" way to use a Kalman filter where "h_z" and "h_f" are set to zero. This is because setting them to their "correct" values caused the states to drift and converge to completely wrong values. 

This new feature can be turned on an off using the parameter "kalman.useFAndR". Setting it to true (or nonzero) causes the EKF to use this feature. When setting it to false the firmware SHOULD work as it did without the change, but I can't be completely sure that it does not cause any difference. 

## Problems

The optical flow measurement implementation in the Kalman filter assumes the Crazyflie is flying over a flat surface. Now that it can fly over obstacles which are not a flat surface, but can have very large differences in distance to the sensor it sometimes messes up the estimates in x and y. This manifests as the x and y estimates stopping or "going the wrong way" while the Crazyflie is moving over an edge. If one has a set point at the other side of the edge it will cause the Crazyflie to speed up and go too far past the set point. I found that this effect happens less or completely disappears when the distance to the obstacles are "large enough". This is because when having a larger distance to the obstacle the relative difference between the distances to the sensor between the different surfaces gets smaller, which makes the errors smaller. I found that this effect tends to disappear when flying at an altitude that is double of the height of the obstacle, e.g if flying over a box that is 0.5m tall one should fly at an altitude of at least 1.0m to the floor.   





