### PR TITLE
Build: Remove ENABLE_UART2 define

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
         submodules: true
 
     - name: All features
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make tag_defconfig && ./tools/build/build PLATFORM=cf2 CONFIG_DEBUG=y "EXTRA_CFLAGS=-DOW_WRITE_TEST -DOW_READ_TEST -DENABLE_UART2"  UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make tag_defconfig && ./tools/build/build PLATFORM=cf2 CONFIG_DEBUG=y "EXTRA_CFLAGS=-DOW_WRITE_TEST -DOW_READ_TEST"  UNIT_TEST_STYLE=min"
 
   features:
     runs-on: ubuntu-latest

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -174,9 +174,6 @@ void systemTask(void *arg)
 #ifdef CONFIG_DEBUG_PRINT_ON_UART1
   uart1Init(115200);
 #endif
-#ifdef ENABLE_UART2
-  uart2Init(115200);
-#endif
 
   initUsecTimer();
   i2cdevInit(I2C3_DEV);


### PR DESCRIPTION
UART2 is used from different decks, if anyone wants to use UART2 for
other stuff, or in an app-layer app they can initialize it themself.

The added benefit of this define is slim and it is a bit confusing.
