### PR TITLE
Enable stack overflow check

### DIFF
--- a/src/config/FreeRTOSConfig.h
+++ b/src/config/FreeRTOSConfig.h
@@ -82,11 +82,7 @@
 #define configUSE_16_BIT_TICKS		0
 #define configIDLE_SHOULD_YIELD		0
 #define configUSE_CO_ROUTINES 		0
-#ifdef DEBUG
-  #define configCHECK_FOR_STACK_OVERFLOW      1
-#else
-  #define configCHECK_FOR_STACK_OVERFLOW      0
-#endif
+#define configCHECK_FOR_STACK_OVERFLOW      1
 #define configUSE_TIMERS          1
 #define configTIMER_TASK_PRIORITY 1
 #define configTIMER_QUEUE_LENGTH  20


### PR DESCRIPTION
Currently the stack overflow check provided by FreeRTOS is enabled in DEBUG compiles only. This pull request also enables it in "normal" compiles. 

The overhead for this check is very low, one if statement per context switch, and I believe it is better to catch this type of problem as early as possible. 

Note: This overflow check is not fool-proof, it only samples the stack size at context switch