### PR TITLE
Use credentials for AI-deck AP mode

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -36,9 +36,9 @@ choice
       bool "Connect to a WiFi network"
 endchoice
 
-menu "Credentials for connecting to another access-point"
+menu "Credentials for access-point"
     depends on DECK_AI  
-    depends on DECK_AI_WIFI_SETUP_STA
+    depends on !DECK_AI_WIFI_NO_SETUP
     config DECK_AI_SSID
         string "WiFi SSID"
         default "myssid"

--- a/src/deck/drivers/src/aideck-router.c
+++ b/src/deck/drivers/src/aideck-router.c
@@ -98,7 +98,6 @@ static void setupWiFi() {
 
   cpxInitRoute(CPX_T_STM32, CPX_T_ESP32, CPX_F_WIFI_CTRL, &cpxTx.route);
 
-#ifdef CONFIG_DECK_AI_WIFI_SETUP_STA
   cpxTx.data[0] = WIFI_SET_SSID_CMD; // Set SSID
   memcpy(&cpxTx.data[1], CONFIG_DECK_AI_SSID, sizeof(CONFIG_DECK_AI_SSID));
   cpxTx.dataLength = sizeof(CONFIG_DECK_AI_SSID);
@@ -108,7 +107,6 @@ static void setupWiFi() {
   memcpy(&cpxTx.data[1], CONFIG_DECK_AI_PASSWORD, sizeof(CONFIG_DECK_AI_PASSWORD));
   cpxTx.dataLength = sizeof(CONFIG_DECK_AI_PASSWORD);
   cpxSendPacketBlocking(&cpxTx);
-#endif
 
   cpxTx.data[0] = WIFI_CONNECT_CMD; // Connect wifi
 #ifdef CONFIG_DECK_AI_WIFI_SETUP_STA


### PR DESCRIPTION
It's now possible to set SSID/PASSWORD also when the WiFi mode AP is selected. If the PASSWORD is empty then the AP will be open.