### PR TITLE
Streamline DFU flashing over USB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ PROJ_OBJ += vl53l1_api_calibration.o vl53l1_api_debug.o vl53l1_api_preset_modes.
 PROJ_OBJ += vl53l1_register_funcs.o vl53l1_wait.o vl53l1_core_support.o
 
 # Modules
-PROJ_OBJ += system.o comm.o console.o pid.o crtpservice.o param_task.o param_logic.o
+PROJ_OBJ += system.o comm.o console.o pid.o crtpservice.o param_task.o param_logic.o bootloader.o
 PROJ_OBJ += log.o worker.o queuemonitor.o msp.o
 PROJ_OBJ += platformservice.o sound_cf2.o extrx.o sysload.o mem.o
 PROJ_OBJ += range.o app_handler.o static_mem.o app_channel.o
@@ -462,7 +462,8 @@ flash_verify:
                  -c "verify_image $(PROG).bin $(LOAD_ADDRESS) bin" -c "reset run" -c shutdown
 
 flash_dfu:
-	$(DFU_UTIL) -a 0 -D $(PROG).dfu
+	$(PYTHON) tools/make/usb-bootloader.py
+	$(DFU_UTIL) -d 0483:df11 -a 0 -D $(PROG).dfu -s :leave
 
 #STM utility targets
 halt:

--- a/src/hal/src/usb.c
+++ b/src/hal/src/usb.c
@@ -48,6 +48,8 @@
 #include "crtp.h"
 #include "static_mem.h"
 
+#include "bootloader.h"
+
 
 NO_DMA_CCM_SAFE_ZERO_INIT __ALIGN_BEGIN USB_OTG_CORE_HANDLE    USB_OTG_dev __ALIGN_END ;
 
@@ -177,6 +179,10 @@ static uint8_t usbd_cf_Setup(void *pdev , USB_SETUP_REQ  *req)
                       USB_RX_TX_PACKET_SIZE);
       rxStopped = false;
     }
+  } else if(command == 0x02){
+    //restart system and transition to DFU bootloader mode
+    //enter bootloader specific to STM32f4xx
+    enter_bootloader(0, 0x00000000);
   } else {
     crtpSetLink(radiolinkGetLink());
   }

--- a/src/init/main.c
+++ b/src/init/main.c
@@ -42,8 +42,12 @@
 /* ST includes */
 #include "stm32fxxx.h"
 
+#include "bootloader.h"
+
 int main() 
 {
+  check_enter_bootloader();
+
   //Initialize the platform.
   int err = platformInit();
   if (err != 0) {

--- a/src/modules/interface/bootloader.h
+++ b/src/modules/interface/bootloader.h
@@ -1,0 +1,49 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie Firmware
+ *
+ * Copyright (C) Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file bootloader.h
+ * Functions to handle transitioning from the firmware to bootloader (DFU) mode on startup
+ *
+ */
+
+/* ST includes */
+#include "stm32f4xx.h"
+
+/**
+ * @brief Check if memory is set after software 
+ * reboot indicating we need to branch to the bootloader.
+ * Run everytime on startup.
+ */
+void check_enter_bootloader();
+
+/**
+ * @brief Initiate the procedure to reboot into the bootloader.
+ * 
+ * This function does not return, instead setting a flag to 
+ * jump to the bootloader on the next start and
+ * issuing a software reset.
+ * 
+ * @param r0 The register to utilize when jumping
+ * @param bl_addr The bootloader address to jump to
+ */
+void enter_bootloader(uint32_t r0, uint32_t bl_addr);

--- a/src/modules/src/bootloader.c
+++ b/src/modules/src/bootloader.c
@@ -1,0 +1,84 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie Firmware
+ *
+ * Copyright (C) Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file bootloader.c
+ * Functions to handle transitioning from the firmware to bootloader (DFU) mode on startup
+ *
+ */
+
+#include "bootloader.h"
+
+// bootloader code based from micropython machine_bootloader function
+
+// STM32H7 has ECC and writes to RAM must be 64-bit so they are fully committed
+// to actual SRAM before a system reset occurs.
+#define BL_STATE_PTR                ((uint64_t *) SRAM2_BASE)  //start of 16kb SRAM bank in stm32f405
+#define BL_STATE_KEY                (0x5a5) //arbitrary bit pattern used as a marker
+#define BL_STATE_KEY_MASK           (0xfff)
+#define BL_STATE_KEY_SHIFT          (32)
+#define BL_STATE_INVALID            (0)
+#define BL_STATE_VALID(reg, addr)   ((uint64_t)(reg) | ((uint64_t)((addr) | BL_STATE_KEY)) << BL_STATE_KEY_SHIFT)
+#define BL_STATE_GET_REG(s)         ((s) & 0xffffffff)
+#define BL_STATE_GET_KEY(s)         (((s) >> BL_STATE_KEY_SHIFT) & BL_STATE_KEY_MASK)
+#define BL_STATE_GET_ADDR(s)        (((s) >> BL_STATE_KEY_SHIFT) & ~BL_STATE_KEY_MASK)
+
+
+/**
+ * @brief Branch directly to the bootloader address, setting the 
+ * stack pointer and destination address first.
+ * Based from the micropython machine_bootloader function.
+ * 
+ * @param r0 The register to utilize
+ * @param bl_addr The bootloader address to jump to
+ */
+static void branch_to_bootloader(uint32_t r0, uint32_t bl_addr){
+    __asm volatile (
+        "ldr r2, [r1, #0]\n"    // get address of stack pointer
+        "msr msp, r2\n"         // get stack pointer
+        "ldr r2, [r1, #4]\n"    // get address of destination
+        "bx r2\n"               // branch to bootloader
+        );
+    //unreachable code
+    while(1);
+}
+
+void check_enter_bootloader(){
+    uint64_t bl_state = *BL_STATE_PTR;
+    //set to invalid for next boot
+    *BL_STATE_PTR = BL_STATE_INVALID;
+
+    if(BL_STATE_GET_KEY(bl_state) == BL_STATE_KEY && (RCC->CSR & RCC_CSR_SFTRSTF)){
+        //if botloader data valid and was just reset with NVIC_SystemReset
+
+        //remap memory to system flash
+        SYSCFG_MemoryRemapConfig(SYSCFG_MemoryRemap_SystemFlash);
+        branch_to_bootloader(BL_STATE_GET_REG(bl_state), BL_STATE_GET_ADDR(bl_state));
+    }
+}
+
+void enter_bootloader(uint32_t r0, uint32_t bl_addr){
+    //set bootloader state values    
+    *BL_STATE_PTR = BL_STATE_VALID(r0, bl_addr);
+    
+    NVIC_SystemReset();
+}

--- a/tools/make/usb-bootloader.py
+++ b/tools/make/usb-bootloader.py
@@ -1,0 +1,21 @@
+#send a USB request to the crazyflie, causing it to enter DFU mode (bootloader) automatically
+#flash new firmware using 'make flash_dfu'
+
+from time import sleep
+import usb
+import usb.core
+
+#find connected crazyflie, usb vendor and product id = 0483:5740
+dev = usb.core.find(idVendor=0x0483, idProduct=0x5740)
+if dev is None:
+    raise ValueError('Could not find any USB connected crazyflie')
+
+#send signal to enter bootloader
+try:
+    dev.ctrl_transfer(bmRequestType=usb.TYPE_VENDOR, 
+        bRequest=0x01, wValue=0x01, wIndex=2)
+except IOError:
+    #io error expected because the crazyflie will not respond to USB request as it resets into the bootloader
+    #TODO usbd_cf_Setup function in firmware needs to return USBD_OK before rebooting to fix this
+        #sleep to allow time for crazyflie to get into DFU mode
+        sleep(0.5)


### PR DESCRIPTION
## Description
- This pull request streamlines the process of flashing the Crazyflie over a USB connection utilizing the STM32F405's DFU mode. 
- Currently, DFU flashing is intended as a recovery backup method, however, in some scenarios it is useful to be able to easily flash the Crazyflie over USB without a Crazyradio. This improves that process.
- Through the `make flash_dfu` command, a python script sends a USB control transfer request with `wIndex = 0x02` to the Crazyflie, the Crazyflie then handles that request by setting a flag in SRAM and rebooting. 
- Upon every start-up, this flag is checked and if set correctly, will jump to the STM32405's DFU mode. 
- Next `dfu-util` is used to download the new cf2.dfu file to the Crazyflie, and automatically transition back to firmware mode once completed.


## References
- Issue #923 
- Crazyflie forum post: https://forum.bitcraze.io/viewtopic.php?p=23802 

## Comments/Concerns
- The storage address for the bootloader flag was chosen to be the start of the 16kb SRAM bank `SRAM2_BASE = 0x2001C000` (see [STM32F405 data sheet](https://www.st.com/resource/en/datasheet/dm00037051.pdf) page 71) this shouldn't conflict with anything else, as the only time it is modified is right before a restart, and it is set to 0 during the startup check. Would there be any future issues with using this address?
- Currently the `check_enter_bootloader` function is called before `platformInit`, I did this to minimize the number of unknown operations that could modify the state of the microcontroller before jumping to the bootloader. This system initialization might need to be performed before the bootloader check to check we are running on the right hardware.
- `usbd_cf_Setup` never returns, as the system reboots while handling the request, this causes an IO error in python that is expected. I believe the system would need to return from `usbd_cf_Setup` for this python error to be avoided. Would there be an easy way to call `enter_bootloader` after the USB request is responded to? 