### PR TITLE
fixed esp flasher compile error with older gcc versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,10 @@ else
 endif
 
 # Disable warnings for unaligned addresses in packed structs (added in GCC 9)
+GCCVERSIONGTE9 := $(shell expr `arm-none-eabi-gcc -dumpversion | cut -f1 -d.` \>= 9)
+ifeq "$(GCCVERSIONGTE9)" "1"
 CFLAGS += -Wno-address-of-packed-member
+endif
 
 # Disable warnings for incorrectly detected region size (added in GCC 11)
 # The compiler is not detecting properly GPIO structure size

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,9 @@ CFLAGS += -Wno-address-of-packed-member
 
 # Disable warnings for incorrectly detected region size (added in GCC 11)
 # The compiler is not detecting properly GPIO structure size
-
+#
+# First check if compiler version is equal or greater than 11, since these flags give errors
+# for earlier versions of gcc
 GCCVERSIONGTE11 := $(shell expr `arm-none-eabi-gcc -dumpversion | cut -f1 -d.` \>= 11)
 
 ifeq "$(GCCVERSIONGTE11)" "1"

--- a/Makefile
+++ b/Makefile
@@ -320,9 +320,14 @@ CFLAGS += -Wno-address-of-packed-member
 
 # Disable warnings for incorrectly detected region size (added in GCC 11)
 # The compiler is not detecting properly GPIO structure size
+
+GCCVERSIONGTE11 := $(shell expr `arm-none-eabi-gcc -dumpversion | cut -f1 -d.` \>= 11)
+
+ifeq "$(GCCVERSIONGTE11)" "1"
 CFLAGS += -Wno-array-bounds
 CFLAGS += -Wno-stringop-overread
 CFLAGS += -Wno-stringop-overflow
+endif
 
 ifeq ($(LTO), 1)
   CFLAGS += -flto

--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,7 @@ else
 endif
 
 # Disable warnings for unaligned addresses in packed structs (added in GCC 9)
+# First check if compiler version is correct
 GCCVERSIONGTE9 := $(shell expr `arm-none-eabi-gcc -dumpversion | cut -f1 -d.` \>= 9)
 ifeq "$(GCCVERSIONGTE9)" "1"
 CFLAGS += -Wno-address-of-packed-member

--- a/Makefile
+++ b/Makefile
@@ -316,24 +316,13 @@ else
 endif
 
 # Disable warnings for unaligned addresses in packed structs (added in GCC 9)
-# First check if compiler version is correct
-GCCVERSIONGTE9 := $(shell expr `arm-none-eabi-gcc -dumpversion | cut -f1 -d.` \>= 9)
-ifeq "$(GCCVERSIONGTE9)" "1"
 CFLAGS += -Wno-address-of-packed-member
-endif
 
 # Disable warnings for incorrectly detected region size (added in GCC 11)
 # The compiler is not detecting properly GPIO structure size
-#
-# First check if compiler version is equal or greater than 11, since these flags give errors
-# for earlier versions of gcc
-GCCVERSIONGTE11 := $(shell expr `arm-none-eabi-gcc -dumpversion | cut -f1 -d.` \>= 11)
-
-ifeq "$(GCCVERSIONGTE11)" "1"
 CFLAGS += -Wno-array-bounds
 CFLAGS += -Wno-stringop-overread
 CFLAGS += -Wno-stringop-overflow
-endif
 
 ifeq ($(LTO), 1)
   CFLAGS += -flto

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -99,7 +99,7 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
   // send buffer if full
   const bool sendBufferFull = (sendBufferIndex == ESP_MTU);
   const bool lastPacket = (sequenceNumber == numberOfDataPackets - 1);
-  bool lastPacketFull = false;
+  bool lastPacketFull = lastPacket && (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU);
   if (lastPacket)
   {
     lastPacketFull = (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU);

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -99,7 +99,7 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
   // send buffer if full
   const bool sendBufferFull = (sendBufferIndex == ESP_MTU);
   const bool lastPacket = (sequenceNumber == numberOfDataPackets - 1);
-  bool lastPacketFull;
+  bool lastPacketFull = false;
   if (lastPacket)
   {
     lastPacketFull = (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU);

--- a/src/modules/src/esp_deck_flasher.c
+++ b/src/modules/src/esp_deck_flasher.c
@@ -100,10 +100,6 @@ bool espDeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen, const u
   const bool sendBufferFull = (sendBufferIndex == ESP_MTU);
   const bool lastPacket = (sequenceNumber == numberOfDataPackets - 1);
   bool lastPacketFull = lastPacket && (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU);
-  if (lastPacket)
-  {
-    lastPacketFull = (sendBufferIndex == ESP_BITSTREAM_SIZE % ESP_MTU);
-  }
 
   if (sendBufferFull || (lastPacket && lastPacketFull))
   {


### PR DESCRIPTION
New compiler flags for gcc 11 have been added in PR #877 but these are causing problems for older compiler versions on Ubuntu 18.04 (see #900)

I've added a check in the Makefile so that it will only use these flags if version 11 is used. 

Update: it ended up to be an uninitalized variable in esp_flasher which removed the necessity to check versions for these flags.