### PR TITLE
Add support for new(), malloc(), free() and assert() in C++ app code

### DIFF
--- a/examples/app_hello_world-cpp/Makefile
+++ b/examples/app_hello_world-cpp/Makefile
@@ -20,4 +20,9 @@ CRAZYFLIE_BASE := ../..
 #
 OOT_CONFIG := $(PWD)/app-config
 
+#
+# Indicate that the out-of-tree build should use a C++ linker
+#
+OOT_USES_CXX := 1
+
 include $(CRAZYFLIE_BASE)/tools/make/oot.mk

--- a/examples/app_hello_world-cpp/src/hello_world.cpp
+++ b/examples/app_hello_world-cpp/src/hello_world.cpp
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2019 Bitcraze AB
+ * Copyright (C) 2022 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <cassert>
+#include <string>
+
 extern "C"
 {
   #include "app.h"
@@ -43,9 +46,22 @@ extern "C"
 
 #define DEBUG_MODULE "HELLOWORLD"
 
+class MyClass {
+  public:
+    int myNum;
+    std::string myString;
+};
+
 void appMain()
 {
   DEBUG_PRINT("Waiting for activation ...\n");
+
+  MyClass *cl = new MyClass();
+  DEBUG_PRINT("MyClass has a num: %d\n", cl->myNum);
+
+  /* make sure that the assertion is not simple enough to be optimized away
+   * by the compiler */
+  assert(cl->myNum + cl->myString.size() == 0);
 
   while(1) {
     vTaskDelay(M2T(2000));

--- a/src/utils/src/Kbuild
+++ b/src/utils/src/Kbuild
@@ -6,6 +6,10 @@ obj-y += crc32.o
 obj-y += debug.o
 obj-y += eprintf.o
 
+### Implementations for abort(), malloc() and free(), needed to interact with apps written in C++
+obj-y += abort.o
+obj-y += malloc.o
+
 ### Add rules for handling generated version.c
 
 obj-y += version.o

--- a/src/utils/src/malloc.c
+++ b/src/utils/src/malloc.c
@@ -1,0 +1,22 @@
+#include "FreeRTOS.h"
+
+void* malloc(size_t size)
+{
+    void* ptr = NULL;
+
+    if (size > 0)
+    {
+        ptr = pvPortMalloc(size);
+    }
+
+    return ptr;
+}
+
+void free(void* ptr)
+{
+    if (ptr)
+    {
+        vPortFree(ptr);
+    }
+}
+

--- a/tools/kbuild/Makefile.kbuild
+++ b/tools/kbuild/Makefile.kbuild
@@ -256,6 +256,10 @@ OBJCOPY	= $(CROSS_COMPILE)objcopy
 OBJDUMP	= $(CROSS_COMPILE)objdump
 SIZE    = $(CROSS_COMPILE)size
 
+ifneq ($(OOT_USES_CXX),)
+LD		= $(CROSS_COMPILE)g++
+endif
+
 AWK		= awk
 PERL	= perl
 PYTHON	= python3
@@ -556,6 +560,10 @@ firmware-dirs	:= $(objs-y)
 firmware-objs	:= $(patsubst %,%/built-in.o, $(objs-y))
 firmware-libs	:= $(patsubst %,%/lib.a, $(libs-y))
 firmware-all	:= $(firmware-objs) $(firmware-libs)
+
+ifneq ($(OOT_USES_CXX),)
+	firmware-libs += -lstdc++
+endif
 
 quiet_cmd_firmware = LD      $@
       cmd_firmware = $(LD) $(image_LDFLAGS) $(LDFLAGS) $(firmware-objs) $(firmware-libs) -lm -o $@.elf

--- a/tools/make/oot.mk
+++ b/tools/make/oot.mk
@@ -12,6 +12,10 @@ OOT_CONFIG ?= $(OOT)/oot-config
 
 OOT_ARGS ?= -C $(CRAZYFLIE_BASE) OOT=$(OOT) EXTRA_CFLAGS=$(EXTRA_CFLAGS)
 
+ifneq ($(OOT_USES_CXX),)
+OOT_ARGS += OOT_USES_CXX=1
+endif
+
 .PHONY: all clean
 
 all:


### PR DESCRIPTION
This PR attempts to fix #960 for more complex C++ apps that uses classes or assertions. See the discussion in #960 for more details.

The PR extends the build system to use the C++ linker and to link to `stdc++` when the OOT app makefile indicates that it needs C++ facilities by setting `OOT_USES_CXX` to a non-empty value. The PR also provides implementations of `malloc()` and `free()` in terms of FreeRTOS functions to ensure that C++ code that was not designed with FreeRTOS in mind keeps on working even in this environment.