### PR TITLE
system: Add request and print of NRF fw version

### DIFF
--- a/src/hal/interface/syslink.h
+++ b/src/hal/interface/syslink.h
@@ -64,6 +64,9 @@
 #define SYSLINK_OW_READ     0x22
 #define SYSLINK_OW_WRITE    0x23
 
+#define SYSLINK_SYS_GROUP        0x30
+#define SYSLINK_SYS_NRF_VERSION  0x30
+
 typedef struct _SyslinkPacket
 {
   uint8_t type;

--- a/src/hal/src/syslink.c
+++ b/src/hal/src/syslink.c
@@ -43,6 +43,7 @@
 #include "pm.h"
 #include "ow.h"
 #include "static_mem.h"
+#include "system.h"
 
 #ifdef UART2_LINK_COMM
 #include "uart2.h"
@@ -101,6 +102,9 @@ static void syslinkRouteIncommingPacket(SyslinkPacket *slp)
       break;
     case SYSLINK_OW_GROUP:
       owSyslinkRecieve(slp);
+      break;
+    case SYSLINK_SYS_GROUP:
+      systemSyslinkReceive(slp);
       break;
     default:
       DEBUG_PRINT("Unknown packet:%X.\n", slp->type);

--- a/src/modules/interface/system.h
+++ b/src/modules/interface/system.h
@@ -42,5 +42,7 @@ void systemSetArmed(bool val);
 bool systemIsArmed();
 
 void systemRequestShutdown();
+void systemRequestNRFVersion();
+void systemSyslinkReceive();
 
 #endif //__SYSTEM_H__


### PR DESCRIPTION
This adds use of a new SYSLINK message: `SYSLINK_SYS_NRF_VERSION`

The NRF will reply with a string, for example: `2021.06 +1*`

Which mean 1 commit from the 2021.06 tag and the `*` marks it as "locally modified".

This will appear in the console log:

<kbd><img src="https://user-images.githubusercontent.com/974401/131655693-b4cafaaa-3285-4784-b640-613454a5f7be.png" /></kbd>
