### PR TITLE
Build: Remove SENSORS_MPU6500_DLPF_256HZ define

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
         submodules: true
 
     - name: All features
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make tag_defconfig && ./tools/build/build PLATFORM=cf2 CONFIG_DEBUG=y "EXTRA_CFLAGS=-DSENSORS_MPU6500_DLPF_256HZ -DOW_WRITE_TEST -DOW_READ_TEST -DDEBUG_PRINT_ON_UART -DENABLE_UART1 -DENABLE_UART2"  UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make tag_defconfig && ./tools/build/build PLATFORM=cf2 CONFIG_DEBUG=y "EXTRA_CFLAGS=-DOW_WRITE_TEST -DOW_READ_TEST -DDEBUG_PRINT_ON_UART -DENABLE_UART1 -DENABLE_UART2"  UNIT_TEST_STYLE=min"
 
   features:
     runs-on: ubuntu-latest

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -52,12 +52,6 @@
 #include "static_mem.h"
 #include "estimator.h"
 
-/**
- * Enable 250Hz digital LPF mode. However does not work with
- * multiple slave reading through MPU9250 (MAG and BARO), only single for some reason.
- */
-//#define SENSORS_MPU6500_DLPF_256HZ
-
 #define SENSORS_ENABLE_PRESSURE_LPS25H
 //#define GYRO_ADD_RAW_AND_VARIANCE_LOG_VALUES
 
@@ -395,13 +389,6 @@ static void sensorsDeviceInit(void)
   // Set accelerometer digital low-pass bandwidth
   mpu6500SetAccelDLPF(MPU6500_ACCEL_DLPF_BW_41);
 
-#if SENSORS_MPU6500_DLPF_256HZ
-  // 256Hz digital low-pass filter only works with little vibrations
-  // Set output rate (15): 8000 / (1 + 7) = 1000Hz
-  mpu6500SetRate(7);
-  // Set digital low-pass bandwidth
-  mpu6500SetDLPFMode(MPU6500_DLPF_BW_256);
-#else
   // To low DLPF bandwidth might cause instability and decrease agility
   // but it works well for handling vibrations and unbalanced propellers
   // Set output rate (1): 1000 / (1 + 0) = 1000Hz
@@ -414,7 +401,6 @@ static void sensorsDeviceInit(void)
     lpf2pInit(&gyroLpf[i], 1000, GYRO_LPF_CUTOFF_FREQ);
     lpf2pInit(&accLpf[i],  1000, ACCEL_LPF_CUTOFF_FREQ);
   }
-#endif
 
 
 #ifdef SENSORS_ENABLE_MAG_AK8963
@@ -456,14 +442,7 @@ static void sensorsDeviceInit(void)
 static void sensorsSetupSlaveRead(void)
 {
   // Now begin to set up the slaves
-#ifdef SENSORS_MPU6500_DLPF_256HZ
-  // As noted in registersheet 4.4: "Data should be sampled at or above sample rate;
-  // SMPLRT_DIV is only used for 1kHz internal sampling." Slowest update rate is then 500Hz.
-  mpu6500SetSlave4MasterDelay(15); // read slaves at 500Hz = (8000Hz / (1 + 15))
-#else
   mpu6500SetSlave4MasterDelay(9); // read slaves at 100Hz = (500Hz / (1 + 4))
-#endif
-
   mpu6500SetI2CBypassEnabled(false);
   mpu6500SetWaitForExternalSensorEnabled(true); // the slave data isn't so important for the state estimation
   mpu6500SetInterruptMode(0); // active high


### PR DESCRIPTION
It is obosolete and was only valid for CF2.0.
