### PR TITLE
deck_memory: Support secondary memory definition

### DIFF
--- a/src/deck/core/deck_memory.c
+++ b/src/deck/core/deck_memory.c
@@ -98,19 +98,53 @@ static uint8_t populateBitfield(const DeckMemDef_t* memDef) {
     return result;
 }
 
-static void populateDeckMemoryInfo(uint8_t buffer[], const uint8_t deckNr) {
+static void populateDeckMemoryInfoBuffer(const DeckMemDef_t *deckMemDef,
+                                         const char *name,
+                                         uint32_t baseAddress,
+                                         uint8_t buffer[])
+{
+    buffer[OFFS_BITFIELD] = populateBitfield(deckMemDef);
+    memcpy(&buffer[OFFS_REQ_HASH], &deckMemDef->requiredHash, 4);
+    memcpy(&buffer[OFFS_REQ_LEN], &deckMemDef->requiredSize, 4);
+    memcpy(&buffer[OFFS_BASE_ADDR], &baseAddress, 4);
+    strncpy((char*)&buffer[OFFS_NAME], name, NAME_LEN_EX_ZERO_TREM);
+
+    //
+    // If the memory definition has an id we append it to the name using
+    // a colon:
+    // name "bcAI" + id "gap8" => "bcAI:gap8"
+    //
+    if (deckMemDef->id) {
+        size_t namelen = strlen(name);
+        buffer[OFFS_NAME + namelen] = ':';
+        memcpy(
+            &buffer[OFFS_NAME] + namelen + 1,
+            deckMemDef->id,
+            strlen(deckMemDef->id)
+        );
+    }
+}
+
+//
+// Fill in information to the deck memory areas primary and secondary, if
+// present. The information is taken from the deck driver.
+//
+static void populateDeckMemoryInfos(uint8_t buffer[], const int deckNr) {
     DeckInfo* info = deckInfo(deckNr);
-    memset(buffer, 0, DECK_MEMORY_INFO_SIZE);
+    memset(buffer, 0, DECK_MEMORY_INFO_SIZE * 2); // primary plus secondary
 
     const DeckMemDef_t* deckMemDef = info->driver->memoryDef;
     if (deckMemDef) {
         uint32_t baseAddress = (deckNr + 1) * DECK_MEM_MAX_SIZE;
+        populateDeckMemoryInfoBuffer(deckMemDef, info->driver->name,
+                                     baseAddress, buffer);
+    }
 
-        buffer[OFFS_BITFIELD] = populateBitfield(deckMemDef);
-        memcpy(&buffer[OFFS_REQ_HASH], &deckMemDef->requiredHash, 4);
-        memcpy(&buffer[OFFS_REQ_LEN], &deckMemDef->requiredSize, 4);
-        memcpy(&buffer[OFFS_BASE_ADDR], &baseAddress, 4);
-        strncpy((char*)&buffer[OFFS_NAME], info->driver->name, NAME_LEN_EX_ZERO_TREM);
+    const DeckMemDef_t* deckMemDefSecondary = info->driver->memoryDefSecondary;
+    if (deckMemDefSecondary) {
+        uint32_t baseAddress = (deckNr + 2) * DECK_MEM_MAX_SIZE;
+        populateDeckMemoryInfoBuffer(deckMemDefSecondary, info->driver->name,
+                                     baseAddress, buffer + DECK_MEMORY_INFO_SIZE);
     }
 }
 
@@ -127,21 +161,22 @@ static bool handleInfoSectionRead(const uint32_t memAddr, const uint8_t readLen,
         bytesLeft--;
     }
 
-    // Deck memory infos
+    // Deck memory infos, it is times 2 because we can have a secondary memDef
     while (bytesLeft > 0) {
-        int deckNr = (memAddr + index - 1) / DECK_MEMORY_INFO_SIZE;
+        int deckNr = (memAddr + index - 1) / (DECK_MEMORY_INFO_SIZE * 2);
 
         if (deckNr >= nrOfDecks) {
             break;
         }
 
-        uint8_t deckMemoryInfo[DECK_MEMORY_INFO_SIZE];
-        populateDeckMemoryInfo(deckMemoryInfo, deckNr);
+        uint8_t deckMemoryInfo[DECK_MEMORY_INFO_SIZE * 2];
 
-        int startAddrOfThisInfo = deckNr * DECK_MEMORY_INFO_SIZE + 1;
+        populateDeckMemoryInfos(deckMemoryInfo, deckNr);
+
+        int startAddrOfThisInfo = deckNr * (DECK_MEMORY_INFO_SIZE * 2) + 1;
         int firstByteToUse = memAddr + index - startAddrOfThisInfo;
 
-        int bytesToUse = DECK_MEMORY_INFO_SIZE - firstByteToUse;
+        int bytesToUse = (DECK_MEMORY_INFO_SIZE * 2) - firstByteToUse;
         if (bytesLeft < bytesToUse) {
             bytesToUse = bytesLeft;
         }

--- a/src/deck/interface/deck_core.h
+++ b/src/deck/interface/deck_core.h
@@ -96,8 +96,12 @@ typedef struct deck_driver {
   StateEstimatorType requiredEstimator;
   bool requiredLowInterferenceRadioMode;
 
-  // Deck memory access definition
+  // Deck memory access definitions
   const struct deckMemDef_s* memoryDef;
+
+  // Have an option to present a secondary memory area for instance for decks
+  // two firmwares.
+  const struct deckMemDef_s* memoryDefSecondary;
 
   /* Init and test functions */
   void (*init)(struct deckInfo_s *);
@@ -195,6 +199,8 @@ typedef struct deckMemDef_s {
   // TOOD krri rename to length?
   uint32_t requiredSize;
 
+  // Optional id, if non-null will be added to the name as [drivername:id]
+  const char *id;
 } DeckMemDef_t;
 
 int deckCount(void);

--- a/test/deck/core/test_deck_memory.c
+++ b/test/deck/core/test_deck_memory.c
@@ -33,7 +33,7 @@ DeckInfo stockInfo;
 
 
 // Constants
-#define SIZE_ONE_DECK 0x20
+#define SIZE_ONE_DECK 0x40
 #define MAX_NR_DECKS 4
 #define BUF_SIZE (SIZE_ONE_DECK * MAX_NR_DECKS)
 uint8_t buffer[BUF_SIZE];


### PR DESCRIPTION
The primary driver here is support two firmwares for one deck, like the
AI deck with the GAP8 and the Nina module.

This makes it possible to set an id to a memory definition so you could
have:

```c
static const DeckMemDef_t memoryDefNina = {
  .write = write_nina,
  .read = read_nina,
  .properties = properties_nina,
  .supportsUpgrade = true,

  .requiredSize = ...,
  .requiredHash = ...,
};

static const DeckMemDef_t memoryDefGap8 = {
  .write = write_gap8,
  .read = read_gap8,
  .properties = properties_gap8,
  .supportsUpgrade = true,

  .requiredSize = ...,
  .requiredHash = ...,

  .id = "gap8"
};

static const DeckDriver aideck_deck = {
    .vid = 0xBC,
    .pid = 0x12,
    .name = "bcAI",

    .usedGpio = DECK_USING_IO_4,
    .usedPeriph = DECK_USING_UART1,

    .init = aideckInit,
    .test = aideckTest,

    .memoryDef = memoryDefNina,
    .memoryDefSecondary = memoryDefGap8,
};
```

And the names visible to the lib would be:
    "bcAI" and
    "bcAI:gap8"
