### PR TITLE
Fix setting the parameter by name for CORE parameters.

### DIFF
--- a/src/modules/src/param.c
+++ b/src/modules/src/param.c
@@ -422,7 +422,7 @@ static char paramWriteByNameProcess(char* group, char* name, int type, void *val
     return ENOENT;
   }
 
-  if (type != params[ptr].type) {
+  if (type != (params[ptr].type & (~(PARAM_CORE | PARAM_RONLY)))) {
     return EINVAL;
   }
 


### PR DESCRIPTION
The introduction of core parameters missed a bitmask which caused EINVAL
to be returned when trying to set a parameter by name.