### PR TITLE
Added version.vtpl to be parsed by doxygen for param docs

### DIFF
--- a/tools/gen-dox/Doxyfile
+++ b/tools/gen-dox/Doxyfile
@@ -291,7 +291,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = vtpl=C
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -817,6 +817,7 @@ INPUT_ENCODING         = UTF-8
 
 FILE_PATTERNS          = *.c \
                          *.h \
+                         *.vtpl \
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
We use doxygen to parse .c files to extract documentation for parameters and logs. The params for the "firmware" group are defined in version.vtpl (a template) and since it has the "wrong" extension it is not included.

This PR adds .vtpl files to the doxygen config.

Related to bitcraze/crazyflie-clients-python#585