### PR TITLE
Move storage buffer from the stack

### DIFF
--- a/src/utils/src/kve/kve_storage.c
+++ b/src/utils/src/kve/kve_storage.c
@@ -98,7 +98,7 @@ void kveStorageMoveMemory(kveMemory_t *kve, size_t sourceAddress, size_t destina
 }
 
 size_t kveStorageFindItemByKey(kveMemory_t *kve, size_t address, const char * key) {
-    char searchBuffer[255];
+    static char searchBuffer[255];
     size_t currentAddress = address;
     uint16_t length;
     uint8_t keyLength;

--- a/src/utils/src/kve/kve_storage.c
+++ b/src/utils/src/kve/kve_storage.c
@@ -66,7 +66,7 @@ uint16_t kveStorageWriteHole(kveMemory_t *kve, size_t address, size_t full_lengt
   kve->write(address, &header, sizeof(header));
   kve->flush();
 
-  return full_length;   
+  return full_length;
 }
 
 uint16_t kveStorageWriteEnd(kveMemory_t *kve, size_t address) {
@@ -188,7 +188,7 @@ size_t kveStorageFindNextItem(kveMemory_t *kve, size_t address)
         if (header.key_length != 0) {
             return currentAddress;
         }
-        
+
         currentAddress += header.full_length;
     }
 
@@ -198,7 +198,7 @@ size_t kveStorageFindNextItem(kveMemory_t *kve, size_t address)
 kveItemHeader_t kveStorageGetItemInfo(kveMemory_t *kve, size_t address)
 {
   kveItemHeader_t header;
-  
+
   kve->read(address, &header, sizeof(header));
 
   return header;


### PR DESCRIPTION
In the storage module (persistent storage) most operations will result in a buffer of 255 bytes being allocated on the stack. This is a pretty large chunk of memory and in this pull request the buffer is moved to static memory instead.

There is already another buffer in the same are of code that is in static memory and this move should not lead to concurrency problems. Concurrent access is protected on the storage module level and the kve functions should not be used by other code.