### PR TITLE
build: Remove stabilzer configuration from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,6 @@ include $(CRAZYFLIE_BASE)/tools/make/platform.mk
 
 CFLAGS += -DCRAZYFLIE_FW
 
-######### Stabilizer configuration ##########
-## These are set by the platform (see tools/make/platforms/*.mk), can be overwritten here
-ESTIMATOR          ?= any
-CONTROLLER         ?= Any # one of Any, PID, Mellinger, INDI
-POWER_DISTRIBUTION ?= stock
-
 #OpenOCD conf
 RTOS_DEBUG        ?= 0
 

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -112,6 +112,15 @@ or with the toolbelt
 tb make PLATFORM=tag
 ```
 
+### Platform specific options
+In `cf2.mk` or `tag.mk` in the `tools/make/` folder you can find additional compile options, for example which ESTIMATOR or CONTROLLER to use as default.
+
+```
+######### Stabilizer configuration ##########
+ESTIMATOR          ?= any
+CONTROLLER         ?= Any # one of Any, PID, Mellinger, INDI
+POWER_DISTRIBUTION ?= stock
+```
 
 ### config.mk
 To create custom build options create a file called `config.mk` in the `tools/make/`


### PR DESCRIPTION
It is already present in `tag.mk|cf2.mk` and changing these values in
the Makefile have no effect because of the question-mark operator.

Fixes #505
