### PR TITLE
cf_math: Avoid double expression evaluation for MIN(), MAX()

### DIFF
--- a/src/utils/interface/cf_math.h
+++ b/src/utils/interface/cf_math.h
@@ -41,8 +41,19 @@
 #define DEG_TO_RAD (PI/180.0f)
 #define RAD_TO_DEG (180.0f/PI)
 
-#define MIN(a, b) ((b) < (a) ? (b) : (a))
-#define MAX(a, b) ((b) > (a) ? (b) : (a))
+#define MIN(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a < _b ? _a : _b;      \
+  })
+
+#define MAX(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a > _b ? _a : _b;      \
+  })
 
 // Matrix data must be aligned on 4 byte bundaries
 static inline void assert_aligned_4_bytes(const arm_matrix_instance_f32* matrix) {


### PR DESCRIPTION
The standard MIN()/MAX() macros can have the unwanted side effect of the
arguments being evaluated twice. Switch to the new "statement
expressions" offered in gcc/clang (see
https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html#Statement-Exprs).