### PR TITLE
Make battery limits persistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,6 @@ ifneq ($(CONFIG_DECK_LOCO_2D_POSITION_HEIGHT),)
 unquoted = $(patsubst "%",%,$(CONFIG_DECK_LOCO_2D_POSITION_HEIGHT))
 ARCH_CFLAGS += -DDECK_LOCO_2D_POSITION_HEIGHT=$(unquoted)
 endif
-unquoted = $(patsubst "%",%,$(CONFIG_PM_BAT_LOW_VOLTAGE))
-ARCH_CFLAGS += -DPM_BAT_LOW_VOLTAGE=$(unquoted)f
-unquoted = $(patsubst "%",%,$(CONFIG_PM_BAT_CRITICAL_LOW_VOLTAGE))
-ARCH_CFLAGS += -DPM_BAT_CRITICAL_LOW_VOLTAGE=$(unquoted)f
 
 ifeq ($(CONFIG_PLATFORM_TAG),y)
 PLATFORM = tag

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -211,12 +211,6 @@
 #define BAT_LOADING_SAG_THRESHOLD  0.95f
 
 /**
- * \def ACTIVATE_AUTO_SHUTDOWN
- * Will automatically shot of system if no radio activity
- */
-//#define ACTIVATE_AUTO_SHUTDOWN
-
-/**
  * \def ACTIVATE_STARTUP_SOUND
  * Playes a startup melody using the motors and PWM modulation
  */

--- a/src/hal/interface/pm.h
+++ b/src/hal/interface/pm.h
@@ -27,50 +27,11 @@
 #ifndef PM_H_
 #define PM_H_
 
+#include "autoconf.h"
 #include "adc.h"
 #include "syslink.h"
 #include "deck.h"
 
-// PM_BAT_LOW_VOLTAGE and PM_BAT_CRITICAL_LOW_VOLTAGE are now defined by the
-// Makefile. Do not use CONFIG_PM_BAT_CRITICAL_LOW_VOLTAGE and
-// CONFIG_PM_BAT_LOW_VOLTAGE as those are strings.
-
-#ifndef CRITICAL_LOW_TIMEOUT
-  #define PM_BAT_CRITICAL_LOW_TIMEOUT   M2T(1000 * 5) // 5 sec default
-#else
-  #define PM_BAT_CRITICAL_LOW_TIMEOUT   CRITICAL_LOW_TIMEOUT
-#endif
-
-#ifndef LOW_TIMEOUT
-  #define PM_BAT_LOW_TIMEOUT   M2T(1000 * 5) // 5 sec default
-#else
-  #define PM_BAT_LOW_TIMEOUT   LOW_TIMEOUT
-#endif
-
-#ifndef SYSTEM_SHUTDOWN_TIMEOUT
-  #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * 5) // 5 min default
-#else
-  #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * SYSTEM_SHUTDOWN_TIMEOUT)
-#endif
-
-#define PM_BAT_DIVIDER                3.0f
-#define PM_BAT_ADC_FOR_3_VOLT         (int32_t)(((3.0f / PM_BAT_DIVIDER) / 2.8f) * 4096)
-#define PM_BAT_ADC_FOR_1p2_VOLT       (int32_t)(((1.2f / PM_BAT_DIVIDER) / 2.8f) * 4096)
-
-#define PM_BAT_IIR_SHIFT     8
-/**
- * Set PM_BAT_WANTED_LPF_CUTOFF_HZ to the wanted cut-off freq in Hz.
- */
-#define PM_BAT_WANTED_LPF_CUTOFF_HZ   1
-
-/**
- * Attenuation should be between 1 to 256.
- *
- * f0 = fs / 2*pi*attenuation.
- * attenuation = fs / 2*pi*f0
- */
-#define PM_BAT_IIR_LPF_ATTENUATION (int)(ADC_SAMPLING_FREQ / (int)(2 * 3.1415f * PM_BAT_WANTED_LPF_CUTOFF_HZ))
-#define PM_BAT_IIR_LPF_ATT_FACTOR  (int)((1<<PM_BAT_IIR_SHIFT) / PM_BAT_IIR_LPF_ATTENUATION)
 
 typedef enum
 {

--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -1,25 +1,12 @@
 menu "Power management configuration"
 
-#
-# Kconfig does not support float, we use strings here and fix them up in the
-# Makefile.
-#
-config PM_BAT_LOW_VOLTAGE
-    string "Low voltage threshold in volts"
-    default 3.2
+config PM_AUTO_SHUTDOWN
+    bool "Enable automatic shutdown"
+    default n
     help
-        The power management subsystem will enter the "low voltage" state when
-        the battery voltage is below this threshold for a prolonged period of
-        time. The length of this period is configured in the code; see
-        hal/interface/pm.h
-
-config PM_BAT_CRITICAL_LOW_VOLTAGE
-    string "Critical low voltage threshold in volts"
-    default 3.0
-    help
-        The power management subsystem will shut the system down when the
-        battery voltage is below this threshold for a prolonged period of
-        time. The length of this period is configured in the code; see
-        hal/interface/pm.h
+        The power management subsystem can automatically shutdown the system.
+        The shutdown time in minutes is defined in platform_defaults_* for
+        the specific platform and is the time since the last radio communication
+        occured.
 
 endmenu

--- a/src/hal/src/pm_stm32f4.c
+++ b/src/hal/src/pm_stm32f4.c
@@ -524,11 +524,11 @@ PARAM_GROUP_START(pm)
 /**
  * @brief At what voltage power management will indicate low battery.
  */
-PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, LowVoltage, &batteryLowVoltage)
+PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, lowVoltage, &batteryLowVoltage)
 /**
  * @brief At what voltage power management will indicate critical low battery.
  */
-PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, CriticalLowVoltage, &batteryCriticalLowVoltage)
+PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, criticalLowVoltage, &batteryCriticalLowVoltage)
 
 PARAM_GROUP_STOP(pm)
 

--- a/src/hal/src/pm_stm32f4.c
+++ b/src/hal/src/pm_stm32f4.c
@@ -45,7 +45,7 @@
 #include "worker.h"
 #include "platform_defaults.h"
 
-// Conversion to ticks
+// Battery time limit conversions to ticks
 #define PM_BAT_CRITICAL_LOW_TIMEOUT   M2T(1000 * DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC)
 #define PM_BAT_LOW_TIMEOUT            M2T(1000 * DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC)
 #define PM_SYSTEM_SHUTDOWN_TIMEOUT    M2T(1000 * 60 * DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN)
@@ -86,7 +86,7 @@ static float     extBatCurrAmpPerVolt;
 
 // Limits
 static float     batteryCriticalLowVoltage = DEFAULT_BAT_CRITICAL_LOW_VOLTAGE;
-static float     batteryLowVoltage = DEFAULT_BAT_BAT_LOW_VOLTAGE;
+static float     batteryLowVoltage = DEFAULT_BAT_LOW_VOLTAGE;
 
 
 #ifdef PM_SYSTLINK_INLCUDE_TEMP
@@ -161,7 +161,7 @@ static void pmSetBatteryVoltage(float voltage)
  */
 static void pmSystemShutdown(void)
 {
-#ifdef ACTIVATE_AUTO_SHUTDOWN
+#ifdef CONFIG_PM_AUTO_SHUTDOWN
   systemRequestShutdown();
 #endif
 }
@@ -517,15 +517,18 @@ LOG_ADD(LOG_FLOAT, temp, &temp)
 #endif
 LOG_GROUP_STOP(pm)
 
+/**
+ * Power management parameters.
+ */
 PARAM_GROUP_START(pm)
 /**
  * @brief At what voltage power management will indicate low battery.
  */
-PARAM_ADD_CORE(PARAM_UINT8 | PARAM_PERSISTENT, LowVoltage, &batteryCriticalLowVoltage)
+PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, LowVoltage, &batteryLowVoltage)
 /**
  * @brief At what voltage power management will indicate critical low battery.
  */
-PARAM_ADD_CORE(PARAM_UINT8 | PARAM_PERSISTENT, CriticalLowVoltage, &batteryCriticalLowVoltage)
+PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, CriticalLowVoltage, &batteryCriticalLowVoltage)
 
 PARAM_GROUP_STOP(pm)
 

--- a/src/platform/interface/platform_defaults_bolt.h
+++ b/src/platform/interface/platform_defaults_bolt.h
@@ -33,12 +33,11 @@
 
 // Defines for default values in the bolt platform
 
-// #define EXAMPLE_DEFAULT_VALUE 0.8
-
 // Default values for battery limits
-#define DEFAULT_BAT_BAT_LOW_VOLTAGE               6.4f
+#define DEFAULT_BAT_LOW_VOLTAGE                   6.4f
 #define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE          6.0f
 #define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC   5
 
-// Default values for system shutdown
+// Default value for system shutdown in minutes after radio silence.
+// Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5

--- a/src/platform/interface/platform_defaults_bolt.h
+++ b/src/platform/interface/platform_defaults_bolt.h
@@ -34,3 +34,11 @@
 // Defines for default values in the bolt platform
 
 // #define EXAMPLE_DEFAULT_VALUE 0.8
+
+// Default values for battery limits
+#define DEFAULT_BAT_BAT_LOW_VOLTAGE               6.4f
+#define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE          6.0f
+#define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC   5
+
+// Default values for system shutdown
+#define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5

--- a/src/platform/interface/platform_defaults_cf2.h
+++ b/src/platform/interface/platform_defaults_cf2.h
@@ -32,13 +32,13 @@
 #endif
 
 // Defines for default values in the cf2 platform
-// #define EXAMPLE_DEFAULT_VALUE 0.4
 
 // Default values for battery limits
-#define DEFAULT_BAT_BAT_LOW_VOLTAGE               3.2f
+#define DEFAULT_BAT_LOW_VOLTAGE                   3.2f
 #define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE          3.0f
 #define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC   5
 
-// Default values for system shutdown
+// Default value for system shutdown in minutes after radio silence.
+// Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
 

--- a/src/platform/interface/platform_defaults_cf2.h
+++ b/src/platform/interface/platform_defaults_cf2.h
@@ -32,5 +32,13 @@
 #endif
 
 // Defines for default values in the cf2 platform
-
 // #define EXAMPLE_DEFAULT_VALUE 0.4
+
+// Default values for battery limits
+#define DEFAULT_BAT_BAT_LOW_VOLTAGE               3.2f
+#define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE          3.0f
+#define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC   5
+
+// Default values for system shutdown
+#define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
+

--- a/src/platform/interface/platform_defaults_tag.h
+++ b/src/platform/interface/platform_defaults_tag.h
@@ -33,12 +33,11 @@
 
 // Defines for default values in the tag platform
 
-// #define EXAMPLE_DEFAULT_VALUE 0.8
-
 // Default values for battery limits
-#define DEFAULT_BAT_BAT_LOW_VOLTAGE               3.2f
+#define DEFAULT_BAT_LOW_VOLTAGE                   3.2f
 #define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE          3.0f
 #define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC   5
 
-// Default values for system shutdown
+// Default value for system shutdown in minutes after radio silence.
+// Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5

--- a/src/platform/interface/platform_defaults_tag.h
+++ b/src/platform/interface/platform_defaults_tag.h
@@ -34,3 +34,11 @@
 // Defines for default values in the tag platform
 
 // #define EXAMPLE_DEFAULT_VALUE 0.8
+
+// Default values for battery limits
+#define DEFAULT_BAT_BAT_LOW_VOLTAGE               3.2f
+#define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE          3.0f
+#define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC   5
+
+// Default values for system shutdown
+#define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5


### PR DESCRIPTION
The battery limits are made persistent instead of kbuild configs so they are easier to change. Also the power managment automatic shutdown was added as a kconfig. Default values for the different platforms was also added in platform_defaults_*

We came to the conclusion that as a rule of thumb, build time configuration should be in kconfig and parameters that can be changed without a re-build should be persistent. 