### PR TITLE
Python bindings for stabilizer_types.h

### DIFF
--- a/bindings/cffirmware.i
+++ b/bindings/cffirmware.i
@@ -8,11 +8,13 @@
 #include "math3d.h"
 #include "pptraj.h"
 #include "planner.h"
+#include "stabilizer_types.h"
 %}
 
 %include "math3d.h"
 %include "pptraj.h"
 %include "planner.h"
+%include "stabilizer_types.h"
 
 %inline %{
 struct poly4d* piecewise_get(struct piecewise_traj *pp, int i)

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -7,6 +7,8 @@ import os
 fw_dir = "."
 include = [
     os.path.join(fw_dir, "src/modules/interface"),
+    os.path.join(fw_dir, "src/hal/interface"),
+    os.path.join(fw_dir, "src/utils/interface/lighthouse"),
 ]
 
 modules = [

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "imu_types.h"
-#include "lighthouse_calibration.h"
+#include "lighthouse_types.h"
 
 /* Data structure used by the stabilizer subsystem.
  * All have a timestamp to be set when the data is calculated.

--- a/src/utils/interface/lighthouse/lighthouse_calibration.h
+++ b/src/utils/interface/lighthouse/lighthouse_calibration.h
@@ -1,23 +1,7 @@
 #pragma once
 
 #include "ootx_decoder.h"
-
-typedef struct {
-  float phase;
-  float tilt;
-  float curve;
-  float gibmag;
-  float gibphase;
-  // Lh2 extra params
-  float ogeemag;
-  float ogeephase;
-} __attribute__((packed)) lighthouseCalibrationSweep_t;
-
-typedef struct {
-  lighthouseCalibrationSweep_t sweep[2];
-  uint32_t uid;
-  bool valid;
-} __attribute__((packed)) lighthouseCalibration_t;
+#include "lighthouse_types.h"
 
 /**
  * @brief Initialize calibration structure from basestation ootx frame
@@ -52,19 +36,6 @@ void lighthouseCalibrationApplyV2(const lighthouseCalibration_t* calib, const fl
  * @param correctedAngles i/j will be same as the raw angles
  */
 void lighthouseCalibrationApplyNothing(const float rawAngles[2], float correctedAngles[2]);
-
-/**
- * @brief Generic function pointer type for a calibration measurement model.
- *        Predict the measured sweep angle based on a position for a lighthouse rotor. The position is relative to the rotor reference frame.
- * @param x meters
- * @param y meters
- * @param z meters
- * @param t Tilt of the light plane in radians
- * @param calib Calibration data for the rotor
- * @return float The predicted uncompensated sweep angle of the rotor
- *
- */
-typedef float (*lighthouseCalibrationMeasurementModel_t)(const float x, const float y, const float z, const float t, const lighthouseCalibrationSweep_t* calib);
 
 /**
  * @brief Predict the measured sweep angle based on a position for a lighthouse 1 rotor. The position is relative to the rotor reference frame.

--- a/src/utils/interface/lighthouse/lighthouse_types.h
+++ b/src/utils/interface/lighthouse/lighthouse_types.h
@@ -1,0 +1,31 @@
+#pragma once
+
+typedef struct {
+  float phase;
+  float tilt;
+  float curve;
+  float gibmag;
+  float gibphase;
+  // Lh2 extra params
+  float ogeemag;
+  float ogeephase;
+} __attribute__((packed)) lighthouseCalibrationSweep_t;
+
+typedef struct {
+  lighthouseCalibrationSweep_t sweep[2];
+  uint32_t uid;
+  bool valid;
+} __attribute__((packed)) lighthouseCalibration_t;
+
+/**
+ * @brief Generic function pointer type for a calibration measurement model.
+ *        Predict the measured sweep angle based on a position for a lighthouse rotor. The position is relative to the rotor reference frame.
+ * @param x meters
+ * @param y meters
+ * @param z meters
+ * @param t Tilt of the light plane in radians
+ * @param calib Calibration data for the rotor
+ * @return float The predicted uncompensated sweep angle of the rotor
+ *
+ */
+typedef float (*lighthouseCalibrationMeasurementModel_t)(const float x, const float y, const float z, const float t, const lighthouseCalibrationSweep_t* calib);


### PR DESCRIPTION
This also breaks lighthouse_calibration.h into two parts, where the new
part is in lighthouse_types.h. This split avoids a unnecessary
dependency on ootx in stabilizer_types.h