### PR TITLE
Python bindings for pptraj and planner modules

### DIFF
--- a/bindings/cffirmware.i
+++ b/bindings/cffirmware.i
@@ -6,11 +6,35 @@
 %{
 #define SWIG_FILE_WITH_INIT
 #include "math3d.h"
+#include "pptraj.h"
+#include "planner.h"
 %}
 
 %include "math3d.h"
+%include "pptraj.h"
+%include "planner.h"
 
 %inline %{
+struct poly4d* piecewise_get(struct piecewise_traj *pp, int i)
+{
+    return &pp->pieces[i];
+}
+void poly4d_set(struct poly4d *poly, int dim, int coef, float val)
+{
+    poly->p[dim][coef] = val;
+}
+float poly4d_get(struct poly4d *poly, int dim, int coef)
+{
+    return poly->p[dim][coef];
+}
+struct poly4d* poly4d_malloc(int size)
+{
+    return (struct poly4d*)malloc(sizeof(struct poly4d) * size);
+}
+void poly4d_free(struct poly4d *p)
+{
+    free(p);
+}
 %}
 
 %pythoncode %{

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -10,7 +10,9 @@ include = [
 ]
 
 modules = [
-    # list firmware c-files here
+    "pptraj.c",
+    "pptraj_compressed.c",
+    "planner.c"
 ]
 fw_sources = [os.path.join(fw_dir, "src/modules/src", mod) for mod in modules]
 
@@ -20,6 +22,9 @@ cffirmware = Extension(
     sources=fw_sources + ["bin/cffirmware_wrap.c"],
     extra_compile_args=[
         "-O3",
+        # The following flags are also used for compiling the actual firmware
+        "-fno-strict-aliasing",
+        "-Wno-address-of-packed-member",
     ],
 )
 

--- a/test_python/test_planner.py
+++ b/test_python/test_planner.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import numpy as np
+import cffirmware
+
+def test_takeoff():
+    # Fixture
+    planner = cffirmware.planner()
+    cffirmware.plan_init(planner)
+    pos = cffirmware.mkvec(0, 0, 0)
+    yaw = 0
+    targetHeight = 1.0
+    targetYaw = 0
+    duration = 2
+
+    # Test
+    cffirmware.plan_takeoff(planner, pos, yaw, targetHeight, targetYaw, duration, 0)
+
+    # Assert
+    state = cffirmware.plan_current_goal(planner, duration)
+    assert np.allclose(np.array([0, 0, 1.0]), state.pos)
+    assert np.allclose(np.array([0, 0, 0.0]), state.vel)

--- a/test_python/test_planner.py
+++ b/test_python/test_planner.py
@@ -18,5 +18,5 @@ def test_takeoff():
 
     # Assert
     state = cffirmware.plan_current_goal(planner, duration)
-    assert np.allclose(np.array([0, 0, 1.0]), state.pos)
+    assert np.allclose(np.array([0, 0, targetHeight]), state.pos)
     assert np.allclose(np.array([0, 0, 0.0]), state.vel)

--- a/test_python/test_pptraj.py
+++ b/test_python/test_pptraj.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import numpy as np
+import cffirmware
+
+def test_that_traj_eval_zero_is_actually_zero():
+    # Fixture
+
+    # Test
+    t = cffirmware.traj_eval_zero()
+    valid = cffirmware.is_traj_eval_valid(t)
+
+    # Assert
+    assert valid
+    assert np.allclose(np.zeros(3), t.pos)
+    assert np.allclose(np.zeros(3), t.vel)
+    assert np.allclose(np.zeros(3), t.acc)
+    assert np.allclose(np.zeros(3), t.omega)
+    assert t.yaw == 0
+
+
+def test_that_traj_eval_invalid_is_actually_invalid():
+    # Fixture
+
+    # Test
+    t = cffirmware.traj_eval_invalid()
+    valid = cffirmware.is_traj_eval_valid(t)
+
+    # Assert
+    assert not valid


### PR DESCRIPTION
These bindings are used in the Crazyswarm for SIL simulation of the
high-level mode.