### PR TITLE
Push-based high-level commander

### DIFF
--- a/src/modules/interface/commander.h
+++ b/src/modules/interface/commander.h
@@ -35,23 +35,25 @@
 #define COMMANDER_WDT_TIMEOUT_STABILIZE  M2T(500)
 #define COMMANDER_WDT_TIMEOUT_SHUTDOWN   M2T(2000)
 
-#define COMMANDER_PRIORITY_DISABLE 0
-#define COMMANDER_PRIORITY_CRTP    1
-#define COMMANDER_PRIORITY_EXTRX   2
+#define COMMANDER_PRIORITY_DISABLE   0
+// Keep a macro for lowest non-disabled priority, regardless of source, in case
+// some day there is a priority lower than the high-level commander.
+#define COMMANDER_PRIORITY_LOWEST    1
+#define COMMANDER_PRIORITY_HIGHLEVEL 1
+#define COMMANDER_PRIORITY_CRTP      2
+#define COMMANDER_PRIORITY_EXTRX     3
 
 void commanderInit(void);
 bool commanderTest(void);
 uint32_t commanderGetInactivityTime(void);
 
+// Arg `setpoint` cannot be const; the commander will mutate its timestamp.
 void commanderSetSetpoint(setpoint_t *setpoint, int priority);
 int commanderGetActivePriority(void);
 
-/* Inform the commander that streaming setpoints are about to stop.
- * Parameter controls the amount of time the last setpoint will remain valid.
- * This gives the PC time to send the next command, e.g. with the high-level
- * commander, before we enter timeout mode.
- */
-void commanderNotifySetpointsStop(int remainValidMillisecs);
+// Sets the priority of the current setpoint to the lowest non-disabled value,
+// so any new setpoint regardless of source will overwrite it.
+void commanderRelaxPriority(void);
 
 void commanderGetSetpoint(setpoint_t *setpoint, const state_t *state);
 

--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -59,7 +59,7 @@ void crtpCommanderHighLevelInit(void);
 
 // Retrieves the current setpoint. Returns false if the high-level commander is
 // disabled, i.e. it does not have an "opinion" on what the setpoint should be.
-bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state);
+bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state, uint32_t tick);
 
 // When flying sequences of high-level commands, the high-level commander uses
 // its own history of commands to determine the initial conditions of the next

--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -57,8 +57,9 @@ typedef enum {
 /* Public functions */
 void crtpCommanderHighLevelInit(void);
 
-// Retrieves the current setpoint
-void crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state);
+// Retrieves the current setpoint. Returns false if the high-level commander is
+// disabled, i.e. it does not have an "opinion" on what the setpoint should be.
+bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state);
 
 // When flying sequences of high-level commands, the high-level commander uses
 // its own history of commands to determine the initial conditions of the next
@@ -137,14 +138,25 @@ int crtpCommanderHighLevelLandYaw(const float absoluteHeight_m, const float dura
 /**
  * @brief stops the current trajectory (turns off the motors)
  *
- * Send the trajectory planner to idle state, where it has no plan. Also used when
- * switching from high-level to low-level commands, or for emergencies.
+ * Send the trajectory planner to stopped state, where it requests motors off.
  *
  * @return zero if the command succeeded, an error code otherwise. The function
  * should never fail, but we provide the error code nevertheless for sake of
  * consistency with the other high-level commander functions.
  */
 int crtpCommanderHighLevelStop();
+
+/**
+ * @brief stops the current trajectory (without requesting motors off)
+ *
+ * Send the trajectory planner to disabled state, where it does not generate
+ * setpoints, but also does not request motors off.
+ *
+ * @return zero if the command succeeded, an error code otherwise. The function
+ * should never fail, but we provide the error code nevertheless for sake of
+ * consistency with the other high-level commander functions.
+ */
+int crtpCommanderHighLevelDisable();
 
 /**
  * @brief Go to an absolute or relative position

--- a/src/modules/interface/planner.h
+++ b/src/modules/interface/planner.h
@@ -64,10 +64,9 @@ enum trajectory_type
 
 struct planner
 {
-	// Not stored as enum to ensure fixed size for logging.
-	uint8_t state;              // current state
-	enum trajectory_type type;  // current type
-	bool reversed;              // true, if trajectory should be evaluated in reverse
+	enum trajectory_state state;	// current state
+	enum trajectory_type type;      // current type
+	bool reversed;					// true, if trajectory should be evaluated in reverse
 
 	union {
 		const struct piecewise_traj* trajectory; // pointer to trajectory

--- a/src/modules/interface/planner.h
+++ b/src/modules/interface/planner.h
@@ -38,15 +38,22 @@ Header file for planning state machine
 
 #pragma once
 
+#include <stdint.h>
+
 #include "math3d.h"
 #include "pptraj.h"
 #include "pptraj_compressed.h"
 
 enum trajectory_state
 {
+	// Motors off.
 	TRAJECTORY_STATE_IDLE            = 0,
+	// Follow a trajectory, then hover at its endpoint.
 	TRAJECTORY_STATE_FLYING          = 1,
+	// Follow a trajectory, but cut motors when it ends.
 	TRAJECTORY_STATE_LANDING         = 3,
+	// Not producing setpoints but also not wanting motors off.
+	TRAJECTORY_STATE_DISABLED        = 4,
 };
 
 enum trajectory_type
@@ -57,9 +64,10 @@ enum trajectory_type
 
 struct planner
 {
-	enum trajectory_state state;	// current state
-	enum trajectory_type type;      // current type
-	bool reversed;					// true, if trajectory should be evaluated in reverse
+	// Not stored as enum to ensure fixed size for logging.
+	uint8_t state;              // current state
+	enum trajectory_type type;  // current type
+	bool reversed;              // true, if trajectory should be evaluated in reverse
 
 	union {
 		const struct piecewise_traj* trajectory; // pointer to trajectory
@@ -82,6 +90,15 @@ void plan_stop(struct planner *p);
 // currently this is true at startup before we take off,
 // and also after an emergency stop.
 bool plan_is_stopped(struct planner *p);
+
+// disable the planner.
+// subsequently, plan_is_disabled(p) will return true,
+// and it is no longer valid to call plan_current_goal(p).
+void plan_disable(struct planner *p);
+
+// query if the planner is disabled.
+// currently this is true when preempted by low-level commands.
+bool plan_is_disabled(struct planner *p);
 
 // get the planner's current goal.
 struct traj_eval plan_current_goal(struct planner *p, float t);

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -203,6 +203,9 @@ typedef struct setpoint_s {
   } mode;
 } setpoint_t;
 
+// A setpoint value that causes the motors to stop.
+extern setpoint_t const nullSetpoint;
+
 /** Estimate of position */
 typedef struct estimate_s {
   uint32_t timestamp; // Timestamp when the data was computed
@@ -300,6 +303,7 @@ typedef struct
 #define RATE_MAIN_LOOP RATE_1000_HZ
 #define ATTITUDE_RATE RATE_500_HZ
 #define POSITION_RATE RATE_100_HZ
+#define RATE_HL_COMMANDER RATE_100_HZ
 
 #define RATE_DO_EXECUTE(RATE_HZ, TICK) ((TICK % (RATE_MAIN_LOOP / RATE_HZ)) == 0)
 

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -203,9 +203,6 @@ typedef struct setpoint_s {
   } mode;
 } setpoint_t;
 
-// A setpoint value that causes the motors to stop.
-extern setpoint_t const nullSetpoint;
-
 /** Estimate of position */
 typedef struct estimate_s {
   uint32_t timestamp; // Timestamp when the data was computed

--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -41,7 +41,7 @@ static bool isInit;
 // Static structs are zero-initialized, so nullSetpoint corresponds to
 // modeDisable for all stab_mode_t members and zero for all physical values.
 // In other words, the controller should cut power upon recieving it.
-const setpoint_t nullSetpoint;
+const static setpoint_t nullSetpoint;
 static state_t lastState;
 const static int priorityDisable = COMMANDER_PRIORITY_DISABLE;
 

--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -46,6 +46,7 @@ static state_t lastState;
 const static int priorityDisable = COMMANDER_PRIORITY_DISABLE;
 
 static uint32_t lastUpdate;
+static bool enableHighLevel = false;
 
 static QueueHandle_t setpointQueue;
 STATIC_MEM_QUEUE_ALLOC(setpointQueue, 1, sizeof(setpoint_t));
@@ -143,3 +144,30 @@ int commanderGetActivePriority(void)
 
   return priority;
 }
+
+/**
+ *
+ * The high level commander handles the setpoints from within the firmware
+ * based on a predefined trajectory. This was merged as part of the
+ * [Crazyswarm](%https://crazyswarm.readthedocs.io/en/latest/) project of the
+ * [USC ACT lab](%https://act.usc.edu/) (see this
+ * [blogpost](%https://www.bitcraze.io/2018/02/merging-crazyswarm-functionality-into-the-official-crazyflie-firmware/)).
+ * The high-level commander uses a planner to generate smooth trajectories
+ * based on actions like ‘take off’, ‘go to’ or ‘land’ with 7th order
+ * polynomials. The planner generates a group of setpoints, which will be
+ * handled by the High level commander and send one by one to the commander
+ * framework.
+ *
+ * It is also possible to upload your own custom trajectory to the memory of
+ * the Crazyflie, which you can try out with the script
+ * `examples/autonomous_sequence_high_level of.py` in the Crazyflie python
+ * library repository.
+ */
+PARAM_GROUP_START(commander)
+
+/**
+ *  @brief Enable high level commander
+ */
+PARAM_ADD_CORE(PARAM_UINT8, enHighLevel, &enableHighLevel)
+
+PARAM_GROUP_STOP(commander)

--- a/src/modules/src/crtp_commander.c
+++ b/src/modules/src/crtp_commander.c
@@ -97,8 +97,9 @@ struct notifySetpointsStopPacket {
 void notifySetpointsStopDecoder(const void *data, size_t datalen)
 {
   ASSERT(datalen == sizeof(struct notifySetpointsStopPacket));
-  const struct notifySetpointsStopPacket *values = data;
-  commanderNotifySetpointsStop(values->remainValidMillisecs);
+  // Note: The remainValidMillisecs argument is an artifact of the old
+  // pull-based high-level commander architecture, and is no longer needed.
+  commanderRelaxPriority();
 }
 
  /* ---===== packetDecoders array =====--- */

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -298,8 +298,12 @@ int crtpCommanderHighLevelDisable()
   return 0;
 }
 
-bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state)
+bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state, uint32_t tick)
 {
+  if (!RATE_DO_EXECUTE(RATE_HL_COMMANDER, tick)) {
+    return false;
+  }
+
   xSemaphoreTake(lockTraj, portMAX_DELAY);
   float t = usecTimestamp() / 1e6;
   struct traj_eval ev = plan_current_goal(&planner, t);

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -89,6 +89,11 @@ struct trajectoryDescription
 uint8_t trajectories_memory[TRAJECTORY_MEMORY_SIZE];
 static struct trajectoryDescription trajectory_descriptions[NUM_TRAJECTORY_DEFINITIONS];
 
+// Static structs are zero-initialized, so nullSetpoint corresponds to
+// modeDisable for all stab_mode_t members and zero for all physical values.
+// In other words, the controller should cut power upon recieving it.
+const static setpoint_t nullSetpoint;
+
 static bool isInit = false;
 static struct planner planner;
 static uint8_t group_mask;

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -821,10 +821,6 @@ bool crtpCommanderHighLevelIsTrajectoryFinished() {
   return plan_is_finished(&planner, t);
 }
 
-LOG_GROUP_START(hlCommander)
-LOG_ADD(LOG_UINT8, pstate, &planner.state)
-LOG_GROUP_STOP(hlCommander)
-
 /**
  * computes smooth setpoints based on high-level inputs such as: take-off,
  * landing, polynomial trajectories.

--- a/src/modules/src/planner.c
+++ b/src/modules/src/planner.c
@@ -88,6 +88,16 @@ bool plan_is_stopped(struct planner *p)
 	return p->state == TRAJECTORY_STATE_IDLE;
 }
 
+void plan_disable(struct planner *p)
+{
+	p->state = TRAJECTORY_STATE_DISABLED;
+}
+
+bool plan_is_disabled(struct planner *p)
+{
+	return p->state == TRAJECTORY_STATE_DISABLED;
+}
+
 struct traj_eval plan_current_goal(struct planner *p, float t)
 {
 	switch (p->state) {

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -259,10 +259,8 @@ static void stabilizerTask(void* param)
       stateEstimator(&state, tick);
       compressState();
 
-      if (RATE_DO_EXECUTE(RATE_HL_COMMANDER, tick)) {
-        if (crtpCommanderHighLevelGetSetpoint(&tempSetpoint, &state)) {
-          commanderSetSetpoint(&tempSetpoint, COMMANDER_PRIORITY_HIGHLEVEL);
-        }
+      if (crtpCommanderHighLevelGetSetpoint(&tempSetpoint, &state, tick)) {
+        commanderSetSetpoint(&tempSetpoint, COMMANDER_PRIORITY_HIGHLEVEL);
       }
 
       commanderGetSetpoint(&setpoint, &state);


### PR DESCRIPTION
Implements push-based high-level commander as discussed in #861.

Summary of changes (HLcmd is short for high-level commander):

1. Adds a new priority level for HLcmd, lower than all but DISABLE.
2. Stabilizer loop steps HLcmd and pushes setpoints on its behalf.
   (Initially I tried having a separate task, but it was messier due to needing a lock on the state estimate struct.)
3. Introduces a new planner state to distinguish between the conditions:
   - HLcmd has been preempted
   - HLcmd has finished landing and wants motors off
   
   This is necessary (as far as I can tell) to preserve the correct leveling-off and emergency stop behaviors on timeout, while also allowing the high-level commander to immediately cut the motors after landing.
4. Switching from low-level to high-level is accomplished by modifying the priority of the current setpoint sitting in the queue. This means we no longer need the `remainValidMillisecs` argument on the `notifySetpointsStop` command.
5. The `commander.enHighLevel` param is no longer needed.

The priority switching mechanism still needs to "know about" the high-level commander (i.e. `commander.c` still includes `crtp_commander_high_level.h`) to switch it into the disabled state when it is preempted. I couldn't figure out a way around this.

Although the net lines of code is increased, notice the simplification of `commander.c`.

Flight tested in 2 scenarios:

```
takeoff
cmdFullState
goTo
cmdFullState
goTo
land
```
and

```
takeoff
cmdFullState
<wait for leveling and emergency stop>
```
