### PR TITLE
Length of received p2p packets is 2 bytes too long

### DIFF
--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -186,10 +186,14 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
     P2PPacket p2pp;
     p2pp.port=slp->data[0];
     p2pp.rssi = slp->data[1];
-    memcpy(&p2pp.data[0], &slp->data[2],slp->length-2);
-    p2pp.size=slp->length;
-    if (p2p_callback)
+
+    const uint8_t p2pDataLength = slp->length - 2;
+    memcpy(&p2pp.data[0], &slp->data[2], p2pDataLength);
+    p2pp.size = p2pDataLength;
+
+    if (p2p_callback) {
         p2p_callback(&p2pp);
+    }
   }
 
   isConnected = radiolinkIsConnected();


### PR DESCRIPTION
When a p2p packet is received from syslink, the data is copied into a P2PPacket struct and passed on to an app callback.
The length of the p2p payload is 2 bytes less than the syslink packet and this is handled when copying the payload, but when the size member of the p2p packet is populated, the full syslink size is used. The correct value is 2 bytes less than the syslink size.
The end result is that an application will get the impression that two extra bytes were received in the p2p message. 