### PR TITLE
delete redundant extern declaration

### DIFF
--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -80,7 +80,6 @@ struct trajectoryDescription
 // 4k allows us to store 31 poly4d pieces
 // other (compressed) formats might be added in the future
 #define TRAJECTORY_MEMORY_SIZE 4096
-extern uint8_t trajectories_memory[TRAJECTORY_MEMORY_SIZE];
 
 #define ALL_GROUPS 0
 


### PR DESCRIPTION
This `extern` declaration for trajectory memory used to be in the high level commander header, but was abstracted behind a read/write API in 73a4e938ce6. The variable is defined in `crtp_commander_high_level.c` a few lines below, so an `extern` declaration visible only to `crtp_commander_high_level.c` is redundant.