### PR TITLE
Add systemRequestShutdown() to allow apps to request a full system shutdown

### DIFF
--- a/app_api/src/app_main.c
+++ b/app_api/src/app_main.c
@@ -46,6 +46,7 @@
 #include "param.h"
 #include "pm.h"
 #include "app_channel.h"
+#include "system.h"
 
 
 #define DEBUG_MODULE "APPAPI"
@@ -131,5 +132,10 @@ void appMain() {
     appchannelSendPacket("hello", 5);
     appchannelReceivePacket(buffer, APPCHANNEL_MTU, APPCHANNEL_WAIT_FOREVER);
     appchannelHasOverflowOccured();
+  }
+
+  // System
+  {
+    systemRequestShutdown();
   }
 }

--- a/src/hal/src/pm_stm32f4.c
+++ b/src/hal/src/pm_stm32f4.c
@@ -149,11 +149,7 @@ static void pmSetBatteryVoltage(float voltage)
 static void pmSystemShutdown(void)
 {
 #ifdef ACTIVATE_AUTO_SHUTDOWN
-  SyslinkPacket slp;
-
-  slp.type = SYSLINK_PM_ONOFF_SWITCHOFF;
-  slp.length = 0;
-  syslinkSendPacket(&slp);
+  systemRequestShutdown();
 #endif
 }
 

--- a/src/modules/interface/system.h
+++ b/src/modules/interface/system.h
@@ -41,4 +41,6 @@ void systemWaitStart(void);
 void systemSetArmed(bool val);
 bool systemIsArmed();
 
+void systemRequestShutdown();
+
 #endif //__SYSTEM_H__

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -330,6 +330,15 @@ bool systemIsArmed()
   return armed || forceArm;
 }
 
+void systemRequestShutdown()
+{
+  SyslinkPacket slp;
+
+  slp.type = SYSLINK_PM_ONOFF_SWITCHOFF;
+  slp.length = 0;
+  syslinkSendPacket(&slp);
+}
+
 void vApplicationIdleHook( void )
 {
   static uint32_t tickOfLatestWatchdogReset = M2T(0);


### PR DESCRIPTION
This PR adds a new function called `systemRequestShutdown()` to the public API of the `system` module. The purpose of the function is to allow apps to request a full, immediate system shutdown.

This would enable an app developer to add extra safety features, e.g., some kind of a "safety fence" functionality that stops the Crazyflie immediately if the position estimate diverges outside a predefined bounding box.