### PR TITLE
Fix a typo in the name of Robert Mahony

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -70,7 +70,7 @@ menu "IMU configuration"
 
 choice
     prompt "IMU algorithm"
-    default IMU_MAYHONY_QUATERNION
+    default IMU_MAHONY_QUATERNION
 
 config IMU_MADGWICK_QUATERNION
     bool "Madgwick's AHRS and IMU algorithms"
@@ -78,10 +78,10 @@ config IMU_MADGWICK_QUATERNION
         Use Madgwick's IMU and AHRS algorithms.
         See: http://www.x-io.co.uk/open-source-ahrs-with-x-imu
 
-config IMU_MAYHONY_QUATERNION
-    bool "Mayhony IMU algorithm"
+config IMU_MAHONY_QUATERNION
+    bool "Mahony IMU algorithm"
     help
-        Use Mayhony's algorithm from the paper:
+        Use Mahony's algorithm from the paper:
         Nonlinear Complementary Filters on the Special Orthogonal Group
         See: https://ieeexplore.ieee.org/document/4608934
 

--- a/src/modules/src/sensfusion6.c
+++ b/src/modules/src/sensfusion6.c
@@ -172,7 +172,7 @@ static void sensfusion6UpdateQImpl(float gx, float gy, float gz, float ax, float
   qz *= recipNorm;
 }
 #else
-// Madgwick's implementation of Mayhony's AHRS algorithm.
+// Madgwick's implementation of Mahony's AHRS algorithm.
 // See: http://www.x-io.co.uk/open-source-ahrs-with-x-imu
 //
 // Date     Author      Notes


### PR DESCRIPTION
This PR fixes a typo in the name of Robert Mahony when referring to his IMU algorithm; check the link to the paper for proof of the correct spelling.