### PR TITLE
ESP32 (AI-deck) flashing from zip from cfclient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ PROJ_OBJ += bmi055_accel.o bmi055_gyro.o bmi160.o bmp280.o bstdr_comm_support.o 
 PROJ_OBJ += bmi088_accel.o bmi088_gyro.o bmi088_fifo.o bmp3.o
 PROJ_OBJ += pca9685.o vl53l0x.o pca95x4.o pca9555.o vl53l1x.o pmw3901.o
 PROJ_OBJ += amg8833.o lh_bootloader.o
-PROJ_OBJ += esp_slip.o
+PROJ_OBJ += esp_rom_bootloader.o esp_slip.o
 
 # USB Files
 PROJ_OBJ += usb_bsp.o usblink.o usbd_desc.o usb.o

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ PROJ_OBJ += configblockeeprom.o
 PROJ_OBJ += sleepus.o statsCnt.o rateSupervisor.o
 PROJ_OBJ += lighthouse_core.o pulse_processor.o pulse_processor_v1.o pulse_processor_v2.o lighthouse_geometry.o ootx_decoder.o lighthouse_calibration.o lighthouse_deck_flasher.o lighthouse_position_est.o lighthouse_storage.o lighthouse_transmit.o
 PROJ_OBJ += kve_storage.o kve.o
+PROJ_OBJ += esp_deck_flasher.o
 
 ifeq ($(DEBUG_PRINT_ON_SEGGER_RTT), 1)
 VPATH += $(LIB)/Segger_RTT/RTT

--- a/src/deck/drivers/interface/aideck.h
+++ b/src/deck/drivers/interface/aideck.h
@@ -1,0 +1,26 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *  
+ */
+
+#define ESP_BITSTREAM_SIZE 610576

--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -56,7 +56,6 @@ static uint8_t byte;
 static void NinaTask(void *param)
 {
   systemWaitStart();
-  vTaskDelay(M2T(3000));
   if (espDeckFlasherCheckVersionAndBoot() == false)
   {
     DEBUG_PRINT("ESP32 not booted.");

--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -32,6 +32,7 @@
 #include <string.h>
 
 #include "FreeRTOS.h"
+#include "aideck.h"
 #include "config.h"
 #include "console.h"
 #include "debug.h"
@@ -138,6 +139,15 @@ static bool aideckTest()
     return true;
 }
 
+static const DeckMemDef_t memoryDef = {
+    .write = espDeckFlasherWrite,
+    .read = 0,
+    .properties = espDeckFlasherPropertiesQuery,
+    .supportsUpgrade = true,
+
+    .requiredSize = ESP_BITSTREAM_SIZE,
+};
+
 static const DeckDriver aideck_deck = {
     .vid = 0xBC,
     .pid = 0x12,
@@ -145,6 +155,8 @@ static const DeckDriver aideck_deck = {
 
     .usedGpio = DECK_USING_IO_4,
     .usedPeriph = DECK_USING_UART1,
+
+    .memoryDef = &memoryDef,
 
     .init = aideckInit,
     .test = aideckTest,

--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -25,25 +25,24 @@
  */
 #define DEBUG_MODULE "AIDECK"
 
+#include <math.h>
 #include <stdint.h>
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "stm32fxxx.h"
+#include "FreeRTOS.h"
 #include "config.h"
 #include "console.h"
-#include "uart1.h"
 #include "debug.h"
 #include "deck.h"
-#include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
+#include "esp_deck_flasher.h"
 #include "log.h"
 #include "param.h"
+#include "queue.h"
+#include "stm32fxxx.h"
 #include "system.h"
+#include "task.h"
 #include "uart1.h"
 #include "uart2.h"
 
@@ -53,13 +52,24 @@ static uint8_t byte;
 //Uncomment when NINA printout read is desired from console
 //#define DEBUG_NINA_PRINT
 
-#ifdef DEBUG_NINA_PRINT
 static void NinaTask(void *param)
 {
     systemWaitStart();
+  vTaskDelay(M2T(3000));
+  if (espDeckFlasherCheckVersionAndBoot() == false)
+  {
+    DEBUG_PRINT("ESP32 not booted.");
+    while (1)
+    {
+      vTaskDelay(portMAX_DELAY);
+    }
+  }
+#ifdef DEBUG_NINA_PRINT
+  systemWaitStart();
     vTaskDelay(M2T(1000));
     DEBUG_PRINT("Starting reading out NINA debugging messages:\n");
     vTaskDelay(M2T(2000));
+  uart2Init(115200);
 
     // Pull the reset button to get a clean read out of the data
     pinMode(DECK_GPIO_IO4, OUTPUT);
@@ -77,8 +87,12 @@ static void NinaTask(void *param)
             consolePutchar(byte);
         }
     }
-}
 #endif
+  while (1)
+  {
+    vTaskDelay(portMAX_DELAY);
+  }
+}
 
 static void Gap8Task(void *param)
 {
@@ -111,14 +125,9 @@ static void aideckInit(DeckInfo *info)
     xTaskCreate(Gap8Task, AI_DECK_GAP_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL,
                 AI_DECK_TASK_PRI, NULL);
 
-#ifdef DEBUG_NINA_PRINT
-    // Initialize the UART for the NINA
-    uart2Init(115200);
     // Initialize task for the NINA
     xTaskCreate(NinaTask, AI_DECK_NINA_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL,
                 AI_DECK_TASK_PRI, NULL);
-
-#endif
 
     isInit = true;
 }

--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -55,7 +55,7 @@ static uint8_t byte;
 
 static void NinaTask(void *param)
 {
-    systemWaitStart();
+  systemWaitStart();
   vTaskDelay(M2T(3000));
   if (espDeckFlasherCheckVersionAndBoot() == false)
   {
@@ -67,27 +67,27 @@ static void NinaTask(void *param)
   }
 #ifdef DEBUG_NINA_PRINT
   systemWaitStart();
-    vTaskDelay(M2T(1000));
-    DEBUG_PRINT("Starting reading out NINA debugging messages:\n");
-    vTaskDelay(M2T(2000));
+  vTaskDelay(M2T(1000));
+  DEBUG_PRINT("Starting reading out NINA debugging messages:\n");
+  vTaskDelay(M2T(2000));
   uart2Init(115200);
 
-    // Pull the reset button to get a clean read out of the data
-    pinMode(DECK_GPIO_IO4, OUTPUT);
-    digitalWrite(DECK_GPIO_IO4, LOW);
-    vTaskDelay(10);
-    digitalWrite(DECK_GPIO_IO4, HIGH);
-    pinMode(DECK_GPIO_IO4, INPUT_PULLUP);
+  // Pull the reset button to get a clean read out of the data
+  pinMode(DECK_GPIO_IO4, OUTPUT);
+  digitalWrite(DECK_GPIO_IO4, LOW);
+  vTaskDelay(10);
+  digitalWrite(DECK_GPIO_IO4, HIGH);
+  pinMode(DECK_GPIO_IO4, INPUT_PULLUP);
 
-    // Read out the byte the NINA sends and immediately send it to the console.
-    uint8_t byte;
-    while (1)
+  // Read out the byte the NINA sends and immediately send it to the console.
+  uint8_t byte;
+  while (1)
+  {
+    if (uart2GetDataWithDefaultTimeout(&byte) == true)
     {
-        if (uart2GetDataWithDefaultTimeout(&byte) == true)
-        {
-            consolePutchar(byte);
-        }
+      consolePutchar(byte);
     }
+  }
 #endif
   while (1)
   {
@@ -97,46 +97,46 @@ static void NinaTask(void *param)
 
 static void Gap8Task(void *param)
 {
-    systemWaitStart();
-    vTaskDelay(M2T(1000));
+  systemWaitStart();
+  vTaskDelay(M2T(1000));
 
-    // Pull the reset button to get a clean read out of the data
-    pinMode(DECK_GPIO_IO4, OUTPUT);
-    digitalWrite(DECK_GPIO_IO4, LOW);
-    vTaskDelay(10);
-    digitalWrite(DECK_GPIO_IO4, HIGH);
-    pinMode(DECK_GPIO_IO4, INPUT_PULLUP);
+  // Pull the reset button to get a clean read out of the data
+  pinMode(DECK_GPIO_IO4, OUTPUT);
+  digitalWrite(DECK_GPIO_IO4, LOW);
+  vTaskDelay(10);
+  digitalWrite(DECK_GPIO_IO4, HIGH);
+  pinMode(DECK_GPIO_IO4, INPUT_PULLUP);
 
-    // Read out the byte the Gap8 sends and immediately send it to the console.
-    while (1)
-    {
-        uart1GetDataWithDefaultTimeout(&byte);
-    }
+  // Read out the byte the Gap8 sends and immediately send it to the console.
+  while (1)
+  {
+    uart1GetDataWithDefaultTimeout(&byte);
+  }
 }
 
 static void aideckInit(DeckInfo *info)
 {
 
-    if (isInit)
-        return;
+  if (isInit)
+    return;
 
-    // Intialize the UART for the GAP8
-    uart1Init(115200);
-    // Initialize task for the GAP8
-    xTaskCreate(Gap8Task, AI_DECK_GAP_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL,
-                AI_DECK_TASK_PRI, NULL);
+  // Intialize the UART for the GAP8
+  uart1Init(115200);
+  // Initialize task for the GAP8
+  xTaskCreate(Gap8Task, AI_DECK_GAP_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL,
+              AI_DECK_TASK_PRI, NULL);
 
-    // Initialize task for the NINA
-    xTaskCreate(NinaTask, AI_DECK_NINA_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL,
-                AI_DECK_TASK_PRI, NULL);
+  // Initialize task for the NINA
+  xTaskCreate(NinaTask, AI_DECK_NINA_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL,
+              AI_DECK_TASK_PRI, NULL);
 
-    isInit = true;
+  isInit = true;
 }
 
 static bool aideckTest()
 {
 
-    return true;
+  return true;
 }
 
 static const DeckMemDef_t memoryDef = {
@@ -146,6 +146,7 @@ static const DeckMemDef_t memoryDef = {
     .supportsUpgrade = true,
 
     .requiredSize = ESP_BITSTREAM_SIZE,
+    // .requiredHash = ESP_BITSTREAM_CRC,
 };
 
 static const DeckDriver aideck_deck = {

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -59,6 +59,17 @@ bool espRomBootloaderSync(uint8_t *sendBuffer);
 bool espRomBootloaderFlashBegin(uint8_t *sendBuffer, uint32_t numberOfDataPackets, uint32_t firmwareSize, uint32_t flashOffset);
 
 /**
+* @brief Called to flash a packet onto the ESP.
+*
+* @param *sendBuffer Pointer to a buffer used to construct the slip packet. Must contain actual to be flashed data.
+* @param flashDataSize Size of the current data packet
+* @param sequenceNumber The sequence number of the current data packet, indicates this is the nth packet
+*
+* @return true if data was succesfully flashed to ESP, false otherwise.
+**/
+bool espRomBootloaderFlashData(uint8_t *sendBuffer, uint32_t flashDataSize, uint32_t sequenceNumber);
+
+/**
 * @brief Called to attach the SPI memory to the ESP. Must be called before issuing any flash command.
 *
 * @param *sendBuffer Pointer to a buffer used to construct the spi attach packet. Can be left empty.

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -37,3 +37,7 @@
 #define ESP_PARTITION_ADDRESS 0x8000
 #define ESP_FW_ADDRESS 0x10000
 
+/**
+* @brief Called to reboot the ESP into bootloader mode.
+**/
+void espRomBootloaderInit();

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -72,7 +72,7 @@ bool espRomBootloaderFlashData(uint8_t *sendBuffer, uint32_t flashDataSize, uint
 /**
 * @brief Called to attach the SPI memory to the ESP. Must be called before issuing any flash command.
 *
-* @param *sendBuffer Pointer to a buffer used to construct the spi attach packet. Can be left empty.
+* @param sendBuffer Buffer used to construct the SPI attach packet. Can be left empty.
 *
 * @return true if SPI was succesfully attached to ESP, false otherwise.
 **/

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -47,6 +47,15 @@
 bool espRomBootloaderSync(uint8_t *sendBuffer);
 
 /**
+* @brief Called to attach the SPI memory to the ESP. Must be called before issuing any flash command.
+*
+* @param *sendBuffer Pointer to a buffer used to construct the spi attach packet. Can be left empty.
+*
+* @return true if SPI was succesfully attached to ESP, false otherwise.
+**/
+bool espRomBootloaderSpiAttach(uint8_t *sendBuffer);
+
+/**
 * @brief Called to reboot the ESP into bootloader mode.
 **/
 void espRomBootloaderInit();

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -47,6 +47,18 @@
 bool espRomBootloaderSync(uint8_t *sendBuffer);
 
 /**
+* @brief Called to initialize the flashing with the ESP.
+*
+* @param *sendBuffer Pointer to a buffer used to construct the flash begin packet. Can be left empty.
+* @param numberOfDataPackets The number of data packets that will be sent
+* @param firmwareSize The total to be flashed size
+* @param flashOffset The offset in flash where flashing will start
+*
+* @return true if flash begin command was accepted by ESP, false otherwise.
+**/
+bool espRomBootloaderFlashBegin(uint8_t *sendBuffer, uint32_t numberOfDataPackets, uint32_t firmwareSize, uint32_t flashOffset);
+
+/**
 * @brief Called to attach the SPI memory to the ESP. Must be called before issuing any flash command.
 *
 * @param *sendBuffer Pointer to a buffer used to construct the spi attach packet. Can be left empty.

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -32,3 +32,8 @@
 #include <stdint.h>
 
 #include "esp_slip.h"
+
+#define ESP_BOOTLOADER_ADDRESS 0x1000
+#define ESP_PARTITION_ADDRESS 0x8000
+#define ESP_FW_ADDRESS 0x10000
+

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -1,0 +1,34 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  @file esp_rom_bootloader.h
+ * Driver for communicating with the ESP32 ROM bootloader
+ * 
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_slip.h"

--- a/src/drivers/esp32/interface/esp_rom_bootloader.h
+++ b/src/drivers/esp32/interface/esp_rom_bootloader.h
@@ -38,6 +38,15 @@
 #define ESP_FW_ADDRESS 0x10000
 
 /**
+* @brief Called to sync with the bootloader. Allows the ESP to automatically configure the baud rate.
+*
+* @param *sendBuffer Pointer to a buffer used to construct the sync packet. Can be left empty.
+*
+* @return true if sync was successful, false otherwise.
+**/
+bool espRomBootloaderSync(uint8_t *sendBuffer);
+
+/**
 * @brief Called to reboot the ESP into bootloader mode.
 **/
 void espRomBootloaderInit();

--- a/src/drivers/esp32/interface/esp_slip.h
+++ b/src/drivers/esp32/interface/esp_slip.h
@@ -33,6 +33,8 @@
 
 #define ESP_MTU 4000
 #define ESP_SLIP_TX_BUFFER_SIZE 128
+#define ESP_SLIP_OVERHEAD_LEN 8
+#define ESP_SLIP_ADDITIONAL_DATA_OVERHEAD_LEN 16 // to account for additional overhead in the SLIP packet while flashing data
 
 /* Commands */
 #define DIR_CMD 0x00

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -97,3 +97,29 @@ bool espRomBootloaderSpiAttach(uint8_t *sendBuffer)
   return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 100);
 }
 
+bool espRomBootloaderFlashBegin(uint8_t *sendBuffer, uint32_t numberOfDataPackets, uint32_t firmwareSize, uint32_t flashOffset)
+{
+  senderPacket.command = FLASH_BEGIN;
+  senderPacket.dataSize = 0x10;
+  sendBuffer[9 + 0] = (uint8_t)((firmwareSize >> 0) & 0x000000FF);
+  sendBuffer[9 + 1] = (uint8_t)((firmwareSize >> 8) & 0x000000FF);
+  sendBuffer[9 + 2] = (uint8_t)((firmwareSize >> 16) & 0x000000FF);
+  sendBuffer[9 + 3] = (uint8_t)((firmwareSize >> 24) & 0x000000FF);
+
+  sendBuffer[9 + 4] = (uint8_t)((numberOfDataPackets >> 0) & 0x000000FF);
+  sendBuffer[9 + 5] = (uint8_t)((numberOfDataPackets >> 8) & 0x000000FF);
+  sendBuffer[9 + 6] = (uint8_t)((numberOfDataPackets >> 16) & 0x000000FF);
+  sendBuffer[9 + 7] = (uint8_t)((numberOfDataPackets >> 24) & 0x000000FF);
+
+  sendBuffer[9 + 8] = (uint8_t)((ESP_MTU >> 0) & 0x000000FF);
+  sendBuffer[9 + 9] = (uint8_t)((ESP_MTU >> 8) & 0x000000FF);
+  sendBuffer[9 + 10] = (uint8_t)((ESP_MTU >> 16) & 0x000000FF);
+  sendBuffer[9 + 11] = (uint8_t)((ESP_MTU >> 24) & 0x000000FF);
+  sendBuffer[9 + 12] = (uint8_t)((flashOffset >> 0) & 0x000000FF);
+  sendBuffer[9 + 13] = (uint8_t)((flashOffset >> 8) & 0x000000FF);
+  sendBuffer[9 + 14] = (uint8_t)((flashOffset >> 16) & 0x000000FF);
+  sendBuffer[9 + 15] = (uint8_t)((flashOffset >> 24) & 0x000000FF);
+
+  return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 10000);
+}
+

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -123,3 +123,35 @@ bool espRomBootloaderFlashBegin(uint8_t *sendBuffer, uint32_t numberOfDataPacket
   return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 10000);
 }
 
+bool espRomBootloaderFlashData(uint8_t *sendBuffer, uint32_t flashDataSize, uint32_t sequenceNumber)
+{
+  senderPacket.command = FLASH_DATA;
+  senderPacket.dataSize = ESP_MTU + 16; // set data size to the data size including the additional header
+
+  sendBuffer[9 + 0] = (uint8_t)((ESP_MTU >> 0) & 0x000000FF);
+  sendBuffer[9 + 1] = (uint8_t)((ESP_MTU >> 8) & 0x000000FF);
+  sendBuffer[9 + 2] = (uint8_t)((ESP_MTU >> 16) & 0x000000FF);
+  sendBuffer[9 + 3] = (uint8_t)((ESP_MTU >> 24) & 0x000000FF);
+
+  sendBuffer[9 + 4] = (uint8_t)((sequenceNumber >> 0) & 0x000000FF);
+  sendBuffer[9 + 5] = (uint8_t)((sequenceNumber >> 8) & 0x000000FF);
+  sendBuffer[9 + 6] = (uint8_t)((sequenceNumber >> 16) & 0x000000FF);
+  sendBuffer[9 + 7] = (uint8_t)((sequenceNumber >> 24) & 0x000000FF);
+
+  sendBuffer[9 + 8] = 0x00;
+  sendBuffer[9 + 9] = 0x00;
+  sendBuffer[9 + 10] = 0x00;
+  sendBuffer[9 + 11] = 0x00;
+  sendBuffer[9 + 12] = 0x00;
+  sendBuffer[9 + 13] = 0x00;
+  sendBuffer[9 + 14] = 0x00;
+  sendBuffer[9 + 15] = 0x00;
+
+  if (flashDataSize < ESP_MTU)
+  {
+    // pad the data with 0xFF
+    memset(&sendBuffer[9 + 16 + flashDataSize], 0xFF, ESP_MTU - flashDataSize);
+  }
+
+  return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 100);
+}

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -37,3 +37,17 @@
 #include "task.h"
 #include "uart2.h"
 
+void espRomBootloaderInit()
+{
+  pinMode(DECK_GPIO_IO1, OUTPUT);
+  digitalWrite(DECK_GPIO_IO1, LOW);
+  pinMode(DECK_GPIO_IO4, OUTPUT);
+  digitalWrite(DECK_GPIO_IO4, LOW);
+  vTaskDelay(10);
+  digitalWrite(DECK_GPIO_IO4, HIGH);
+  pinMode(DECK_GPIO_IO4, INPUT_PULLUP);
+  vTaskDelay(100);
+  digitalWrite(DECK_GPIO_IO1, HIGH);
+  pinMode(DECK_GPIO_IO1, INPUT_PULLUP);
+}
+

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -26,7 +26,7 @@
  *  
  */
 
-#define DEBUG_MODULE "ESPROMBL"
+#define DEBUG_MODULE "ESP_ROM_BL"
 
 #include <string.h>
 

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -1,0 +1,39 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file esp_rom_bootloader.c
+ * Driver for communicating with the ESP32 ROM bootloader
+ *  
+ */
+
+#define DEBUG_MODULE "ESPROMBL"
+
+#include <string.h>
+
+#include "FreeRTOS.h"
+#include "debug.h"
+#include "deck.h"
+#include "esp_rom_bootloader.h"
+#include "task.h"
+#include "uart2.h"
+

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -37,6 +37,9 @@
 #include "task.h"
 #include "uart2.h"
 
+static espSlipSendPacket_t senderPacket;
+static espSlipReceivePacket_t receiverPacket;
+
 void espRomBootloaderInit()
 {
   pinMode(DECK_GPIO_IO1, OUTPUT);

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -41,6 +41,8 @@
 #warning "ESP SLIP transmission buffer size must be smaller than or equal to UART2 DMA buffer size"
 #endif
 
+#define ESP_SLIP_DATA_START_INDEX 9
+
 static espSlipSendPacket_t senderPacket;
 static espSlipReceivePacket_t receiverPacket;
 
@@ -62,10 +64,10 @@ bool espRomBootloaderSync(uint8_t *sendBuffer)
 {
   senderPacket.command = SYNC;
   senderPacket.dataSize = 0x24;
-  sendBuffer[9 + 0] = 0x07;
-  sendBuffer[9 + 1] = 0x07;
-  sendBuffer[9 + 2] = 0x12;
-  sendBuffer[9 + 3] = 0x20;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 0] = 0x07;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 1] = 0x07;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 2] = 0x12;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 3] = 0x20;
   for (int i = 0; i < 32; i++)
   {
     sendBuffer[9 + 4 + i] = 0x55;
@@ -89,14 +91,14 @@ bool espRomBootloaderSpiAttach(uint8_t *sendBuffer)
 {
   senderPacket.command = SPI_ATTACH;
   senderPacket.dataSize = 0x4;
-  sendBuffer[9 + 0] = 0x00;
-  sendBuffer[9 + 1] = 0x00;
-  sendBuffer[9 + 2] = 0x00;
-  sendBuffer[9 + 3] = 0x00;
-  sendBuffer[9 + 4] = 0x00;
-  sendBuffer[9 + 5] = 0x00;
-  sendBuffer[9 + 6] = 0x00;
-  sendBuffer[9 + 7] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 0] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 1] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 2] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 3] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 4] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 5] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 6] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 7] = 0x00;
 
   return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 100);
 }
@@ -105,24 +107,25 @@ bool espRomBootloaderFlashBegin(uint8_t *sendBuffer, uint32_t numberOfDataPacket
 {
   senderPacket.command = FLASH_BEGIN;
   senderPacket.dataSize = 0x10;
-  sendBuffer[9 + 0] = (uint8_t)((firmwareSize >> 0) & 0x000000FF);
-  sendBuffer[9 + 1] = (uint8_t)((firmwareSize >> 8) & 0x000000FF);
-  sendBuffer[9 + 2] = (uint8_t)((firmwareSize >> 16) & 0x000000FF);
-  sendBuffer[9 + 3] = (uint8_t)((firmwareSize >> 24) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 0] = (uint8_t)((firmwareSize >> 0) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 1] = (uint8_t)((firmwareSize >> 8) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 2] = (uint8_t)((firmwareSize >> 16) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 3] = (uint8_t)((firmwareSize >> 24) & 0x000000FF);
 
-  sendBuffer[9 + 4] = (uint8_t)((numberOfDataPackets >> 0) & 0x000000FF);
-  sendBuffer[9 + 5] = (uint8_t)((numberOfDataPackets >> 8) & 0x000000FF);
-  sendBuffer[9 + 6] = (uint8_t)((numberOfDataPackets >> 16) & 0x000000FF);
-  sendBuffer[9 + 7] = (uint8_t)((numberOfDataPackets >> 24) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 4] = (uint8_t)((numberOfDataPackets >> 0) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 5] = (uint8_t)((numberOfDataPackets >> 8) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 6] = (uint8_t)((numberOfDataPackets >> 16) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 7] = (uint8_t)((numberOfDataPackets >> 24) & 0x000000FF);
 
-  sendBuffer[9 + 8] = (uint8_t)((ESP_MTU >> 0) & 0x000000FF);
-  sendBuffer[9 + 9] = (uint8_t)((ESP_MTU >> 8) & 0x000000FF);
-  sendBuffer[9 + 10] = (uint8_t)((ESP_MTU >> 16) & 0x000000FF);
-  sendBuffer[9 + 11] = (uint8_t)((ESP_MTU >> 24) & 0x000000FF);
-  sendBuffer[9 + 12] = (uint8_t)((flashOffset >> 0) & 0x000000FF);
-  sendBuffer[9 + 13] = (uint8_t)((flashOffset >> 8) & 0x000000FF);
-  sendBuffer[9 + 14] = (uint8_t)((flashOffset >> 16) & 0x000000FF);
-  sendBuffer[9 + 15] = (uint8_t)((flashOffset >> 24) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 8] = (uint8_t)((ESP_MTU >> 0) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 9] = (uint8_t)((ESP_MTU >> 8) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 10] = (uint8_t)((ESP_MTU >> 16) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 11] = (uint8_t)((ESP_MTU >> 24) & 0x000000FF);
+
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 12] = (uint8_t)((flashOffset >> 0) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 13] = (uint8_t)((flashOffset >> 8) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 14] = (uint8_t)((flashOffset >> 16) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 15] = (uint8_t)((flashOffset >> 24) & 0x000000FF);
 
   return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 10000);
 }
@@ -132,24 +135,22 @@ bool espRomBootloaderFlashData(uint8_t *sendBuffer, uint32_t flashDataSize, uint
   senderPacket.command = FLASH_DATA;
   senderPacket.dataSize = ESP_MTU + 16; // set data size to the data size including the additional header
 
-  sendBuffer[9 + 0] = (uint8_t)((ESP_MTU >> 0) & 0x000000FF);
-  sendBuffer[9 + 1] = (uint8_t)((ESP_MTU >> 8) & 0x000000FF);
-  sendBuffer[9 + 2] = (uint8_t)((ESP_MTU >> 16) & 0x000000FF);
-  sendBuffer[9 + 3] = (uint8_t)((ESP_MTU >> 24) & 0x000000FF);
-
-  sendBuffer[9 + 4] = (uint8_t)((sequenceNumber >> 0) & 0x000000FF);
-  sendBuffer[9 + 5] = (uint8_t)((sequenceNumber >> 8) & 0x000000FF);
-  sendBuffer[9 + 6] = (uint8_t)((sequenceNumber >> 16) & 0x000000FF);
-  sendBuffer[9 + 7] = (uint8_t)((sequenceNumber >> 24) & 0x000000FF);
-
-  sendBuffer[9 + 8] = 0x00;
-  sendBuffer[9 + 9] = 0x00;
-  sendBuffer[9 + 10] = 0x00;
-  sendBuffer[9 + 11] = 0x00;
-  sendBuffer[9 + 12] = 0x00;
-  sendBuffer[9 + 13] = 0x00;
-  sendBuffer[9 + 14] = 0x00;
-  sendBuffer[9 + 15] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 0] = (uint8_t)((ESP_MTU >> 0) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 1] = (uint8_t)((ESP_MTU >> 8) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 2] = (uint8_t)((ESP_MTU >> 16) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 3] = (uint8_t)((ESP_MTU >> 24) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 4] = (uint8_t)((sequenceNumber >> 0) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 5] = (uint8_t)((sequenceNumber >> 8) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 6] = (uint8_t)((sequenceNumber >> 16) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 7] = (uint8_t)((sequenceNumber >> 24) & 0x000000FF);
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 8] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 9] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 10] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 11] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 12] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 13] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 14] = 0x00;
+  sendBuffer[ESP_SLIP_DATA_START_INDEX + 15] = 0x00;
 
   if (flashDataSize < ESP_MTU)
   {

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -80,3 +80,20 @@ bool espRomBootloaderSync(uint8_t *sendBuffer)
 
   return sync;
 }
+
+bool espRomBootloaderSpiAttach(uint8_t *sendBuffer)
+{
+  senderPacket.command = SPI_ATTACH;
+  senderPacket.dataSize = 0x4;
+  sendBuffer[9 + 0] = 0x00;
+  sendBuffer[9 + 1] = 0x00;
+  sendBuffer[9 + 2] = 0x00;
+  sendBuffer[9 + 3] = 0x00;
+  sendBuffer[9 + 4] = 0x00;
+  sendBuffer[9 + 5] = 0x00;
+  sendBuffer[9 + 6] = 0x00;
+  sendBuffer[9 + 7] = 0x00;
+
+  return espSlipExchange(sendBuffer, &receiverPacket, &senderPacket, uart2SendDataDmaBlocking, uart2GetDataWithTimeout, 100);
+}
+

--- a/src/drivers/esp32/src/esp_rom_bootloader.c
+++ b/src/drivers/esp32/src/esp_rom_bootloader.c
@@ -37,6 +37,10 @@
 #include "task.h"
 #include "uart2.h"
 
+#if UART2_DMA_BUFFER_SIZE < ESP_SLIP_TX_BUFFER_SIZE
+#warning "ESP SLIP transmission buffer size must be smaller than or equal to UART2 DMA buffer size"
+#endif
+
 static espSlipSendPacket_t senderPacket;
 static espSlipReceivePacket_t receiverPacket;
 

--- a/src/drivers/esp32/src/esp_slip.c
+++ b/src/drivers/esp32/src/esp_slip.c
@@ -30,8 +30,6 @@
 
 #include "esp_slip.h"
 
-#define ESP_OVERHEAD_LEN 8
-
 typedef enum
 {
   receiveStart,
@@ -57,7 +55,7 @@ static uint32_t sendSize;
 static uint8_t generateChecksum(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacket)
 {
   uint8_t checksum = 0xEF; // seed
-  for (int i = 0; i < senderPacket->dataSize - 16; i++)
+  for (int i = 0; i < senderPacket->dataSize - ESP_SLIP_ADDITIONAL_DATA_OVERHEAD_LEN; i++)
   {
     checksum ^= sendBuffer[25 + i]; // Calculate bytewise XOR checksum. Actual data payload starts at index 25.
   }
@@ -288,7 +286,7 @@ static bool receivePacket(espSlipReceivePacket_t *receiverPacket, espSlipSendPac
 
 static void assembleBuffer(uint8_t *sendBuffer, espSlipSendPacket_t *senderPacket)
 {
-  sendSize = senderPacket->dataSize + ESP_OVERHEAD_LEN + 2; // + 2 to account for the start and stop bytes
+  sendSize = senderPacket->dataSize + ESP_SLIP_OVERHEAD_LEN + 2; // + 2 to account for the start and stop bytes
 
   sendBuffer[0] = SLIP_START_STOP_BYTE;
   sendBuffer[1] = DIR_CMD;

--- a/src/modules/interface/esp_deck_flasher.h
+++ b/src/modules/interface/esp_deck_flasher.h
@@ -37,4 +37,15 @@
 **/
 bool espDeckFlasherCheckVersionAndBoot();
 
+/**
+* @brief Repeatedly called upon arrival of a data packet from the radio when flashing the ESP from the cfclient with zip.
+*
+* @param memAddr The address in memory where the data should be written.
+* @param writeLen The length of the data to write.
+* @param *buffer Pointer to the data to write.
+*
+* @return true if the data was written successfully, false otherwise.
+**/
+bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const uint8_t *buffer);
+
 uint8_t espDeckFlasherPropertiesQuery();

--- a/src/modules/interface/esp_deck_flasher.h
+++ b/src/modules/interface/esp_deck_flasher.h
@@ -32,7 +32,7 @@
 #include <stdint.h>
 
 /**
-* @brief Dummy function that can be adapted to verify firmware checksum before booting ESP32.
+* @brief Dummy function that can be adapted to verify firmware checksum before booting ESP32. An MD5 checksum can be calculated by the ESP32 ROM bootloader and verified with a hard-coded checksum here.
 *
 **/
 bool espDeckFlasherCheckVersionAndBoot();

--- a/src/modules/interface/esp_deck_flasher.h
+++ b/src/modules/interface/esp_deck_flasher.h
@@ -1,0 +1,32 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file esp_deck_flasher.h
+ * Handles flashing of binaries on the ESP32
+ *  
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>

--- a/src/modules/interface/esp_deck_flasher.h
+++ b/src/modules/interface/esp_deck_flasher.h
@@ -36,3 +36,5 @@
 *
 **/
 bool espDeckFlasherCheckVersionAndBoot();
+
+uint8_t espDeckFlasherPropertiesQuery();

--- a/src/modules/interface/esp_deck_flasher.h
+++ b/src/modules/interface/esp_deck_flasher.h
@@ -30,3 +30,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+/**
+* @brief Dummy function that can be adapted to verify firmware checksum before booting ESP32.
+*
+**/
+bool espDeckFlasherCheckVersionAndBoot();

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define DEBUG_MODULE "ESPFL"
+#define DEBUG_MODULE "ESP_FLASHER"
 #include "debug.h"
 
 #include "FreeRTOS.h"
@@ -63,12 +63,12 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
     espRomBootloaderInit();
     if (!espRomBootloaderSync(&sendBuffer[0]))
     {
-      DEBUG_PRINT("Sync failed\n");
+      DEBUG_PRINT("Write failed - cannot sync with bootloader\n");
       return false;
     }
     if (!espRomBootloaderSpiAttach(&sendBuffer[0]))
     {
-      DEBUG_PRINT("SPI attach failed\n");
+      DEBUG_PRINT("Write failed - cannot attach SPI flash\n");
       return false;
     }
 

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -40,3 +40,11 @@
 #include "esp_rom_bootloader.h"
 #include "uart2.h"
 
+static bool hasStarted = false;
+
+bool espDeckFlasherCheckVersionAndBoot()
+{
+  hasStarted = true;
+  return true;
+}
+

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -96,7 +96,6 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
     memcpy(&sendBuffer[9 + 16 + sendBufferIndex], buffer, writeLen);
     sendBufferIndex += writeLen;
   }
-  DEBUG_PRINT("sendBufferIndex: %lu\n", sendBufferIndex);
 
   // send buffer if full
   if (sendBufferIndex == ESP_MTU || ((sequenceNumber == numberOfDataPackets - 1) && (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU)))
@@ -114,7 +113,6 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
     // put overshoot into send buffer for next send & update sendBufferIndex
     if (overshoot)
     {
-      DEBUG_PRINT("Overshoot: %d\n", overshoot);
       memcpy(&sendBuffer[9 + 16 + 0], &buffer[writeLen - overshoot], overshoot);
       sendBufferIndex = overshoot;
       overshoot = 0;
@@ -126,21 +124,15 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
 
     // increment sequence number
     sequenceNumber++;
-    DEBUG_PRINT("Sequence number %lu\n", sequenceNumber);
 
     // if very last radio packet triggered overshoot, send padded carry buffer
     if (((sequenceNumber == numberOfDataPackets - 1) && (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU)))
     {
-      DEBUG_PRINT("Last radio packet triggered overshoot of %lu bytes\n", sendBufferIndex);
 
       if (!espRomBootloaderFlashData(&sendBuffer[0], sendBufferIndex, sequenceNumber))
       {
         DEBUG_PRINT("Flash write failed\n");
         return false;
-      }
-      else
-      {
-        DEBUG_PRINT("Flash write successful\n");
       }
     }
   }

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -1,0 +1,42 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2021 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file esp_deck_flasher.c
+ * Handles flashing of binaries on the ESP32
+ *  
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DEBUG_MODULE "ESPFL"
+#include "debug.h"
+
+#include "FreeRTOS.h"
+#include "aideck.h"
+#include "deck.h"
+#include "esp_deck_flasher.h"
+#include "esp_rom_bootloader.h"
+#include "uart2.h"
+

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -40,6 +40,7 @@
 #include "esp_rom_bootloader.h"
 #include "uart2.h"
 
+static bool inBootloaderMode = true;
 static bool hasStarted = false;
 
 bool espDeckFlasherCheckVersionAndBoot()
@@ -48,3 +49,19 @@ bool espDeckFlasherCheckVersionAndBoot()
   return true;
 }
 
+uint8_t espDeckFlasherPropertiesQuery()
+{
+  uint8_t result = 0;
+
+  if (hasStarted)
+  {
+    result |= DECK_MEMORY_MASK_STARTED;
+  }
+
+  if (inBootloaderMode)
+  {
+    result |= DECK_MEMORY_MASK_BOOT_LOADER_ACTIVE | DECK_MEMORY_MASK_UPGRADE_REQUIRED;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Allows for wireless flashing of ESP32 on the AI-deck from zip.

1. The memoryDef in the AI-deck driver marks the deck as flash-able to cflib.
2. Whenever a packet with to be flashed data is received, the writing function in `esp_deck_flasher.c` is called.
3. This in turn calls functions to communicate with the ESP ROM bootloader (`esp_rom_bootloader.c`) to execute different commands necessary to flash the chip. For more information on the different commands, visit the Espressif [ESP32 serial protocol documentation](https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html)