### PR TITLE
Add const to string parameters

### DIFF
--- a/src/hal/interface/storage.h
+++ b/src/hal/interface/storage.h
@@ -62,7 +62,7 @@ bool storageTest();
  * 
  * @return true in case of success, false otherwise.
  */
-bool storageStore(char* key, const void* buffer, size_t length);
+bool storageStore(const char* key, const void* buffer, size_t length);
 
 /**
  * Fetch a buffer from the memory at some key.
@@ -75,7 +75,7 @@ bool storageStore(char* key, const void* buffer, size_t length);
  *         receiving buffer, and the length of the data in memory. If the key is not found
  *         this function returns 0.
  */
-size_t storageFetch(char *key, void* buffer, size_t length);
+size_t storageFetch(const char *key, void* buffer, size_t length);
 
 /**
  * Deletes and entry from the storage.
@@ -84,4 +84,4 @@ size_t storageFetch(char *key, void* buffer, size_t length);
  * 
  * @return true in case of success. false if the key was not found or if an error occured.
  */
-bool storageDelete(char* key);
+bool storageDelete(const char* key);

--- a/src/hal/src/storage.c
+++ b/src/hal/src/storage.c
@@ -148,7 +148,7 @@ bool storageTest()
   return pass;
 }
 
-bool storageStore(char* key, const void* buffer, size_t length)
+bool storageStore(const char* key, const void* buffer, size_t length)
 {
   if (!isInit) {
     return false;
@@ -163,7 +163,7 @@ bool storageStore(char* key, const void* buffer, size_t length)
   return result;
 }
 
-size_t storageFetch(char *key, void* buffer, size_t length)
+size_t storageFetch(const char *key, void* buffer, size_t length)
 {
   if (!isInit) {
     return 0;
@@ -178,7 +178,7 @@ size_t storageFetch(char *key, void* buffer, size_t length)
   return result;
 }
 
-bool storageDelete(char* key)
+bool storageDelete(const char* key)
 {
   if (!isInit) {
     return false;

--- a/src/modules/interface/console.h
+++ b/src/modules/interface/console.h
@@ -63,7 +63,7 @@ int consolePutcharFromISR(int ch);
  * @param str Null terminated string
  * @return a nonnegative number on success, or EOF on error.
  */
-int consolePuts(char *str);
+int consolePuts(const char *str);
 
 /**
  * Flush the console buffer

--- a/src/modules/interface/log.h
+++ b/src/modules/interface/log.h
@@ -51,7 +51,7 @@ typedef uint16_t logVarId_t;
  * @param name Name of the variable
  * @return The variable ID or an invalid ID. Use logVarIdIsValid() to check validity.
  */
-logVarId_t logGetVarId(char* group, char* name);
+logVarId_t logGetVarId(const char* group, const char* name);
 
 /** Check variable ID validity
  *

--- a/src/modules/interface/param.h
+++ b/src/modules/interface/param.h
@@ -54,7 +54,7 @@ typedef struct paramVarId_s {
  * @param name Name of the variable
  * @return The variable ID or an invalid ID. Use PARAM_VARID_IS_VALID() to check validity.
  */
-paramVarId_t paramGetVarId(char* group, char* name);
+paramVarId_t paramGetVarId(const char* group, const char* name);
 
 /** Check variable ID validity
  *

--- a/src/modules/src/console.c
+++ b/src/modules/src/console.c
@@ -148,7 +148,7 @@ int consolePutcharFromISR(int ch) {
   return ch;
 }
 
-int consolePuts(char *str)
+int consolePuts(const char *str)
 {
   int ret = 0;
 

--- a/src/modules/src/log.c
+++ b/src/modules/src/log.c
@@ -971,7 +971,7 @@ static void logReset(void)
 /* Public API to access log TOC from within the copter */
 static logVarId_t invalidVarId = 0xffffu;
 
-logVarId_t logGetVarId(char* group, char* name)
+logVarId_t logGetVarId(const char* group, const char* name)
 {
   int i;
   logVarId_t varId = invalidVarId;

--- a/src/modules/src/param.c
+++ b/src/modules/src/param.c
@@ -553,7 +553,7 @@ static int variableGetIndex(int id)
 /* Public API to access param TOC from within the copter */
 static paramVarId_t invalidVarId = {0xffffu, 0xffffu};
 
-paramVarId_t paramGetVarId(char* group, char* name)
+paramVarId_t paramGetVarId(const char* group, const char* name)
 {
   int ptr;
   int id = 0;

--- a/src/utils/interface/kve/kve.h
+++ b/src/utils/interface/kve/kve.h
@@ -35,11 +35,11 @@
 
 void kveDefrag(kveMemory_t *kve);
 
-bool kveStore(kveMemory_t *kve, char* key, const void* buffer, size_t length);
+bool kveStore(kveMemory_t *kve, const char* key, const void* buffer, size_t length);
 
 size_t kveFetch(kveMemory_t *kve, const char* key, void* buffer, size_t bufferLength);
 
-bool kveDelete(kveMemory_t *kve, char* key);
+bool kveDelete(kveMemory_t *kve, const char* key);
 
 void kveFormat(kveMemory_t *kve);
 

--- a/src/utils/src/kve/kve.c
+++ b/src/utils/src/kve/kve.c
@@ -89,7 +89,7 @@ void kveDefrag(kveMemory_t *kve) {
     }
 }
 
-bool kveStore(kveMemory_t *kve, char* key, const void* buffer, size_t length) {
+bool kveStore(kveMemory_t *kve, const char* key, const void* buffer, size_t length) {
     size_t itemAddress;
 
     // Search if the key is already present in the table
@@ -127,7 +127,7 @@ size_t kveFetch(kveMemory_t *kve, const char* key, void* buffer, size_t bufferLe
     return 0;
 }
 
-bool kveDelete(kveMemory_t *kve, char* key) {
+bool kveDelete(kveMemory_t *kve, const char* key) {
     size_t itemAddress = kveStorageFindItemByKey(kve, FIRST_ITEM_ADDRESS, key);
 
     if (KVE_STORAGE_IS_VALID(itemAddress)) {


### PR DESCRIPTION
If a function does not modify its string input, it should be declared const so that the api user knows that the string will not be modified (it can be static) and to make the compiler check that we are not modifying the strings.

This PR adds const everywhere I could find it was needed.