### PR TITLE
Implementation for #854. Control onboard LEDs via parameters.

### DIFF
--- a/docs/userguides/logparam.md
+++ b/docs/userguides/logparam.md
@@ -109,6 +109,9 @@ variables in run-time, but note the following:
     logging framework.
 -   The reading or writing of a parameter can be done at any time once
     you are connected to the Crazyflie.
+-   If the callback parameter version is used to get notified that it has
+    changed, it will run from the param task, it should not block and should 
+    run quickly.
 
 ## Logging
 
@@ -210,3 +213,21 @@ Note: The rate computation function is called from the logging framework with th
 specifed in the logging configuration. The rate, on the other hand, is calculated if the time since
 last computation exceeds the configured update time of the rate logger, and if the logging intervall
 is longer than the update intervall, updates will be done for each logging call.
+
+### Parameter callback function to get notifed when a parameter has been updated.
+
+Using the macro `PARAM_ADD_WITH_CALLBACK` it is possible to register a callback function that will be called
+when the parameter gets updated. This callback will run from the parameter task so it is important to not 
+block in this callback or make it run for too long.
+
+Example:
+         void myCallbackFunction(void)
+         {
+            // The parameter has been updated before the callback and the new parameter value can be used
+            digitalWrite(DECK_GPIO_IO1, pinValue);
+         }
+         
+         ...
+         
+         PARAM_ADD_WITH_CALLBACK(PARAM_UINT8, setIO1pin, &pinValue, &myCallbackFunction)
+

--- a/src/drivers/interface/led.h
+++ b/src/drivers/interface/led.h
@@ -58,6 +58,7 @@
 #define LED_NUM 6
 
 typedef enum {LED_BLUE_L = 0, LED_GREEN_L, LED_RED_L, LED_GREEN_R, LED_RED_R, LED_BLUE_NRF} led_t;
+typedef enum { LED_LEDSEQ, LED_PARAM_BITMASK } ledSwitch_t;
 
 void ledInit();
 bool ledTest();
@@ -71,11 +72,8 @@ void ledSetAll(void);
 // Procedures to set the status of the LEDs
 void ledSet(led_t led, bool value);
 
-// Lowest level procedures to set the status of the LEDs
-void ledSetOverride(led_t led, bool value);
-
 // Shoes fault pattern (2 Red ON, 2 Green and Blue OFF)
-void ledSetFault(void);
+void ledShowFaultPattern(void);
 
 //Legacy functions
 #define ledSetRed(VALUE) ledSet(LED_RED, VALUE)

--- a/src/drivers/interface/led.h
+++ b/src/drivers/interface/led.h
@@ -55,21 +55,24 @@
 #define ERR_LED1         LED_RED_L
 #define ERR_LED2         LED_RED_R
 
-#define LED_NUM 5
+#define LED_NUM 6
 
-typedef enum {LED_BLUE_L = 0, LED_GREEN_L, LED_RED_L, LED_GREEN_R, LED_RED_R} led_t;
+typedef enum {LED_BLUE_L = 0, LED_GREEN_L, LED_RED_L, LED_GREEN_R, LED_RED_R, LED_BLUE_NRF} led_t;
 
 void ledInit();
 bool ledTest();
 
-// Clear all configured LEDs
+// Clear all configured LEDs, including NRF LED
 void ledClearAll(void);
 
-// Set all configured LEDs
+// Set all configured LEDs, including NRF LED
 void ledSetAll(void);
 
 // Procedures to set the status of the LEDs
 void ledSet(led_t led, bool value);
+
+// Shoes fault pattern (2 Red ON, 2 Green and Blue OFF)
+void ledSetFault(void);
 
 void ledTask(void *param);
 

--- a/src/drivers/interface/led.h
+++ b/src/drivers/interface/led.h
@@ -71,10 +71,11 @@ void ledSetAll(void);
 // Procedures to set the status of the LEDs
 void ledSet(led_t led, bool value);
 
+// Lowest level procedures to set the status of the LEDs
+void ledSetOverride(led_t led, bool value);
+
 // Shoes fault pattern (2 Red ON, 2 Green and Blue OFF)
 void ledSetFault(void);
-
-void ledTask(void *param);
 
 //Legacy functions
 #define ledSetRed(VALUE) ledSet(LED_RED, VALUE)

--- a/src/drivers/src/nvic.c
+++ b/src/drivers/src/nvic.c
@@ -129,9 +129,7 @@ void DONT_DISCARD printHardFault(uint32_t* hardfaultArgs)
   UART_PRINT("DFSR = %x\n", (*((volatile unsigned int *)(0xE000ED30))));
   UART_PRINT("AFSR = %x\n", (*((volatile unsigned int *)(0xE000ED3C))));
 
-  ledClearAll();
-  ledSet(ERR_LED1, 1);
-  ledSet(ERR_LED2, 1);
+  ledSetFault();
   powerStop();
 
   storeAssertHardfaultData(
@@ -152,9 +150,7 @@ void DONT_DISCARD printHardFault(uint32_t* hardfaultArgs)
 void DONT_DISCARD MemManage_Handler(void)
 {
   /* Go to infinite loop when Memory Manage exception occurs */
-  ledClearAll();
-  ledSet(ERR_LED1, 1);
-  ledSet(ERR_LED2, 1);
+  ledSetFault();
   powerStop();
 
   storeAssertTextData("MemManage");
@@ -168,9 +164,7 @@ void DONT_DISCARD MemManage_Handler(void)
 void DONT_DISCARD BusFault_Handler(void)
 {
   /* Go to infinite loop when Bus Fault exception occurs */
-  ledClearAll();
-  ledSet(ERR_LED1, 1);
-  ledSet(ERR_LED2, 1);
+  ledSetFault();
   powerStop();
 
   storeAssertTextData("BusFault");
@@ -184,9 +178,7 @@ void DONT_DISCARD BusFault_Handler(void)
 void DONT_DISCARD UsageFault_Handler(void)
 {
   /* Go to infinite loop when Usage Fault exception occurs */
-  ledClearAll();
-  ledSet(ERR_LED1, 1);
-  ledSet(ERR_LED2, 1);
+  ledSetFault();
   powerStop();
 
   storeAssertTextData("UsageFault");

--- a/src/drivers/src/nvic.c
+++ b/src/drivers/src/nvic.c
@@ -129,8 +129,8 @@ void DONT_DISCARD printHardFault(uint32_t* hardfaultArgs)
   UART_PRINT("DFSR = %x\n", (*((volatile unsigned int *)(0xE000ED30))));
   UART_PRINT("AFSR = %x\n", (*((volatile unsigned int *)(0xE000ED3C))));
 
-  ledSetFault();
   powerStop();
+  ledShowFaultPattern();
 
   storeAssertHardfaultData(
     stacked_r0,
@@ -150,7 +150,7 @@ void DONT_DISCARD printHardFault(uint32_t* hardfaultArgs)
 void DONT_DISCARD MemManage_Handler(void)
 {
   /* Go to infinite loop when Memory Manage exception occurs */
-  ledSetFault();
+  ledShowFaultPattern();
   powerStop();
 
   storeAssertTextData("MemManage");
@@ -164,8 +164,8 @@ void DONT_DISCARD MemManage_Handler(void)
 void DONT_DISCARD BusFault_Handler(void)
 {
   /* Go to infinite loop when Bus Fault exception occurs */
-  ledSetFault();
   powerStop();
+  ledShowFaultPattern();
 
   storeAssertTextData("BusFault");
   while (1)
@@ -178,8 +178,8 @@ void DONT_DISCARD BusFault_Handler(void)
 void DONT_DISCARD UsageFault_Handler(void)
 {
   /* Go to infinite loop when Usage Fault exception occurs */
-  ledSetFault();
   powerStop();
+  ledShowFaultPattern();
 
   storeAssertTextData("UsageFault");
   while (1)

--- a/src/hal/interface/syslink.h
+++ b/src/hal/interface/syslink.h
@@ -59,6 +59,8 @@
 #define SYSLINK_PM_BATTERY_AUTOUPDATE 0x14
 #define SYSLINK_PM_SHUTDOWN_REQUEST   0x15
 #define SYSLINK_PM_SHUTDOWN_ACK       0x16
+#define SYSLINK_PM_LED_ON             0x17
+#define SYSLINK_PM_LED_OFF            0x18
 
 #define SYSLINK_OW_GROUP    0x20
 #define SYSLINK_OW_SCAN     0x20
@@ -90,6 +92,7 @@ typedef enum
 
 void syslinkInit();
 bool syslinkTest();
+bool isSyslinkUp();
 int syslinkSendPacket(SyslinkPacket *slp);
 
 #endif

--- a/src/hal/src/syslink.c
+++ b/src/hal/src/syslink.c
@@ -139,6 +139,12 @@ bool syslinkTest()
   return isInit;
 }
 
+bool isSyslinkUp()
+{
+  return isInit;
+}
+
+
 int syslinkSendPacket(SyslinkPacket *slp)
 {
   int i = 0;

--- a/src/modules/interface/param.h
+++ b/src/modules/interface/param.h
@@ -172,16 +172,20 @@ struct param_s {
 #ifndef UNIT_TEST_MODE
 
 #define PARAM_ADD(TYPE, NAME, ADDRESS) \
-   { .type = TYPE, .name = #NAME, .address = (void*)(ADDRESS), },
+  { .type = TYPE, .name = #NAME, .address = (void*)(ADDRESS), },
+
+// The callback notification function will run from the param task, it should not block and should run quickly.
+#define PARAM_ADD_WITH_CALLBACK(TYPE, NAME, ADDRESS, CALLBACK) \
+  { .type = TYPE | PARAM_CALLBACK, .name = #NAME, .address = (void*)(ADDRESS), .callback = (void *)CALLBACK, },
 
 #define PARAM_ADD_CORE(TYPE, NAME, ADDRESS) \
   PARAM_ADD(TYPE | PARAM_CORE, NAME, ADDRESS)
 
-#define PARAM_ADD_WITH_CALLBACK(TYPE, NAME, ADDRESS, CALLBACK) \
-   { .type = TYPE | PARAM_CALLBACK, .name = #NAME, .address = (void*)(ADDRESS), .callback = (void *)CALLBACK, },
+#define PARAM_ADD_CORE_WITH_CALLBACK(TYPE, NAME, ADDRESS, CALLBACK) \
+  PARAM_ADD_WITH_CALLBACK(TYPE | PARAM_CORE, NAME, ADDRESS, CALLBACK)
 
 #define PARAM_ADD_GROUP(TYPE, NAME, ADDRESS) \
-   { \
+  { \
   .type = TYPE, .name = #NAME, .address = (void*)(ADDRESS), },
 
 #define PARAM_GROUP_START(NAME)  \

--- a/src/modules/interface/param.h
+++ b/src/modules/interface/param.h
@@ -129,6 +129,7 @@ struct param_s {
   uint8_t type;
   char * name;
   void * address;
+  void (*callback)(void);
 };
 
 #define PARAM_BYTES_MASK 0x03
@@ -145,6 +146,8 @@ struct param_s {
 
 #define PARAM_VARIABLE (0x00<<7)
 #define PARAM_GROUP    (0x01<<7)
+
+#define PARAM_CALLBACK (1<<4)
 
 #define PARAM_CORE (1<<5)
 
@@ -173,6 +176,9 @@ struct param_s {
 
 #define PARAM_ADD_CORE(TYPE, NAME, ADDRESS) \
   PARAM_ADD(TYPE | PARAM_CORE, NAME, ADDRESS)
+
+#define PARAM_ADD_WITH_CALLBACK(TYPE, NAME, ADDRESS, CALLBACK) \
+   { .type = TYPE | PARAM_CALLBACK, .name = #NAME, .address = (void*)(ADDRESS), .callback = (void *)CALLBACK, },
 
 #define PARAM_ADD_GROUP(TYPE, NAME, ADDRESS) \
    { \

--- a/src/modules/src/param.c
+++ b/src/modules/src/param.c
@@ -358,6 +358,11 @@ static void paramWriteProcess()
     }
 
     crtpSendPacketBlock(&p);
+
+    if ((params[id].type & PARAM_CALLBACK) && params[id].callback) {
+      params[id].callback();
+    }
+
   } else {
     int ident = p.data[0];
     void* valptr = &p.data[1];

--- a/src/utils/src/cfassert.c
+++ b/src/utils/src/cfassert.c
@@ -81,9 +81,7 @@ void assertFail(char *exp, char *file, int line)
   storeAssertFileData(file, line);
   DEBUG_PRINT("Assert failed %s:%d\n", file, line);
 
-  ledClearAll();
-  ledSet(ERR_LED1, 1);
-  ledSet(ERR_LED2, 1);
+  ledSetFault();
   powerStop();
 
   NVIC_SystemReset();

--- a/src/utils/src/cfassert.c
+++ b/src/utils/src/cfassert.c
@@ -81,8 +81,8 @@ void assertFail(char *exp, char *file, int line)
   storeAssertFileData(file, line);
   DEBUG_PRINT("Assert failed %s:%d\n", file, line);
 
-  ledSetFault();
   powerStop();
+  ledShowFaultPattern();
 
   NVIC_SystemReset();
 }


### PR DESCRIPTION
This adds functionality to control the LEDs via parameters. If it is enabled it will override the normal LED control.

The control is done through a bitmask parameter and if bit 7 is set it will be enabled:
| 7:ENABLE | 6:N/A | 5:BLUE_R | 4:RED_R | 3:GREEN_R | 2:RED_L | 1:GREEN_L | 0:BLUE_L |

The blue NRF LED was added to the led driver and will be controlled via the syslink. Thus the nRF FW with this support must run a version including [this](https://github.com/bitcraze/crazyflie2-nrf-firmware/issues/65) issue.

To simplify the update of a change of the parameter a callback option when creating a parameter was added, e.g:
PARAM_ADD_WITH_CALLBACK(PARAM_UINT8, setIO1pin, &pinValue, &myCallbackFunction)

One of the test I did using the a clib script can be found below.
```
import logging
import time

import cflib.crtp
from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
from cflib.utils import uri_helper

# URI to the Crazyflie to connect to
URI = uri_helper.uri_from_env(default='radio://0/80/2M/E7E7E7E7E7')

# Only output errors from the logging framework
logging.basicConfig(level=logging.ERROR)

bitSeq = [0b10000001, 0b10000010, 0b10001000, 0b10100000,
          0b10000001, 0b10000100, 0b10010000, 0b10100000] 

if __name__ == '__main__':
    # Initialize the low-level drivers
    cflib.crtp.init_drivers()

    with SyncCrazyflie(URI) as scf:
        cf = scf.cf

# Create a spinning effect using the onboard LEDs
        for i in range(10):         
            for j in range(8):
                # Set black color effect
                cf.param.set_value('led.bitmask', bitSeq[j])
                time.sleep(0.15)
```