### PR TITLE
Improved CPPM - alternative GPIOs, arming and altitude hold, init fix

### DIFF
--- a/src/deck/interface/deck_core.h
+++ b/src/deck/interface/deck_core.h
@@ -66,6 +66,7 @@ bool deckTest(void);
 #define DECK_USING_I2C     (DECK_USING_PB6  | DECK_USING_PB7)
 #define DECK_USING_TIMER3  (1 << 13)
 #define DECK_USING_TIMER5  (1 << 14)
+#define DECK_USING_TIMER10 (1 << 16)
 #define DECK_USING_TIMER14 (1 << 15)
 
 struct deckInfo_s;

--- a/src/drivers/src/cppm.c
+++ b/src/drivers/src/cppm.c
@@ -40,26 +40,113 @@
 #include "debug.h"
 #include "log.h"
 
-
-#define CPPM_TIMER                   TIM14
-#define CPPM_TIMER_RCC               RCC_APB1Periph_TIM14
-#define CPPM_TIMER_CH_Init           TIM_OC1Init
-#define CPPM_TIMER_CH_PreloadConfig  TIM_OC1PreloadConfig
-#define CPPM_TIMER_CH_SetCompare     TIM_SetCompare1
-#define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOA
-#define CPPM_GPIO_PORT               GPIOA
-#define CPPM_GPIO_PIN                GPIO_Pin_7
-#define CPPM_GPIO_SOURCE             GPIO_PinSource7
-#define CPPM_GPIO_AF                 GPIO_AF_TIM14
-
-#define CPPM_TIM_PRESCALER           (84 - 1) // TIM14 clock running at sysclk/2. Will give 1us tick.
+#ifdef CPPM_USE_PB4
+  #define CPPM_TIMER_NUMBER            3
+  #define CPPM_TIMER_CHANNEL           1
+  #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOB
+  #define CPPM_GPIO_PORT               GPIOB
+  #define CPPM_GPIO_PIN                GPIO_Pin_4
+  #define CPPM_GPIO_SOURCE             GPIO_PinSource4
+#elif defined(CPPM_USE_PB5) 
+  #define CPPM_TIMER_NUMBER            3
+  #define CPPM_TIMER_CHANNEL           2
+  #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOB
+  #define CPPM_GPIO_PORT               GPIOB
+  #define CPPM_GPIO_PIN                GPIO_Pin_5
+  #define CPPM_GPIO_SOURCE             GPIO_PinSource5
+#elif defined(CPPM_USE_PB8)
+  #define CPPM_TIMER_NUMBER            10
+  #define CPPM_TIMER_CHANNEL           1
+  #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOB
+  #define CPPM_GPIO_PORT               GPIOB
+  #define CPPM_GPIO_PIN                GPIO_Pin_8
+  #define CPPM_GPIO_SOURCE             GPIO_PinSource8
+#elif defined(CPPM_USE_PA2)
+  #define CPPM_TIMER_NUMBER            9
+  #define CPPM_TIMER_CHANNEL           1
+  #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOA
+  #define CPPM_GPIO_PORT               GPIOA
+  #define CPPM_GPIO_PIN                GPIO_Pin_2
+  #define CPPM_GPIO_SOURCE             GPIO_PinSource2
+#elif defined(CPPM_USE_PA3)
+  #define CPPM_TIMER_NUMBER            9
+  #define CPPM_TIMER_CHANNEL           2
+  #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOA
+  #define CPPM_GPIO_PORT               GPIOA
+  #define CPPM_GPIO_PIN                GPIO_Pin_3
+  #define CPPM_GPIO_SOURCE             GPIO_PinSource3
+#else // default is PA7 
+  #define CPPM_TIMER_NUMBER            14
+  #define CPPM_TIMER_CHANNEL           1
+  #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOA
+  #define CPPM_GPIO_PORT               GPIOA
+  #define CPPM_GPIO_PIN                GPIO_Pin_7
+  #define CPPM_GPIO_SOURCE             GPIO_PinSource7
+#endif
 
 #define CPPM_MIN_PPM_USEC            1100
 #define CPPM_MAX_PPM_USEC            1900
 
+#if (CPPM_TIMER_NUMBER == 3)
+  #define CPPM_TIMER                   TIM3
+  #define CPPM_TIMER_RCC               RCC_APB1Periph_TIM3
+  #define CPPM_GPIO_AF                 GPIO_AF_TIM3
+  #define CPPM_IRQ                     TIM3_IRQn
+  #define CPPM_TIM_PRESCALER           (84 - 1) // TIM3 clock running at sysclk/2 (84 MHz). Prescaler of 84 will give 1MHz --> 1us tick.
+#elif (CPPM_TIMER_NUMBER == 9)
+  #define CPPM_TIMER                   TIM9
+  #define CPPM_TIMER_RCC               RCC_APB2Periph_TIM9
+  #define CPPM_GPIO_AF                 GPIO_AF_TIM9
+  #define CPPM_IRQ                     TIM1_BRK_TIM9_IRQn
+  #define CPPM_TIM_PRESCALER           (168 - 1) // TIM9 clock running at sysclk (168 MHz). Prescaler of 168 will give 1MHz --> 1us tick.
+#elif (CPPM_TIMER_NUMBER == 10)
+  #define CPPM_TIMER                   TIM10
+  #define CPPM_TIMER_RCC               RCC_APB2Periph_TIM10
+  #define CPPM_GPIO_AF                 GPIO_AF_TIM10
+  #define CPPM_IRQ                     TIM1_UP_TIM10_IRQn
+  #define CPPM_TIM_PRESCALER           (168 - 1) // TIM10 clock running at sysclk (168 MHz). Prescaler of 168 will give 1MHz --> 1us tick.
+#else
+  #define CPPM_TIMER                   TIM14
+  #define CPPM_TIMER_RCC               RCC_APB1Periph_TIM14
+  #define CPPM_GPIO_AF                 GPIO_AF_TIM14
+  #define CPPM_IRQ                     TIM8_TRG_COM_TIM14_IRQn
+  #define CPPM_TIM_PRESCALER           (84 - 1) // TIM14 clock running at sysclk/2 (84 MHz). Prescaler of 84 will give 1MHz --> 1us tick.
+#endif
+
+#if (CPPM_TIMER_CHANNEL == 2)
+  #define CPPM_TIMER_CH                TIM_Channel_2
+  #define CPPM_TIMER_CH_Init           TIM_OC2Init
+  #define CPPM_TIMER_CH_PreloadConfig  TIM_OC2PreloadConfig
+  #define CPPM_TIMER_CH_SetCompare     TIM_SetCompare2
+  #define CPPM_TIMER_IT_CC             TIM_IT_CC2
+  #define CPPM_TIMER_FLAG_CC           TIM_FLAG_CC2OF
+#elif (CPPM_TIMER_CHANNEL == 3)
+  #define CPPM_TIMER_CH                TIM_Channel_3
+  #define CPPM_TIMER_CH_Init           TIM_OC3Init
+  #define CPPM_TIMER_CH_PreloadConfig  TIM_OC3PreloadConfig
+  #define CPPM_TIMER_CH_SetCompare     TIM_SetCompare3
+  #define CPPM_TIMER_IT_CC             TIM_IT_CC3
+  #define CPPM_TIMER_FLAG_CC           TIM_FLAG_CC3OF
+#elif (CPPM_TIMER_CHANNEL == 4)
+  #define CPPM_TIMER_CH                TIM_Channel_4
+  #define CPPM_TIMER_CH_Init           TIM_OC4Init
+  #define CPPM_TIMER_CH_PreloadConfig  TIM_OC4PreloadConfig
+  #define CPPM_TIMER_CH_SetCompare     TIM_SetCompare4
+  #define CPPM_TIMER_IT_CC             TIM_IT_CC4
+  #define CPPM_TIMER_FLAG_CC           TIM_FLAG_CC4OF
+#else
+  #define CPPM_TIMER_CH                TIM_Channel_1
+  #define CPPM_TIMER_CH_Init           TIM_OC1Init
+  #define CPPM_TIMER_CH_PreloadConfig  TIM_OC1PreloadConfig
+  #define CPPM_TIMER_CH_SetCompare     TIM_SetCompare1
+  #define CPPM_TIMER_IT_CC             TIM_IT_CC1
+  #define CPPM_TIMER_FLAG_CC           TIM_FLAG_CC1OF
+#endif
+
+
 static xQueueHandle captureQueue;
 STATIC_MEM_QUEUE_ALLOC(captureQueue, 64, sizeof(uint16_t));
-static uint16_t prevCapureVal;
+static uint16_t prevCaptureVal;
 static bool captureFlag;
 static bool isAvailible;
 
@@ -71,7 +158,11 @@ void cppmInit(void)
   NVIC_InitTypeDef NVIC_InitStructure;
 
   RCC_AHB1PeriphClockCmd(CPPM_GPIO_RCC, ENABLE);
-  RCC_APB1PeriphClockCmd(CPPM_TIMER_RCC, ENABLE);
+  #if (CPPM_TIMER_NUMBER == 9) || (CPPM_TIMER_NUMBER == 10)
+    RCC_APB2PeriphClockCmd(CPPM_TIMER_RCC, ENABLE);
+  #else
+    RCC_APB1PeriphClockCmd(CPPM_TIMER_RCC, ENABLE);
+  #endif
 
   // Configure the GPIO for the timer input
   GPIO_StructInit(&GPIO_InitStructure);
@@ -87,11 +178,12 @@ void cppmInit(void)
   TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
   TIM_TimeBaseInit(CPPM_TIMER, &TIM_TimeBaseStructure);
 
-  // Setup input capture using default config.
+  // Setup input capture
   TIM_ICStructInit(&TIM_ICInitStructure);
+  TIM_ICInitStructure.TIM_Channel = CPPM_TIMER_CH;
   TIM_ICInit(CPPM_TIMER, &TIM_ICInitStructure);
 
-  NVIC_InitStructure.NVIC_IRQChannel = TIM8_TRG_COM_TIM14_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannel = CPPM_IRQ;
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_CPPM_PRI;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
@@ -99,7 +191,7 @@ void cppmInit(void)
 
   captureQueue = STATIC_MEM_QUEUE_CREATE(captureQueue);
 
-  TIM_ITConfig(CPPM_TIMER, TIM_IT_Update | TIM_IT_CC1, ENABLE);
+  TIM_ITConfig(CPPM_TIMER, TIM_IT_Update | CPPM_TIMER_IT_CC, ENABLE);
   TIM_Cmd(CPPM_TIMER, ENABLE);
 }
 
@@ -122,36 +214,43 @@ void cppmClearQueue(void)
 
 float cppmConvert2Float(uint16_t timestamp, float min, float max, float deadband)
 {
-  if (timestamp < CPPM_MIN_PPM_USEC)
-  {
-    timestamp = CPPM_MIN_PPM_USEC;
-  }
-  if (timestamp > CPPM_MAX_PPM_USEC)
-  {
-    timestamp = CPPM_MAX_PPM_USEC;
-  }
-
-  float scale_raw = (float)(timestamp - CPPM_MIN_PPM_USEC) / (float)(CPPM_MAX_PPM_USEC - CPPM_MIN_PPM_USEC);
   float scale;
-  if (deadband == 0)
+  
+  if (timestamp == 0) // timestamp is zero before we get the first valid timestamp --> set scale to neutral (0.5)
   {
-    scale = scale_raw;
+    scale = 0.5f;
   }
   else
   {
-    if (scale_raw < (0.5f - deadband/2) )
+    if (timestamp < CPPM_MIN_PPM_USEC)
     {
-      scale = scale_raw / (1.f - deadband);
+      timestamp = CPPM_MIN_PPM_USEC;
     }
-    else if (scale_raw > (0.5f + deadband/2) )
+    if (timestamp > CPPM_MAX_PPM_USEC)
     {
-      scale = (scale_raw - deadband) / (1.f - deadband);
+      timestamp = CPPM_MAX_PPM_USEC;
+    }
+
+    float scale_raw = (float)(timestamp - CPPM_MIN_PPM_USEC) / (float)(CPPM_MAX_PPM_USEC - CPPM_MIN_PPM_USEC);
+    if (deadband == 0)
+    {
+      scale = scale_raw;
     }
     else
     {
-      scale = 0.5f;
+      if (scale_raw < (0.5f - deadband/2) )
+      {
+        scale = scale_raw / (1.f - deadband);
+      }
+      else if (scale_raw > (0.5f + deadband/2) )
+      {
+        scale = (scale_raw - deadband) / (1.f - deadband);
+      }
+      else
+      {
+        scale = 0.5f;
+      }
     }
-    
   }
   
   return min + ((max - min) * scale);
@@ -173,27 +272,43 @@ uint16_t cppmConvert2uint16(uint16_t timestamp)
   return base * (65535 / (CPPM_MAX_PPM_USEC - CPPM_MIN_PPM_USEC));
 }
 
+#if (CPPM_TIMER_NUMBER == 3)
+void __attribute__((used)) TIM3_IRQHandler()
+#elif (CPPM_TIMER_NUMBER == 9)
+void __attribute__((used)) TIM1_BRK_TIM9_IRQHandler()
+#elif (CPPM_TIMER_NUMBER == 10)
+void __attribute__((used)) TIM1_UP_TIM10_IRQHandler()
+#else
 void __attribute__((used)) TIM8_TRG_COM_TIM14_IRQHandler()
+#endif
 {
-  uint16_t capureVal;
-  uint16_t capureValDiff;
+  uint16_t captureVal;
+  uint16_t captureValDiff;
   portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 
-  if (TIM_GetITStatus(CPPM_TIMER, TIM_IT_CC1) != RESET)
+  if (TIM_GetITStatus(CPPM_TIMER, CPPM_TIMER_IT_CC) != RESET)
   {
-    if (TIM_GetFlagStatus(CPPM_TIMER, TIM_FLAG_CC1OF) != RESET)
+    if (TIM_GetFlagStatus(CPPM_TIMER, CPPM_TIMER_FLAG_CC) != RESET)
     {
       //TODO: Handle overflow error
     }
 
-    capureVal = TIM_GetCapture1(CPPM_TIMER);
-    capureValDiff = capureVal - prevCapureVal;
-    prevCapureVal = capureVal;
+    #if (CPPM_TIMER_CHANNEL == 2)
+      captureVal = TIM_GetCapture2(CPPM_TIMER);
+    #elif (CPPM_TIMER_CHANNEL == 3)
+      captureVal = TIM_GetCapture3(CPPM_TIMER);
+    #elif (CPPM_TIMER_CHANNEL == 4)
+      captureVal = TIM_GetCapture4(CPPM_TIMER);
+    #else
+      captureVal = TIM_GetCapture1(CPPM_TIMER);
+    #endif
+    captureValDiff = captureVal - prevCaptureVal;
+    prevCaptureVal = captureVal;
 
-    xQueueSendFromISR(captureQueue, &capureValDiff, &xHigherPriorityTaskWoken);
+    xQueueSendFromISR(captureQueue, &captureValDiff, &xHigherPriorityTaskWoken);
 
     captureFlag = true;
-    TIM_ClearITPendingBit(CPPM_TIMER, TIM_IT_CC1);
+    TIM_ClearITPendingBit(CPPM_TIMER, CPPM_TIMER_IT_CC);
   }
 
   if (TIM_GetITStatus(CPPM_TIMER, TIM_IT_Update) != RESET)
@@ -204,3 +319,4 @@ void __attribute__((used)) TIM8_TRG_COM_TIM14_IRQHandler()
     TIM_ClearITPendingBit(CPPM_TIMER, TIM_IT_Update);
   }
 }
+

--- a/src/modules/src/extrx.c
+++ b/src/modules/src/extrx.c
@@ -85,11 +85,13 @@
 
 #define EXTRX_SWITCH_MIN_CNT 5 // number of identical subsequent switch states before the switch variable is changed
 
+bool extRxArm = false;
+bool extRxAltHold = false;
+  
 #ifndef EXTRX_ARMING
   #define EXTRX_ARMING    false
 #endif
 #if EXTRX_ARMING
-  bool extRxArm = false;
   bool extRxArmPrev = false;
   int8_t arm_cnt = 0;
 #endif
@@ -100,7 +102,6 @@
 #if EXTRX_ALT_HOLD
   #define EXTRX_DEADBAND_ZVEL  (0.25f)
   bool extRxAltHoldPrev = false;
-  bool extRxAltHold = false;
   int8_t altHold_cnt = 0;
 #endif
 

--- a/src/modules/src/extrx.c
+++ b/src/modules/src/extrx.c
@@ -69,6 +69,12 @@
   #define EXTRX_SIGN_YAW     (-1)
 #endif
 
+#define EXTRX_CH_ALTHOLD   4
+#define EXTRX_CH_ARM       5
+
+#define EXTRX_SIGN_ALTHOLD   (-1)
+#define EXTRX_SIGN_ARM       (-1)
+
 #define EXTRX_SCALE_ROLL   (40.0f)
 #define EXTRX_SCALE_PITCH  (40.0f)
 #define EXTRX_SCALE_YAW    (200.0f)
@@ -77,12 +83,35 @@
 #define EXTRX_DEADBAND_PITCH (0.05f)
 #define EXTRX_DEADBAND_YAW (0.05f)
 
+#define EXTRX_SWITCH_MIN_CNT 5 // number of identical subsequent switch states before the switch variable is changed
+
+#ifndef EXTRX_ARMING
+  #define EXTRX_ARMING    false
+#endif
+#if EXTRX_ARMING
+  bool extRxArm = false;
+  bool extRxArmPrev = false;
+  int8_t arm_cnt = 0;
+#endif
+
+#ifndef EXTRX_ALT_HOLD
+  #define EXTRX_ALT_HOLD    false
+#endif
+#if EXTRX_ALT_HOLD
+  #define EXTRX_DEADBAND_ZVEL  (0.25f)
+  bool extRxAltHoldPrev = false;
+  bool extRxAltHold = false;
+  int8_t altHold_cnt = 0;
+#endif
+
+
 static setpoint_t extrxSetpoint;
-static uint16_t ch[EXTRX_NR_CHANNELS];
+static uint16_t ch[EXTRX_NR_CHANNELS] = {0};
 
 static void extRxTask(void *param);
 static void extRxDecodeCppm(void);
 static void extRxDecodeChannels(void);
+
 
 STATIC_MEM_TASK_ALLOC(extRxTask, EXTRX_TASK_STACKSIZE);
 
@@ -125,10 +154,73 @@ static void extRxTask(void *param)
 
 static void extRxDecodeChannels(void)
 {
+  
+  #if EXTRX_ARMING
+  if (EXTRX_SIGN_ARM * cppmConvert2Float(ch[EXTRX_CH_ARM], -1, 1, 0.0) > 0.5f) // channel needs to be 75% or more to work correctly with 2/3 way switches
+  {
+    if (arm_cnt < EXTRX_SWITCH_MIN_CNT) arm_cnt++;
+    else extRxArm = true;
+    
+    if (extRxArmPrev != extRxArm)
+    {
+      DEBUG_PRINT("Engines armed\n");
+      systemSetArmed(extRxArm);
+    }
+  }
+  else
+  {
+    if (arm_cnt > 0) arm_cnt--;
+    else extRxArm = false;
+
+    if (extRxArmPrev != extRxArm)
+    {
+      DEBUG_PRINT("Engines unarmed\n");
+      systemSetArmed(extRxArm);
+    }
+  }
+
+  extRxArmPrev = extRxArm;
+  #endif
+
+  #if EXTRX_ALT_HOLD
+  if (EXTRX_SIGN_ALTHOLD * cppmConvert2Float(ch[EXTRX_CH_ALTHOLD], -1, 1, 0.0) > 0.5f)
+  {
+    if (altHold_cnt < EXTRX_SWITCH_MIN_CNT) altHold_cnt++;
+    else extRxAltHold=true;
+
+    if (extRxAltHoldPrev != extRxAltHold) DEBUG_PRINT("Althold mode ON\n");
+  }
+  else
+  {
+    if (altHold_cnt > 0) altHold_cnt--;
+    else extRxAltHold=false;
+
+    if (extRxAltHoldPrev != extRxAltHold) DEBUG_PRINT("Althold mode OFF\n");
+  }
+
+  if (extRxAltHold) 
+  {
+    extrxSetpoint.thrust = 0;
+    extrxSetpoint.mode.z = modeVelocity;
+
+    extrxSetpoint.velocity.z = cppmConvert2Float(ch[EXTRX_CH_THRUST], -1, 1, EXTRX_DEADBAND_ZVEL);
+  } 
+  else 
+  {
+    extrxSetpoint.mode.z = modeDisable;
+    extrxSetpoint.thrust = cppmConvert2uint16(ch[EXTRX_CH_THRUST]);
+  }
+  
+  extRxAltHoldPrev = extRxAltHold;
+  #else
+  extrxSetpoint.mode.z = modeDisable;
   extrxSetpoint.thrust = cppmConvert2uint16(ch[EXTRX_CH_THRUST]);
+  #endif
+  
   extrxSetpoint.attitude.roll = EXTRX_SIGN_ROLL * EXTRX_SCALE_ROLL * cppmConvert2Float(ch[EXTRX_CH_ROLL], -1, 1, EXTRX_DEADBAND_ROLL);
   extrxSetpoint.attitude.pitch = EXTRX_SIGN_PITCH * EXTRX_SCALE_PITCH * cppmConvert2Float(ch[EXTRX_CH_PITCH], -1, 1, EXTRX_DEADBAND_PITCH);
   extrxSetpoint.attitudeRate.yaw = EXTRX_SIGN_YAW * EXTRX_SCALE_YAW *cppmConvert2Float(ch[EXTRX_CH_YAW], -1, 1, EXTRX_DEADBAND_YAW);
+
   commanderSetSetpoint(&extrxSetpoint, COMMANDER_PRIORITY_EXTRX);
 }
 
@@ -201,9 +293,9 @@ static void extRxDecodeSpektrum(void)
 #ifdef ENABLE_EXTRX_LOG
 /**
  * External receiver (RX) log group. This contains received raw
- * channel data as well as RPTY data after it has been converted.
+ * channel data
  */
-LOG_GROUP_START(extrx)
+LOG_GROUP_START(extrx_raw)
 /**
  * @brief External RX received channel 0 value
  */
@@ -221,20 +313,56 @@ LOG_ADD(LOG_UINT16, ch2, &ch[2])
  */
 LOG_ADD(LOG_UINT16, ch3, &ch[3])
 /**
- * @brief External RX channel converted to thrust
+ * @brief External RX received channel 4 value
  */
-LOG_ADD(LOG_UINT16, thrust, &extrxSetpoint.thrust)
+LOG_ADD(LOG_UINT16, ch4, &ch[4])
 /**
- * @brief External RX channel converted to roll
+ * @brief External RX received channel 5 value
+ */
+LOG_ADD(LOG_UINT16, ch5, &ch[5])
+/**
+ * @brief External RX received channel 6 value
+ */
+LOG_ADD(LOG_UINT16, ch6, &ch[6])
+/**
+ * @brief External RX received channel 7 value
+ */
+LOG_ADD(LOG_UINT16, ch7, &ch[7])
+LOG_GROUP_STOP(extrx_raw)
+
+/**
+ * External receiver (RX) log group. This contains setpoints for 
+ * thrust, roll, pitch, yaw rate, z velocity, and arming and 
+ * altitude-hold signals
+ */
+LOG_GROUP_START(extrx)
+/**
+ * @brief External RX thrust
+ */
+LOG_ADD(LOG_FLOAT, thrust, &extrxSetpoint.thrust)
+/**
+ * @brief External RX roll setpoint
  */
 LOG_ADD(LOG_FLOAT, roll, &extrxSetpoint.attitude.roll)
 /**
- * @brief External RX channel converted to pitch
+ * @brief External RX pitch setpoint
  */
 LOG_ADD(LOG_FLOAT, pitch, &extrxSetpoint.attitude.pitch)
 /**
- * @brief External RX channel converted to yaw
+ * @brief External RX yaw rate setpoint
  */
-LOG_ADD(LOG_FLOAT, yaw, &extrxSetpoint.attitude.yaw)
+LOG_ADD(LOG_FLOAT, yawRate, &extrxSetpoint.attitudeRate.yaw)
+/**
+ * @brief External RX z-velocity setpoint
+ */
+LOG_ADD(LOG_FLOAT, zVel, &extrxSetpoint.velocity.z)
+/**
+ * @brief External RX Altitude Hold signal
+ */
+LOG_ADD(LOG_UINT8, AltHold, &extRxAltHold)
+/**
+ * @brief External RX Arming signal
+ */
+LOG_ADD(LOG_UINT8, Arm, &extRxArm)
 LOG_GROUP_STOP(extrx)
 #endif

--- a/tools/make/config.mk.example
+++ b/tools/make/config.mk.example
@@ -117,8 +117,11 @@
 ## Improved altitude hold complementary filter
 # CFLAGS += -DIMPROVED_BARO_Z_HOLD
 
-## External CPPM receiver on PA7
+## External CPPM receiver (by default on PA7/MOSI)
 # CFLAGS += -DDECK_FORCE=bcCPPM # force the CCPM deck if not using BigQuad
+# CFLAGS += -DCPPM_USE_PA2 # use alternative pins for CPPM: PA2(TX2), PA3(RX2), PB4(IO_3), PB5(IO_2) or PB8(IO_1)
+# CFLAGS += -DEXTRX_ALT_HOLD # enable altitude hold with external Rx
+# CFLAGS += -DEXTRX_ARMING # enable arming with external Rx (setup via "Brushless handling" compile flags)
 # CFLAGS += -DEXTRX_TAER # use TAER channel mapping instead of the default AETR - Aileron(Roll), Elevator(Pitch), Thrust, Rudder(Yaw)
 
 ## Euler angles defining nonstandard IMU orientation on the airframe (in degrees)


### PR DESCRIPTION
This PR further improves the support of external CPPM receivers:
- alternative GPIO's can be used: PA7(MOSI), PA2(TX2), PA3(RX2), PB4(IO_3), PB5(IO_2) or PB8(IO_1). This allows to use a CPPM receiver alongside many of the decks without pin interference
- switches can be used for arming and triggering altitude hold
- initialization of all channels is improved to prevent undefined behaviour when no physical receiver is connected, or when transmitter is switched on after the crazyflie
- logs are split into two groups: ext_raw for raw channel data (8 channels now) and ext for processed data
- some other minor fixes