### PR TITLE
added missing LED ring modes

### DIFF
--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -1131,27 +1131,27 @@ PARAM_GROUP_START(ring)
 /**
  * @brief Id of effect to use (default: 6)
  *
- * | Id | Effect              | \n
- * | -  | -                   | \n
- * | 0  | Off                 | \n
- * | 1  | White spinner       | \n
- * | 2  | Color spinner       | \n
- * | 3  | Tilt                | \n
- * | 4  | Brightness          | \n
- * | 5  | Color spinner 2     | \n
- * | 6  | Double spinner      | \n
- * | 7  | Solid color effect  | \n
- * | 8  | Factory test        | \n
- * | 9  | Battery status      | \n
- * | 10 | Boat lights         | \n
- * | 11 | Alert               | \n
- * | 12 | Gravity             | \n
- * | 13 | Virtual Memory      | \n
- * | 14 | Fade color          | \n
- * | 15 | Communication Signal Strength                | \n
- * | 16 | Status Localization Service| \n
- * | 17 | LED timing from memory       | \n
- * | 18 | Lighthouse  Positioning      | \n
+ * | Id | Effect                        | \n
+ * | -  | -                             | \n
+ * | 0  | Off                           | \n
+ * | 1  | White spinner                 | \n
+ * | 2  | Color spinner                 | \n
+ * | 3  | Tilt                          | \n
+ * | 4  | Brightness                    | \n
+ * | 5  | Color spinner 2               | \n
+ * | 6  | Double spinner                | \n
+ * | 7  | Solid color effect            | \n
+ * | 8  | Factory test                  | \n
+ * | 9  | Battery status                | \n
+ * | 10 | Boat lights                   | \n
+ * | 11 | Alert                         | \n
+ * | 12 | Gravity                       | \n
+ * | 13 | Virtual Memory                | \n
+ * | 14 | Fade color                    | \n
+ * | 15 | Communication Signal Strength | \n
+ * | 16 | Status Localization Service   | \n
+ * | 17 | LED timing from memory        | \n
+ * | 18 | Lighthouse  Positioning       | \n
  */
 PARAM_ADD_CORE(PARAM_UINT8, effect, &effect)
 

--- a/src/deck/drivers/src/ledring12.c
+++ b/src/deck/drivers/src/ledring12.c
@@ -1146,6 +1146,12 @@ PARAM_GROUP_START(ring)
  * | 10 | Boat lights         | \n
  * | 11 | Alert               | \n
  * | 12 | Gravity             | \n
+ * | 13 | Virtual Memory      | \n
+ * | 14 | Fade color          | \n
+ * | 15 | Communication Signal Strength                | \n
+ * | 16 | Status Localization Service| \n
+ * | 17 | LED timing from memory       | \n
+ * | 18 | Lighthouse  Positioning      | \n
  */
 PARAM_ADD_CORE(PARAM_UINT8, effect, &effect)
 


### PR DESCRIPTION
The auto generated doc of the led ring modes was only displaying 13 modes even though [there are actually 19.](https://github.com/bitcraze/crazyflie-firmware/blob/308ceb323945c72ac92f50f30380a7ef54ce07e0/src/deck/drivers/src/ledring12.c#L950-L968). It created some confusion for users (see this issue: https://github.com/bitcraze/crazyflie-lib-python/issues/261)