### PR TITLE
Makefile: Avoid referencing users absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ bin/vendor:
 	mkdir -p bin/vendor
 
 libarm_math.a:
-	+$(MAKE) -C $(CRAZYFLIE_BASE)/tools/make/cmsis_dsp/ CRAZYFLIE_BASE=$(abspath $(CRAZYFLIE_BASE)) PROJ_ROOT=$(CURDIR) V=$(V) CROSS_COMPILE=$(CROSS_COMPILE)
+	+$(MAKE) -C $(CRAZYFLIE_BASE)/tools/make/cmsis_dsp/ CRAZYFLIE_BASE=$(CRAZYFLIE_BASE)/../../../ PROJ_ROOT=$(CRAZYFLIE_BASE)/../../../ V=$(V) CROSS_COMPILE=$(CROSS_COMPILE)
 
 clean_version:
 ifeq ($(SHELL),/bin/sh)


### PR DESCRIPTION
We currently get build errors when there is spaces in the absolute path leading up to the crazyflie-firmware directory:

```
$ mkdir "dir with spaces"
$ cd "dir with spaces"
$ git clone git@github.com:bitcraze/crazyflie-firmware.git
$ cd crazyflie-firmware/
$ git submodule init
$ git submodule update
$ make
  CLEAN_VERSION
  CC    list.o
  CC    tasks.o
[...]
make -C .//tools/make/cmsis_dsp/ CRAZYFLIE_BASE=/home/jonasdn/sandbox/dir with spaces/crazyflie-firmware PROJ_ROOT=/home/jonasdn/sandbox/dir with spaces/crazyflie-firmware V= CROSS_COMPILE=arm-none-eabi-
make[2]: *** No rule to make target 'with'.  Stop.
make[1]: *** [Makefile:408: libarm_math.a] Error 2
rm version.c
make: *** [Makefile:393: build] Error 2
```

The general advice to handling whitespace in GNU Make is "don't", it gets very messy, see: https://www.cmcrossroads.com/article/gnu-make-meets-file-names-spaces-them.

In our case I think we want to try hard not to reference any paths out side of our own control. So this commit tries to use relative paths instead of absolute ones.

Fixes: #840
