### PR TITLE
move relative trajectory shift computation into planner.c

### DIFF
--- a/src/modules/interface/planner.h
+++ b/src/modules/interface/planner.h
@@ -98,11 +98,11 @@ int plan_go_to(struct planner *p, bool relative, struct vec hover_pos, float hov
 // same as above, but with current state provided from outside.
 int plan_go_to_from(struct planner *p, const struct traj_eval *curr_eval, bool relative, struct vec hover_pos, float hover_yaw, float duration, float t);
 
-// start trajectory
-int plan_start_trajectory(struct planner *p, const struct piecewise_traj* trajectory, bool reversed);
+// start trajectory. start_from param is ignored if relative == false.
+int plan_start_trajectory(struct planner *p, struct piecewise_traj* trajectory, bool reversed, bool relative, struct vec start_from);
 
-// start compressed trajectory
-int plan_start_compressed_trajectory(struct planner *p, struct piecewise_traj_compressed* trajectory);
+// start compressed trajectory. start_from param is ignored if relative == false.
+int plan_start_compressed_trajectory(struct planner *p, struct piecewise_traj_compressed* trajectory, bool relative, struct vec start_from);
 
 // Query if the trjectory is finished
 bool plan_is_finished(struct planner *p, float t);

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -566,21 +566,7 @@ int start_trajectory(const struct data_start_trajectory* data)
         trajectory.timescale = data->timescale;
         trajectory.n_pieces = trajDesc->trajectoryIdentifier.mem.n_pieces;
         trajectory.pieces = (struct poly4d*)&trajectories_memory[trajDesc->trajectoryIdentifier.mem.offset];
-        if (data->relative) {
-          trajectory.shift = vzero();
-          struct traj_eval traj_init;
-          if (data->reversed) {
-            traj_init = piecewise_eval_reversed(&trajectory, trajectory.t_begin);
-          }
-          else {
-            traj_init = piecewise_eval(&trajectory, trajectory.t_begin);
-          }
-          struct vec shift_pos = vsub(pos, traj_init.pos);
-          trajectory.shift = shift_pos;
-        } else {
-          trajectory.shift = vzero();
-        }
-        result = plan_start_trajectory(&planner, &trajectory, data->reversed);
+        result = plan_start_trajectory(&planner, &trajectory, data->reversed, data->relative, pos);
         xSemaphoreGive(lockTraj);
       } else if (trajDesc->trajectoryLocation == TRAJECTORY_LOCATION_MEM
           && trajDesc->trajectoryType == CRTP_CHL_TRAJECTORY_TYPE_POLY4D_COMPRESSED) {
@@ -595,16 +581,7 @@ int start_trajectory(const struct data_start_trajectory* data)
             &trajectories_memory[trajDesc->trajectoryIdentifier.mem.offset]
           );
           compressed_trajectory.t_begin = t;
-          if (data->relative) {
-            struct traj_eval traj_init = piecewise_compressed_eval(
-              &compressed_trajectory, compressed_trajectory.t_begin
-            );
-            struct vec shift_pos = vsub(pos, traj_init.pos);
-            compressed_trajectory.shift = shift_pos;
-          } else {
-            compressed_trajectory.shift = vzero();
-          }
-          result = plan_start_compressed_trajectory(&planner, &compressed_trajectory);
+          result = plan_start_compressed_trajectory(&planner, &compressed_trajectory, data->relative, pos);
           xSemaphoreGive(lockTraj);
         }
 


### PR DESCRIPTION
When executing a previously uploaded trajectory in relative position mode, we need some slightly bulky and non-obvious branching code to deal with the forward/reverse and regular/compressed polynomial options.

This code currently lives in `crtp_commander_high_level.c`. In my opinion, it would be more appropriate to move it into `planner.c` because that is the high-level wrapper in between polynomials and the user. This would leave `crtp_commander_high_level.c` only responsible for listening to the radio and managing trajectory memory.

Note that this changes the planner API but not the crtpHighLevelCommander API. To my understanding, only the latter is considered "public" w.r.t. the app layer.

This change will be useful for the bind-able top level commander state machine proposed in #861, but IMO is worth doing even if that idea is ultimately rejected.

I flight tested with regular polynomials but not compressed polynomials.