### PR TITLE
Add Kconfig option to force the firmware to assume that the drone has no charger

### DIFF
--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -22,4 +22,14 @@ config PM_BAT_CRITICAL_LOW_VOLTAGE
         time. The length of this period is configured in the code; see
         hal/interface/pm.h
 
+config PM_DISABLE_CHARGER_DETECTION
+    bool "Disable charger detection"
+    default n
+    help
+        Use this setting on boards without a charger circuit that may
+        incorrectly report that a charger is connected. Enabling this setting
+        will force the firmware to assume that no charger is connected and the
+        drone is not charging, even if the syslink info from the nRF51 chip
+        tells otherwise.
+
 endmenu

--- a/src/hal/src/pm_stm32f4.c
+++ b/src/hal/src/pm_stm32f4.c
@@ -42,6 +42,7 @@
 #include "deck.h"
 #include "static_mem.h"
 #include "worker.h"
+#include "autoconf.h"
 
 typedef struct _PmSyslinkInfo
 {
@@ -265,6 +266,14 @@ PMStates pmUpdateState()
   bool isCharging = pmSyslinkInfo.chg;
   bool isPgood = pmSyslinkInfo.pgood;
   uint32_t batteryLowTime;
+
+#ifdef CONFIG_PM_DISABLE_CHARGER_DETECTION
+  /* This branch may be enabled when the hardware incorrectly reports that a
+   * charger is connected even when it isn't (e.g., if the board has no charger
+   * at all). */
+  isPgood = false;
+  isCharging = false;
+#endif
 
   batteryLowTime = xTaskGetTickCount() - batteryLowTimeStamp;
 


### PR DESCRIPTION
This PR adds a configuration option to the firmware that forces it to assume that the drone has no charger. This is useful for the Bolt board, which has no charger, but the syslink info incorrectly reports that the drone is constantly being charged.