### PR TITLE
Low-level ESP32 bootloader SLIP communication protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ CFLAGS += -DAPP_PRIORITY=$(APP_PRIORITY)
 endif
 
 # Crazyflie sources
-VPATH += $(CRAZYFLIE_BASE)/src/init $(CRAZYFLIE_BASE)/src/hal/src $(CRAZYFLIE_BASE)/src/modules/src $(CRAZYFLIE_BASE)/src/modules/src/lighthouse $(CRAZYFLIE_BASE)/src/modules/src/kalman_core $(CRAZYFLIE_BASE)/src/utils/src $(CRAZYFLIE_BASE)/src/drivers/bosch/src $(CRAZYFLIE_BASE)/src/drivers/src $(CRAZYFLIE_BASE)/src/platform
+VPATH += $(CRAZYFLIE_BASE)/src/init $(CRAZYFLIE_BASE)/src/hal/src $(CRAZYFLIE_BASE)/src/modules/src $(CRAZYFLIE_BASE)/src/modules/src/lighthouse $(CRAZYFLIE_BASE)/src/modules/src/kalman_core $(CRAZYFLIE_BASE)/src/utils/src $(CRAZYFLIE_BASE)/src/drivers/bosch/src $(CRAZYFLIE_BASE)/src/drivers/src $(CRAZYFLIE_BASE)/src/platform $(CRAZYFLIE_BASE)/src/drivers/esp32/src
 VPATH += $(CRAZYFLIE_BASE)/src/utils/src/kve
 
 ############### Source files configuration ################
@@ -140,6 +140,7 @@ PROJ_OBJ += bmi055_accel.o bmi055_gyro.o bmi160.o bmp280.o bstdr_comm_support.o 
 PROJ_OBJ += bmi088_accel.o bmi088_gyro.o bmi088_fifo.o bmp3.o
 PROJ_OBJ += pca9685.o vl53l0x.o pca95x4.o pca9555.o vl53l1x.o pmw3901.o
 PROJ_OBJ += amg8833.o lh_bootloader.o
+PROJ_OBJ += esp_slip.o
 
 # USB Files
 PROJ_OBJ += usb_bsp.o usblink.o usbd_desc.o usb.o
@@ -288,7 +289,7 @@ INCLUDES += -I$(CRAZYFLIE_BASE)/src/config
 INCLUDES += -I$(CRAZYFLIE_BASE)/src/platform
 
 INCLUDES += -I$(CRAZYFLIE_BASE)/src/deck/interface -I$(CRAZYFLIE_BASE)/src/deck/drivers/interface
-INCLUDES += -I$(CRAZYFLIE_BASE)/src/drivers/interface -I$(CRAZYFLIE_BASE)/src/drivers/bosch/interface
+INCLUDES += -I$(CRAZYFLIE_BASE)/src/drivers/interface -I$(CRAZYFLIE_BASE)/src/drivers/bosch/interface -I$(CRAZYFLIE_BASE)/src/drivers/esp32/interface
 INCLUDES += -I$(CRAZYFLIE_BASE)/src/hal/interface
 INCLUDES += -I$(CRAZYFLIE_BASE)/src/modules/interface -I$(CRAZYFLIE_BASE)/src/modules/interface/kalman_core -I$(CRAZYFLIE_BASE)/src/modules/interface/lighthouse
 INCLUDES += -I$(CRAZYFLIE_BASE)/src/utils/interface -I$(CRAZYFLIE_BASE)/src/utils/interface/kve -I$(CRAZYFLIE_BASE)/src/utils/interface/lighthouse -I$(CRAZYFLIE_BASE)/src/utils/interface/tdoa

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -86,4 +86,4 @@ typedef struct
 *
 * @return true if ESP responds with a status byte indicating success.
 **/
-bool espSlipExchange(uint8_t *sendBuffer, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_sendbuffer_t sendBufferFunction, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks);
+bool espSlipExchange(uint8_t *sendBuffer, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_sendbuffer_t sendBufferFunction, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize);

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -45,6 +45,9 @@
 #define CHANGE_BAUDRATE 0x0f
 #define SPI_ATTACH 0x0d
 
+typedef void (*coms_sendbuffer_t)(uint32_t size, uint8_t *data);
+typedef bool (*coms_getDataWithTimeout_t)(uint8_t *c, const uint32_t timeoutTicks);
+
 
 typedef struct
 {

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -30,3 +30,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#define ESP_MTU 4000
+

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -33,3 +33,15 @@
 
 #define ESP_MTU 4000
 
+/* Commands */
+#define DIR_CMD 0x00
+#define FLASH_BEGIN 0x02
+#define FLASH_DATA 0x03
+#define FLASH_END 0x04
+#define SYNC 0x08
+#define SPI_FLASH_MD5 0x13
+#define ERASE_FLASH 0xd0
+#define READ_FLASH 0xd2
+#define CHANGE_BAUDRATE 0x0f
+#define SPI_ATTACH 0x0d
+

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -45,6 +45,8 @@
 #define CHANGE_BAUDRATE 0x0f
 #define SPI_ATTACH 0x0d
 
+#define SLIP_START_STOP_BYTE 0xc0
+
 typedef void (*coms_sendbuffer_t)(uint32_t size, uint8_t *data);
 typedef bool (*coms_getDataWithTimeout_t)(uint8_t *c, const uint32_t timeoutTicks);
 

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -89,4 +89,5 @@ typedef struct
 *
 * @return true if ESP responds with a status byte indicating success.
 **/
-bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks);
+bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction,
+                     espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks);

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -32,7 +32,7 @@
 #include <stdint.h>
 
 #define ESP_MTU 4000
-#define TX_BUFFER_SIZE 128
+#define ESP_SLIP_TX_BUFFER_SIZE 128
 
 /* Commands */
 #define DIR_CMD 0x00

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -1,0 +1,32 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file esp_slip.h
+ * Protocol for assembling, sending, receiving and decoding SLIP packets to/from the ESP32 ROM bootloader
+ *  
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -47,8 +47,8 @@
 
 #define SLIP_START_STOP_BYTE 0xc0
 
-typedef void (*coms_sendbuffer_t)(uint32_t size, uint8_t *data);
-typedef bool (*coms_getDataWithTimeout_t)(uint8_t *c, const uint32_t timeoutTicks);
+typedef void (*espSlipSendBuffer_t)(uint32_t size, uint8_t *data);
+typedef bool (*espSlipGetDataWithTimeout_t)(uint8_t *c, const uint32_t timeoutTicks);
 
 typedef enum
 {
@@ -63,7 +63,7 @@ typedef struct
   uint8_t command;
   uint16_t dataSize;
   uint32_t checksum;
-} __attribute__((packed)) esp_slip_send_packet;
+} __attribute__((packed)) espSlipSendPacket_t;
 
 typedef struct
 {
@@ -74,7 +74,7 @@ typedef struct
   uint8_t data[256];
   uint8_t status;
   uint8_t error;
-} __attribute__((packed)) esp_slip_receive_packet;
+} __attribute__((packed)) espSlipReceivePacket_t;
 
 /**
 * @brief Called to send a SLIP packet to the ESP, and receive the response.
@@ -88,4 +88,4 @@ typedef struct
 *
 * @return true if ESP responds with a status byte indicating success.
 **/
-bool espSlipExchange(uint8_t *sendBuffer, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_sendbuffer_t sendBufferFunction, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize);
+bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize);

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -48,6 +48,12 @@
 typedef void (*coms_sendbuffer_t)(uint32_t size, uint8_t *data);
 typedef bool (*coms_getDataWithTimeout_t)(uint8_t *c, const uint32_t timeoutTicks);
 
+typedef enum
+{
+  SLIP_DECODING,
+  SLIP_SUCCESS,
+  SLIP_ERROR
+} slipDecoderStatus_t;
 
 typedef struct
 {

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -74,3 +74,16 @@ typedef struct
   uint8_t error;
 } __attribute__((packed)) esp_slip_receive_packet;
 
+/**
+* @brief Called to send a SLIP packet to the ESP, and receive the response.
+*
+* @param *sendBuffer Pointer to the to be sent buffer
+* @param *receiverPacket Pointer to receiver packet struct, which will be filled with the response
+* @param *senderPacket Pointer to sender packet struct, which will be used to fill the send buffer header
+* @param sendBufferFunction Function pointer to the function that sends the buffer (split into pages) to the ESP
+* @param getDataWithTimeoutFunction Function pointer to the function that receives data (byte by byte) from the ESP
+* @param timeoutTicks Number of ticks to wait for a response from the ESP
+*
+* @return true if ESP responds with a status byte indicating success.
+**/
+bool espSlipExchange(uint8_t *sendBuffer, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_sendbuffer_t sendBufferFunction, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks);

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 
 #define ESP_MTU 4000
+#define TX_BUFFER_SIZE 128
 
 /* Commands */
 #define DIR_CMD 0x00
@@ -88,4 +89,4 @@ typedef struct
 *
 * @return true if ESP responds with a status byte indicating success.
 **/
-bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize);
+bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks);

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -45,3 +45,23 @@
 #define CHANGE_BAUDRATE 0x0f
 #define SPI_ATTACH 0x0d
 
+
+typedef struct
+{
+  uint8_t direction;
+  uint8_t command;
+  uint16_t dataSize;
+  uint32_t checksum;
+} __attribute__((packed)) esp_slip_send_packet;
+
+typedef struct
+{
+  uint8_t direction;
+  uint8_t command;
+  uint16_t dataSize;
+  uint32_t value; // only for READ_REG command
+  uint8_t data[256];
+  uint8_t status;
+  uint8_t error;
+} __attribute__((packed)) esp_slip_receive_packet;
+

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -318,11 +318,11 @@ static void assembleBuffer(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacke
 static void flushTxBuffer(espSlipGetDataWithTimeout_t getDataWithTimeout)
 {
   uint8_t c;
-  bool success = true;
-  while (success)
+  bool success;
+  do
   {
     success = getDataWithTimeout(&c, 1);
-  }
+  } while (success);
   return;
 }
 

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -1,0 +1,32 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file esp_slip.c
+ * Protocol for assembling, sending, receiving and decoding SLIP packets to/from the ESP32 ROM bootloader
+ *  
+ */
+
+#include <string.h>
+
+#include "esp_slip.h"
+#include "uart2.h"

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -106,3 +106,14 @@ static void assembleBuffer(uint8_t *sendBuffer, esp_slip_send_packet *senderPack
 
   sendBuffer[9 + senderPacket->dataSize] = 0xC0;
 }
+
+static void clearUart2Buffer(coms_getDataWithTimeout_t getDataWithTimeout)
+{
+  uint8_t c;
+  bool success = true;
+  while (success)
+  {
+    success = getDataWithTimeout(&c, 1);
+  }
+  return;
+}

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -76,8 +76,21 @@ static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sen
     {
       for (int j = 0; j < 2; j++)
       {
-        j == 0 ? (sendBuffer[sendSize] = 0xDB) : data[i] == SLIP_START_STOP_BYTE ? (sendBuffer[sendSize] = 0xDC)
-                                                                                 : (sendBuffer[sendSize] = 0xDD);
+        if (j == 0)
+        {
+          sendBuffer[sendSize] = 0xDB;
+        }
+        else
+        {
+          if (data[i] == SLIP_START_STOP_BYTE)
+          {
+            sendBuffer[sendSize] = 0xDC;
+          }
+          else
+          {
+            sendBuffer[sendSize] = 0xDD;
+          }
+        }
         sendSize += 1;
       }
     }

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -33,3 +33,12 @@
 
 #define ESP_OVERHEAD_LEN 8
 
+static uint8_t generateChecksum(uint8_t *sendBuffer, esp_slip_send_packet *senderPacket)
+{
+  uint8_t checksum = 0xEF; // seed
+  for (int i = 0; i < senderPacket->dataSize - 16; i++)
+  {
+    checksum ^= sendBuffer[9 + 16 + i];
+  }
+  return checksum;
+}

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -108,6 +108,7 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
     receiverPacket->status = 1;
     espblReceiveState = (c == SLIP_START_STOP_BYTE) ? receiveDirection : receiveStart;
     break;
+
   case receiveDirection:
     if (c == 0x01)
     {
@@ -119,6 +120,7 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
       decoderStatus = SLIP_ERROR;
     }
     break;
+
   case receiveCommand:
     receiverPacket->command = c;
     slipSizeIndex = 0;
@@ -132,6 +134,7 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
       decoderStatus = SLIP_ERROR;
     }
     break;
+
   case receiveSize:
     slipSize[slipSizeIndex] = c;
     if (slipSizeIndex == 1)
@@ -150,6 +153,7 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
     }
     slipSizeIndex++;
     break;
+
   case receiveValue: // only used for READ_REG
     slipValue[slipValueIndex] = c;
     if (slipValueIndex == 3)
@@ -161,6 +165,7 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
     }
     slipValueIndex++;
     break;
+
   case receiveData:
   {
     const uint16_t payloadSize = receiverPacket->dataSize - 4;

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -54,7 +54,7 @@ static bool inEscapeSequence = false;
 
 static uint32_t sendSize;
 
-static uint8_t generateChecksum(uint8_t *sendBuffer, esp_slip_send_packet *senderPacket)
+static uint8_t generateChecksum(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacket)
 {
   uint8_t checksum = 0xEF; // seed
   for (int i = 0; i < senderPacket->dataSize - 16; i++)
@@ -64,7 +64,7 @@ static uint8_t generateChecksum(uint8_t *sendBuffer, esp_slip_send_packet *sende
   return checksum;
 }
 
-static void sendSlipPacket(uint32_t size, uint8_t *data, coms_sendbuffer_t sendBufferFn, uint32_t txBufferSize)
+static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sendBufferFn, uint32_t txBufferSize)
 {
   uint32_t i;
   uint8_t sendBuffer[txBufferSize];
@@ -98,7 +98,7 @@ static void sendSlipPacket(uint32_t size, uint8_t *data, coms_sendbuffer_t sendB
   }
 }
 
-static slipDecoderStatus_t decodeSlipPacket(uint8_t c, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket)
+static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket)
 {
 
   slipDecoderStatus_t decoderStatus = SLIP_DECODING;
@@ -235,7 +235,7 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, esp_slip_receive_packet *
   return decoderStatus;
 }
 
-static bool receivePacket(esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks)
+static bool receivePacket(espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks)
 {
   uint8_t c;
   uint8_t numberOfTimeouts = 0;
@@ -263,7 +263,7 @@ static bool receivePacket(esp_slip_receive_packet *receiverPacket, esp_slip_send
   return statusOk == receiverPacket->status && packetReceivedStatus == SLIP_SUCCESS;
 }
 
-static void assembleBuffer(uint8_t *sendBuffer, esp_slip_send_packet *senderPacket)
+static void assembleBuffer(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacket)
 {
   sendSize = senderPacket->dataSize + ESP_OVERHEAD_LEN + 2;
 
@@ -292,7 +292,7 @@ static void assembleBuffer(uint8_t *sendBuffer, esp_slip_send_packet *senderPack
   sendBuffer[9 + senderPacket->dataSize] = SLIP_START_STOP_BYTE;
 }
 
-static void flushTxBuffer(coms_getDataWithTimeout_t getDataWithTimeout)
+static void flushTxBuffer(espSlipGetDataWithTimeout_t getDataWithTimeout)
 {
   uint8_t c;
   bool success = true;
@@ -303,7 +303,7 @@ static void flushTxBuffer(coms_getDataWithTimeout_t getDataWithTimeout)
   return;
 }
 
-bool espSlipExchange(uint8_t *sendBuffer, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_sendbuffer_t sendBufferFunction, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize)
+bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize)
 {
   flushTxBuffer(getDataWithTimeout);
   assembleBuffer(sendBuffer, senderPacket);

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -30,3 +30,6 @@
 
 #include "esp_slip.h"
 #include "uart2.h"
+
+#define ESP_OVERHEAD_LEN 8
+

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -296,7 +296,7 @@ static void assembleBuffer(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacke
   sendBuffer[3] = (uint8_t)((senderPacket->dataSize >> 0) & 0x000000FF);
   sendBuffer[4] = (uint8_t)((senderPacket->dataSize >> 8) & 0x000000FF);
 
-  if (senderPacket->command == FLASH_DATA) // or MEM_DATA
+  if (senderPacket->command == FLASH_DATA)
   {
     uint32_t checksum = (uint32_t)generateChecksum(sendBuffer, senderPacket);
     sendBuffer[5] = (uint8_t)((checksum >> 0) & 0x000000FF);

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -59,7 +59,7 @@ static uint8_t generateChecksum(uint8_t *sendBuffer, espSlipSendPacket_t *sender
   uint8_t checksum = 0xEF; // seed
   for (int i = 0; i < senderPacket->dataSize - 16; i++)
   {
-    checksum ^= sendBuffer[9 + 16 + i];
+    checksum ^= sendBuffer[25 + i]; // Calculate bytewise XOR checksum. Actual data payload starts at index 25.
   }
   return checksum;
 }
@@ -158,7 +158,9 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
     slipValue[slipValueIndex] = c;
     if (slipValueIndex == 3)
     {
-      receiverPacket->value = ((uint32_t)slipValue[0] + ((uint32_t)slipValue[1] << 8) + ((uint32_t)slipValue[2] << 16) + ((uint32_t)slipValue[3] << 24));
+      //
+      // Bit shifting to pack the four received 8-bit values into a 32-bit value.
+      //
       slipDataIndex = 0;
       inEscapeSequence = false;
       espblReceiveState = receiveData;
@@ -270,7 +272,7 @@ static bool receivePacket(espSlipReceivePacket_t *receiverPacket, espSlipSendPac
 
 static void assembleBuffer(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacket)
 {
-  sendSize = senderPacket->dataSize + ESP_OVERHEAD_LEN + 2;
+  sendSize = senderPacket->dataSize + ESP_OVERHEAD_LEN + 2; // + 2 to account for the start and stop bytes
 
   sendBuffer[0] = SLIP_START_STOP_BYTE;
   sendBuffer[1] = DIR_CMD;

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -64,10 +64,10 @@ static uint8_t generateChecksum(uint8_t *sendBuffer, espSlipSendPacket_t *sender
   return checksum;
 }
 
-static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sendBufferFn, uint32_t txBufferSize)
+static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sendBufferFn)
 {
   uint32_t i;
-  uint8_t sendBuffer[txBufferSize];
+  static uint8_t sendBuffer[TX_BUFFER_SIZE];
   uint32_t sendSize = 0;
 
   for (i = 0; i < size; i++)
@@ -86,7 +86,7 @@ static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sen
       sendBuffer[sendSize] = data[i];
       sendSize += 1;
     }
-    if (sendSize >= (txBufferSize - 2))
+    if (sendSize >= (TX_BUFFER_SIZE - 2))
     {
       sendBufferFn(sendSize, &sendBuffer[0]);
       sendSize = 0;
@@ -303,12 +303,12 @@ static void flushTxBuffer(espSlipGetDataWithTimeout_t getDataWithTimeout)
   return;
 }
 
-bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks, uint32_t txBufferSize)
+bool espSlipExchange(uint8_t *sendBuffer, espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipSendBuffer_t sendBufferFunction, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks)
 {
   flushTxBuffer(getDataWithTimeout);
   assembleBuffer(sendBuffer, senderPacket);
 
-  sendSlipPacket(sendSize, sendBuffer, sendBufferFunction, txBufferSize);
+  sendSlipPacket(sendSize, sendBuffer, sendBufferFunction);
 
   return receivePacket(receiverPacket, senderPacket, getDataWithTimeout, timeoutTicks);
 }

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -47,9 +47,9 @@ static ESPblReceiveState espblReceiveState = receiveStart;
 
 static uint8_t slipSize[2];
 static uint8_t slipValue[4];
-static uint8_t slipDataIndex = 0;
-static uint8_t slipSizeIndex = 0;
-static uint8_t slipValueIndex = 0;
+static uint8_t slipDataIndex;
+static uint8_t slipSizeIndex;
+static uint8_t slipValueIndex;
 static bool inEscapeSequence = false;
 
 static uint32_t sendSize;

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -67,7 +67,7 @@ static uint8_t generateChecksum(uint8_t *sendBuffer, espSlipSendPacket_t *sender
 static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sendBufferFn)
 {
   uint32_t i;
-  static uint8_t sendBuffer[TX_BUFFER_SIZE];
+  static uint8_t sendBuffer[ESP_SLIP_TX_BUFFER_SIZE];
   uint32_t sendSize = 0;
 
   for (i = 0; i < size; i++)
@@ -99,7 +99,7 @@ static void sendSlipPacket(uint32_t size, uint8_t *data, espSlipSendBuffer_t sen
       sendBuffer[sendSize] = data[i];
       sendSize += 1;
     }
-    if (sendSize >= (TX_BUFFER_SIZE - 2))
+    if (sendSize >= (ESP_SLIP_TX_BUFFER_SIZE - 2))
     {
       sendBufferFn(sendSize, &sendBuffer[0]);
       sendSize = 0;

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -303,3 +303,13 @@ static void clearUart2Buffer(coms_getDataWithTimeout_t getDataWithTimeout)
   }
   return;
 }
+
+bool espSlipExchange(uint8_t *sendBuffer, esp_slip_receive_packet *receiverPacket, esp_slip_send_packet *senderPacket, coms_sendbuffer_t sendBufferFunction, coms_getDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks)
+{
+  clearUart2Buffer(getDataWithTimeout);
+  assembleBuffer(sendBuffer, senderPacket);
+
+  sendSlipPacket(sendSize, sendBuffer, sendBufferFunction);
+
+  return receivePacket(receiverPacket, senderPacket, getDataWithTimeout, timeoutTicks);
+}

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -174,6 +174,8 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
       //
       // Bit shifting to pack the four received 8-bit values into a 32-bit value.
       //
+      receiverPacket->value = (uint32_t)slipValue[0] + ((uint32_t)slipValue[1] << 8);
+      receiverPacket->value += ((uint32_t)slipValue[2] << 16) + ((uint32_t)slipValue[3] << 24);
       slipDataIndex = 0;
       inEscapeSequence = false;
       espblReceiveState = receiveData;
@@ -255,7 +257,8 @@ static slipDecoderStatus_t decodeSlipPacket(uint8_t c, espSlipReceivePacket_t *r
   return decoderStatus;
 }
 
-static bool receivePacket(espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket, espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks)
+static bool receivePacket(espSlipReceivePacket_t *receiverPacket, espSlipSendPacket_t *senderPacket,
+                          espSlipGetDataWithTimeout_t getDataWithTimeout, uint32_t timeoutTicks)
 {
   uint8_t c;
   uint8_t numberOfTimeouts = 0;

--- a/src/drivers/interface/uart2.h
+++ b/src/drivers/interface/uart2.h
@@ -41,6 +41,7 @@
 #define ENABLE_UART2_RCC       RCC_APB1PeriphClockCmd
 #define UART2_IRQ              USART2_IRQn
 
+#define UART2_DMA_BUFFER_SIZE 128
 #define UART2_DMA_IRQ           DMA1_Stream6_IRQn
 #define UART2_DMA_IT_TC         DMA_IT_TC4
 #define UART2_DMA_STREAM        DMA1_Stream6

--- a/src/drivers/src/uart2.c
+++ b/src/drivers/src/uart2.c
@@ -53,7 +53,7 @@ static StaticSemaphore_t waitUntilSendDoneBuffer;
 static bool isInit = false;
 
 static DMA_InitTypeDef DMA_InitStructureShare;
-static uint8_t dmaBuffer[128];
+static uint8_t dmaBuffer[UART2_DMA_BUFFER_SIZE];
 static bool    isUartDmaInitialized;
 static uint32_t initialDMACount;
 
@@ -239,7 +239,7 @@ void uart2SendDataDmaBlocking(uint32_t size, uint8_t* data)
 
 int uart2Putchar(int ch)
 {
-    uart2SendData(1, (uint8_t *)&ch);
+  uart2SendData(1, (uint8_t *)&ch);
 
     return (unsigned char)ch;
 }

--- a/test/deck/drivers/esp32/src/test_esp_slip.c
+++ b/test/deck/drivers/esp32/src/test_esp_slip.c
@@ -1,0 +1,384 @@
+// File under test esp_slip.crftq
+#include "esp_slip.h"
+
+#define UART2_LINK_COMM 1
+
+#include <string.h>
+
+#include "unity.h"
+
+// Mocks
+static void mockPutChar(uint32_t size, uint8_t *data);
+static bool mockGetChar(uint8_t *c, const uint32_t timeoutTicks);
+
+static uint8_t mockPutCharBuf[256];
+static int mockPutCharBufSize = 0;
+static uint8_t mockGetCharBuf[256];
+static int mockGetCharBufIndex = 0;
+static int mockGetCharDirtCounter = 0;
+static bool mockGetCharHasReceivedSend = false;
+
+// Helpers
+static void setupSenderHeader(espSlipSendPacket_t *senderPckt, const uint8_t command);
+static void setupEmptyReceivePacket(espSlipReceivePacket_t *receiverPckt, const uint8_t command);
+
+void setUp(void)
+{
+  // emptyResultBuffer
+  mockPutCharBufSize = 0;
+  memset(mockPutCharBuf, 0, sizeof(mockPutCharBuf));
+  mockGetCharBufIndex = 0;
+  memset(mockGetCharBuf, 0, sizeof(mockGetCharBuf));
+  mockGetCharDirtCounter = 0;
+  mockGetCharHasReceivedSend = false;
+}
+
+void testFullSentPacket()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  senderPckt.command = command;
+  senderPckt.dataSize = 0x03;
+  uint8_t sendBuffer[14];
+  sendBuffer[9] = 6;
+  sendBuffer[10] = 7;
+  sendBuffer[11] = 8;
+
+  espSlipReceivePacket_t receiverPckt;
+  setupEmptyReceivePacket(&receiverPckt, command);
+
+  // Test
+  espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX8(0xC0, mockPutCharBuf[0]);    // start byte
+  TEST_ASSERT_EQUAL_HEX8(0x00, mockPutCharBuf[1]);    // direction
+  TEST_ASSERT_EQUAL_HEX8(command, mockPutCharBuf[2]); // command
+  TEST_ASSERT_EQUAL_HEX8(0x03, mockPutCharBuf[3]);    // data payload size
+  TEST_ASSERT_EQUAL_HEX8(0x00, mockPutCharBuf[4]);    // data payload size
+  TEST_ASSERT_EQUAL_HEX8(0x06, mockPutCharBuf[9]);
+  TEST_ASSERT_EQUAL_HEX8(0x07, mockPutCharBuf[10]);
+  TEST_ASSERT_EQUAL_HEX8(0x08, mockPutCharBuf[11]);
+  TEST_ASSERT_EQUAL_HEX8(0xC0, mockPutCharBuf[12]); // end byte
+}
+
+void testEscapedSendData()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  senderPckt.command = command;
+  senderPckt.dataSize = 0x04;
+  uint8_t sendBuffer[14];
+  sendBuffer[9] = 6;
+  sendBuffer[10] = 0xC0;
+  sendBuffer[11] = 0xDB;
+  sendBuffer[12] = 7;
+
+  espSlipReceivePacket_t receiverPckt;
+  setupEmptyReceivePacket(&receiverPckt, command);
+
+  // Test
+  espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX8(0xC0, mockPutCharBuf[0]); // start byte
+  TEST_ASSERT_EQUAL_HEX8(0x04, mockPutCharBuf[3]); // data payload size
+  TEST_ASSERT_EQUAL_HEX8(0x00, mockPutCharBuf[4]); // data payload size
+  TEST_ASSERT_EQUAL_HEX8(0x06, mockPutCharBuf[9]);
+  TEST_ASSERT_EQUAL_HEX8(0xDB, mockPutCharBuf[10]);
+  TEST_ASSERT_EQUAL_HEX8(0xDC, mockPutCharBuf[11]);
+  TEST_ASSERT_EQUAL_HEX8(0xDB, mockPutCharBuf[12]);
+  TEST_ASSERT_EQUAL_HEX8(0xDD, mockPutCharBuf[13]);
+  TEST_ASSERT_EQUAL_HEX8(0x07, mockPutCharBuf[14]);
+}
+
+void testExtractCorrectReceivePcktCommands()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  setupSenderHeader(&senderPckt, command);
+  uint8_t sendBuffer[14];
+
+  espSlipReceivePacket_t receiverPckt;
+
+  mockGetCharBuf[0] = 0xC0;    // start byte
+  mockGetCharBuf[1] = 0x01;    // direction
+  mockGetCharBuf[2] = command; // command
+  mockGetCharBuf[3] = 0x04;    // data payload size
+  mockGetCharBuf[4] = 0x00;    // data payload size
+  mockGetCharBuf[9] = 0x00;    // status byte
+  mockGetCharBuf[10] = 0x00;
+  mockGetCharBuf[11] = 0x00;
+  mockGetCharBuf[12] = 0x00;
+  mockGetCharBuf[13] = 0xC0; // end byte
+
+  // Test
+  bool actual = espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_INT8(0x17, receiverPckt.command);
+  TEST_ASSERT_TRUE(actual);
+}
+
+void testReceivedData()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  setupSenderHeader(&senderPckt, command);
+
+  uint8_t sendBuffer[14];
+
+  espSlipReceivePacket_t receiverPckt;
+
+  mockGetCharBuf[0] = 0xC0;    // start byte
+  mockGetCharBuf[1] = 0x01;    // direction
+  mockGetCharBuf[2] = command; // command
+  mockGetCharBuf[3] = 0x09;    // data payload size
+  mockGetCharBuf[4] = 0x00;    // data payload size
+  mockGetCharBuf[9] = 0x50;
+  mockGetCharBuf[10] = 0x12;
+  mockGetCharBuf[11] = 0x17;
+  mockGetCharBuf[12] = 0x55;
+  mockGetCharBuf[13] = 0x03;
+  mockGetCharBuf[14] = 0x00; // status byte
+  mockGetCharBuf[15] = 0x00;
+  mockGetCharBuf[16] = 0x00;
+  mockGetCharBuf[17] = 0x00;
+  mockGetCharBuf[18] = 0xC0; // end byte
+
+  // Test
+  espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX8(0x50, receiverPckt.data[0]);
+  TEST_ASSERT_EQUAL_HEX8(0x12, receiverPckt.data[1]);
+  TEST_ASSERT_EQUAL_HEX8(0x17, receiverPckt.data[2]);
+  TEST_ASSERT_EQUAL_HEX8(0x55, receiverPckt.data[3]);
+  TEST_ASSERT_EQUAL_HEX8(0x03, receiverPckt.data[4]);
+}
+
+void testEscapedReceivedData()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  setupSenderHeader(&senderPckt, command);
+
+  uint8_t sendBuffer[14];
+
+  espSlipReceivePacket_t receiverPckt;
+  mockGetCharBuf[0] = 0xC0;    // start byte
+  mockGetCharBuf[1] = 0x01;    // direction
+  mockGetCharBuf[2] = command; // command
+  mockGetCharBuf[3] = 0x07;    // data payload size
+  mockGetCharBuf[4] = 0x00;    // data payload size
+  mockGetCharBuf[9] = 0xDB;    // data payload
+  mockGetCharBuf[10] = 0xDC;
+  mockGetCharBuf[11] = 0xDB;
+  mockGetCharBuf[12] = 0xDD;
+  mockGetCharBuf[13] = 0x03;
+  mockGetCharBuf[14] = 0x00; // status byte
+  mockGetCharBuf[15] = 0x00;
+  mockGetCharBuf[16] = 0x00;
+  mockGetCharBuf[17] = 0x00;
+  mockGetCharBuf[18] = 0xC0; // end byte
+
+  // Test
+  espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX8(0xC0, receiverPckt.data[0]);
+  TEST_ASSERT_EQUAL_HEX8(0xDB, receiverPckt.data[1]);
+  TEST_ASSERT_EQUAL_HEX8(0x03, receiverPckt.data[2]);
+}
+
+void testWrongCommandRaisesError()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  setupSenderHeader(&senderPckt, command);
+
+  uint8_t sendBuffer[14];
+
+  espSlipReceivePacket_t receiverPckt;
+
+  mockGetCharBuf[0] = 0xC0;  // start byte
+  mockGetCharBuf[1] = 0x01;  // direction
+  mockGetCharBuf[2] = 0x29;  // wrong command
+  mockGetCharBuf[3] = 0x04;  // data payload size
+  mockGetCharBuf[4] = 0x00;  // data payload size
+  mockGetCharBuf[14] = 0x00; // status byte
+  mockGetCharBuf[15] = 0x00;
+  mockGetCharBuf[16] = 0x00;
+  mockGetCharBuf[17] = 0x00;
+  mockGetCharBuf[18] = 0xC0; // end byte
+
+  // Test
+  bool actual = espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_FALSE(actual);
+}
+
+void testThatWeIgnoreLeadingGarbage()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  setupSenderHeader(&senderPckt, command);
+
+  uint8_t sendBuffer[14];
+
+  espSlipReceivePacket_t receiverPckt;
+  mockGetCharBuf[0] = 0x23;    // garbage
+  mockGetCharBuf[1] = 0x34;    // garbage
+  mockGetCharBuf[2] = 0x45;    // garbage
+  mockGetCharBuf[3] = 0xC0;    // start byte
+  mockGetCharBuf[4] = 0x01;    // direction
+  mockGetCharBuf[5] = command; // command
+  mockGetCharBuf[6] = 0x09;    // data payload size
+  mockGetCharBuf[7] = 0x00;    // data payload size
+  mockGetCharBuf[12] = 0x50;
+  mockGetCharBuf[13] = 0x12;
+  mockGetCharBuf[14] = 0x17;
+  mockGetCharBuf[15] = 0x55;
+  mockGetCharBuf[16] = 0x03;
+  mockGetCharBuf[17] = 0x00; // status byte
+  mockGetCharBuf[18] = 0x00;
+  mockGetCharBuf[19] = 0x00;
+  mockGetCharBuf[20] = 0x00;
+  mockGetCharBuf[21] = 0xC0; // end byte
+
+  // Test
+  espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX8(0x50, receiverPckt.data[0]);
+  TEST_ASSERT_EQUAL_HEX8(0x12, receiverPckt.data[1]);
+  TEST_ASSERT_EQUAL_HEX8(0x17, receiverPckt.data[2]);
+  TEST_ASSERT_EQUAL_HEX8(0x55, receiverPckt.data[3]);
+  TEST_ASSERT_EQUAL_HEX8(0x03, receiverPckt.data[4]);
+}
+
+void testThatWeDetectMissingEndMarker()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  setupSenderHeader(&senderPckt, command);
+
+  uint8_t sendBuffer[14];
+
+  espSlipReceivePacket_t receiverPckt;
+  mockGetCharBuf[0] = 0xC0;    // start byte
+  mockGetCharBuf[1] = 0x01;    // direction
+  mockGetCharBuf[2] = command; // command
+  mockGetCharBuf[3] = 0x07;    // data payload size
+  mockGetCharBuf[4] = 0x00;    // data payload size
+  mockGetCharBuf[9] = 0xDB;    // data payload
+  mockGetCharBuf[10] = 0xDC;
+  mockGetCharBuf[11] = 0xDB;
+  mockGetCharBuf[12] = 0xDD;
+  mockGetCharBuf[13] = 0x03;
+  mockGetCharBuf[14] = 0x00; // status byte
+  mockGetCharBuf[15] = 0x00;
+  mockGetCharBuf[16] = 0x00;
+  mockGetCharBuf[17] = 0x00;
+  mockGetCharBuf[18] = 0x00; // Missing end marker
+
+  // Test
+  bool actual = espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_FALSE(actual);
+}
+
+void testThatTheBufferIsClearedBeforeWritingSomething()
+{
+  // Fixture
+  const uint8_t command = 0x17;
+
+  espSlipSendPacket_t senderPckt;
+  senderPckt.command = command;
+  senderPckt.dataSize = 0x03;
+
+  uint8_t sendBuffer[14];
+  sendBuffer[9] = 6;
+  sendBuffer[10] = 7;
+  sendBuffer[11] = 8;
+
+  espSlipReceivePacket_t receiverPckt;
+  setupEmptyReceivePacket(&receiverPckt, command);
+  mockGetCharDirtCounter = 10;
+
+  // Test
+  espSlipExchange(&sendBuffer[0], &receiverPckt, &senderPckt, mockPutChar, mockGetChar, 100);
+
+  // Assert
+  TEST_ASSERT_EQUAL_INT32(0, mockGetCharDirtCounter);
+}
+
+// Helpers ///////////////////////////////////////////////////////////////////////////////////////////////
+
+static void mockPutChar(uint32_t size, uint8_t *data)
+{
+  mockGetCharHasReceivedSend = true;
+  memcpy(&mockPutCharBuf[mockPutCharBufSize], data, size);
+  mockPutCharBufSize += size;
+}
+
+static bool mockGetChar(uint8_t *c, const uint32_t timeoutTicks)
+{
+  if (mockGetCharHasReceivedSend)
+  {
+    *c = mockGetCharBuf[mockGetCharBufIndex++];
+
+    return true;
+  }
+  else
+  {
+    if (mockGetCharDirtCounter == 0)
+    {
+      return false;
+    }
+
+    // Return start of packet as garbage to make sure the state machine failes if it is red
+    *c = 0xC0;
+
+    mockGetCharDirtCounter--;
+    return true;
+  }
+}
+
+static void setupSenderHeader(espSlipSendPacket_t *senderPckt, const uint8_t command)
+{
+  senderPckt->command = command;
+  senderPckt->dataSize = 0x04;
+}
+
+static void setupEmptyReceivePacket(espSlipReceivePacket_t *receiverPckt, const uint8_t command)
+{
+  mockGetCharBuf[0] = 0xC0;    // start byte
+  mockGetCharBuf[1] = 0x01;    // direction
+  mockGetCharBuf[2] = command; // command
+  mockGetCharBuf[3] = 0x04;    // data payload size
+  mockGetCharBuf[4] = 0x00;    // data payload size
+  mockGetCharBuf[9] = 0x00;    // status byte
+  mockGetCharBuf[10] = 0x00;
+  mockGetCharBuf[11] = 0x00;
+  mockGetCharBuf[12] = 0x00;
+  mockGetCharBuf[13] = 0xC0; // end byte
+}

--- a/tools/test/gcc.yml
+++ b/tools/test/gcc.yml
@@ -38,6 +38,8 @@ compiler:
       - 'src/config/'
       - 'src/drivers/interface/'
       - 'src/drivers/src'
+      - 'src/drivers/esp32/interface/'
+      - 'src/drivers/esp32/src/'
       - 'src/hal/interface/'
       - 'src/lib/CMSIS/STM32F4xx/Include'
       - 'src/lib/STM32F4xx_StdPeriph_Driver/inc'


### PR DESCRIPTION
Low-level implementation of ESP32 ROM bootloader communication protocol. First stepping stone to wireless flashing of ESP32 from zip.

The ESP32 bootloader sends no unsolicited messages. The exchange function can be called from a higher level with a variation of instructions and data (to write). The exchange executes the following tasks:
1. Clear the UART buffer. Despite the ESP32 ROM bootloader otherwise not sending any unsolicited packets, it does send several responses upon successful synchronization, overflowing the UART buffer and potentially putting the SLIP packet decoding state machine in a wrong state. Clearing the UART buffer before sending a new SLIP packet avoids this.
2. Construct a SLIP packet out of 1) a struct containing header information (esp_slip_send_packet) and 2) a buffer containing to be sent data
3. Send this buffer in parts over UART with DMA
4. Receive the response from the ESP32 ROM bootloader, read out the status byte.
5. Return true for status byte indicating success, return false otherwise