### PR TITLE
Update GNU copying permission statement

### DIFF
--- a/examples/app_appchannel_test/tools/appchannelTest.py
+++ b/examples/app_appchannel_test/tools/appchannelTest.py
@@ -19,10 +19,8 @@
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-#  MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 Simple example that connects to the first Crazyflie found, Sends and
 receive appchannel packets

--- a/examples/demos/swarm_demo/control_tower/control_tower.py
+++ b/examples/demos/swarm_demo/control_tower/control_tower.py
@@ -18,10 +18,8 @@
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-#  MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import time
 import cflib.crtp  # noqa


### PR DESCRIPTION
We do not want to keep drack of the Free Software Foundation office.
Instead we use the recommened lines from https://www.gnu.org/licenses/gpl-howto.en.html
