### PR TITLE
add missing brief identifier to param doc flightmode

### DIFF
--- a/src/modules/src/crtp_commander_rpyt.c
+++ b/src/modules/src/crtp_commander_rpyt.c
@@ -258,17 +258,17 @@ PARAM_ADD_CORE(PARAM_UINT8, posSet, &posSetMode)
 PARAM_ADD(PARAM_UINT8, yawMode, &yawMode)
 
 /**
- * Stabilization type for roll: rate(0) or angle(1)
+ * @brief Stabilization type for roll: rate(0) or angle(1)
  */
 PARAM_ADD_CORE(PARAM_UINT8, stabModeRoll, &stabilizationModeRoll)
 
 /**
- * Stabilization type for pitch: rate(0) or angle(1)
+ * @brief Stabilization type for pitch: rate(0) or angle(1)
  */
 PARAM_ADD_CORE(PARAM_UINT8, stabModePitch, &stabilizationModePitch)
 
 /**
- * Stabilization type for yaw: rate(0) or angle(1)
+ * @brief Stabilization type for yaw: rate(0) or angle(1)
  */
 PARAM_ADD_CORE(PARAM_UINT8, stabModeYaw, &stabilizationModeYaw)
 


### PR DESCRIPTION
The website doc didn't have the possibilities of the yaw stabilizer mode in the table, but it it was missing the [at]brief in the doxygen comments. This PR fixes that.