### PR TITLE
Add radiolink txQueue info

### DIFF
--- a/src/hal/interface/radiolink.h
+++ b/src/hal/interface/radiolink.h
@@ -58,6 +58,7 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp);
 struct crtpLinkOperations * radiolinkGetLink();
 bool radiolinkSendP2PPacketBroadcast(P2PPacket *p2pp);
 void p2pRegisterCB(P2PCallback cb);
-
+int linkGetFreeTxQueuePackets(void);
+int linkResetTxQueuePackets(void);
 
 #endif //__RADIO_H__

--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -74,6 +74,16 @@ static bool radiolinkIsConnected(void) {
   return (xTaskGetTickCount() - lastPacketTick) < M2T(RADIO_ACTIVITY_TIMEOUT_MS);
 }
 
+int linkGetFreeTxQueuePackets(void)
+{
+  return (RADIOLINK_TX_QUEUE_SIZE - uxQueueMessagesWaiting(txQueue));
+}
+
+int linkResetTxQueuePackets(void)
+{
+  return xQueueReset(txQueue);
+}
+
 static struct crtpLinkOperations radiolinkOp =
 {
   .setEnable         = radiolinkSetEnable,


### PR DESCRIPTION
This PR allows reading the radio link output queue status. 

We are using `link->sendPacket(...)` directly to communicate with our crazyflie and we need to wait for the packet to be delivered using `linkGetFreeTxQueuePackets()` before reading the response and delete the packet after a timeout if the delivery fails `linkResetTxQueuePackets()`.

Feel free to suggest changes or alternatives.