### PR TITLE
Fix incorrect PID filter reset introduced in #803

### DIFF
--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -258,7 +258,11 @@ void positionControllerResetAllfilters() {
   filterReset(&this.pidZ.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
   filterReset(&this.pidVX.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
   filterReset(&this.pidVY.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
-  filterReset(&this.pidVZ.pid, POSITION_RATE, ZVELOCITY_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  #ifdef IMPROVED_BARO_Z_HOLD
+    filterReset(&this.pidVZ.pid, POSITION_RATE, ZVELOCITY_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  #else
+    filterReset(&this.pidVZ.pid, POSITION_RATE, POSITION_LPF_CUTOFF_FREQ, POSITION_LPF_ENABLE);
+  #endif
 }
 
 /**


### PR DESCRIPTION
This PR fixes a bug introduced in #803 

The function `positionControllerResetAllfilters()` reinitialized the z velocity filter to ZVELOCITY_LPF_CUTOFF_FREQ even if IMPROVED_BARO_Z_HOLD was not defined. This is now fixed and the filter gets reset to POSITION_LPF_CUTOFF_FREQ by default.