### PR TITLE
disabled warnings for incorrectly detected sector size (fixes compilation for GCC11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,12 @@ endif
 # Disable warnings for unaligned addresses in packed structs (added in GCC 9)
 CFLAGS += -Wno-address-of-packed-member
 
+# Disable warnings for incorrectly detected region size (added in GCC 11)
+# The compiler is not detecting properly GPIO structure size
+CFLAGS += -Wno-array-bounds
+CFLAGS += -Wno-stringop-overread
+CFLAGS += -Wno-stringop-overflow
+
 ifeq ($(LTO), 1)
   CFLAGS += -flto
 endif


### PR DESCRIPTION
fixes #876 