### PR TITLE
motors: Remove unnecessary function calls

### DIFF
--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -228,10 +228,6 @@ void motorsInit(const MotorPerifDef** motorMapSelect)
     // Configure Output Compare for PWM
     motorMap[i]->ocInit(motorMap[i]->tim, &TIM_OCInitStructure);
     motorMap[i]->preloadConfig(motorMap[i]->tim, TIM_OCPreload_Enable);
-
-    MOTORS_TIM_DBG_CFG(motorMap[i]->timDbgStop, ENABLE);
-    //Enable the timer PWM outputs
-    TIM_CtrlPWMOutputs(motorMap[i]->tim, ENABLE);
   }
 
   // Start the timers


### PR DESCRIPTION
From user X-N-C in issue #705:

  In motorsInit there are two unnecessary function calls with the
  currently used motor timers (2, 3, 4, 5 and 14 according to
  motors_def_cf2.c).

  MOTORS_TIM_DBG_CFG is defined in motors.h as DBGMCU_APB2PeriphConfig.
  Since the used STM32F405 timers are connected via bus APB1, according
  to the reference manual, the define should be changed (or removed).

Closes #705
