### PR TITLE
Add setting to Kconfig for max number of Lighthouse base stations

### DIFF
--- a/docs/functional-areas/lighthouse/multi_base_stations.md
+++ b/docs/functional-areas/lighthouse/multi_base_stations.md
@@ -17,10 +17,9 @@ guide on our web to get a good understanding of basic use.
 in the python client for this task
 2. Place your base stations. They must overlap, but avoid too many in one spot, there should not be more than 4 visible
 at the same time.
-3. Re-flash the Crazyflie with support for more base stations. Start by editing the
-`src/utils/interface/lighthouse/pulse_processor.h` file in this project and change the PULSE_PROCESSOR_N_BASE_STATIONS
-to the desired number of base stations. Note: more base stations use more RAM. Build the code and flash it to the
-Crazyflie, see the documentation in this repo for instructions on building and flashing.
+3. Re-flash the Crazyflie with support for more base stations. Run `make menuconfig` and go to the `Expansion deck configuration`
+menu and set `Max number of base stations` to the desired value. Note: more base stations use more RAM. Build the code and
+flash it to the Crazyflie, see the documentation in this repo for instructions on building and flashing.
 4. Acquire calibration data from all the base stations in the system. The Crazyflie gets the calibration data from the
 base stations through the light sweeps and this process takes from 20 seconds and up. When data is received there is
 a notification in the client consol log, and data is stored in the persistent memory in the Crazyflie. First connect

--- a/docs/functional-areas/lighthouse/system_overview.md
+++ b/docs/functional-areas/lighthouse/system_overview.md
@@ -29,8 +29,7 @@ The protocol for the lighthouse V1 is composed of frames starting with sync puls
 
 The protocol in lighthouse 2 does not use the same frame concept and there is no need for frame sync.
 
-The lighthouse V2 protocol supports more than 2 base stations and most of the Crazyflie firmware is designed for this as well but the tools currently only support two base stations.
-The ```PULSE_PROCESSOR_N_BASE_STATIONS``` (in pulse_processor.h) determines the number of base stations that are handled by the system and can be increased by brave users. This feature is very much untested and there is currently no support to estimate the geometry of a 2+ system.
+The lighthouse V2 protocol supports more than 2 base stations. There's currently experimental support implemented for 2+ base stations, for more information please see [the 2+ base station documentation](/docs/functional-areas/lighthouse/multi_base_stations.md).
 
 ## Position estimation methods
 There are currently two ways of calculating the position using the lighthouse.

--- a/examples/demos/swarm_demo/app.c
+++ b/examples/demos/swarm_demo/app.c
@@ -20,6 +20,7 @@
 #include "pptraj.h"
 #include "lighthouse_position_est.h"
 #include "lighthouse_core.h"
+#include "autoconf.h"
 
 #define DEBUG_MODULE "APP"
 #include "debug.h"
@@ -173,12 +174,12 @@ static bool isBatLow() { return logGetInt(logIdPmState) == lowPower; }
 static bool isCharging() { return logGetInt(logIdPmState) == charging; }
 static bool isLighthouseAvailable() { return logGetFloat(logIdlighthouseEstBs0Rt) >= 0.0f || logGetFloat(logIdlighthouseEstBs1Rt) >= 0.0f; }
 
-const baseStationGeometry_t lighthouseGeoData[PULSE_PROCESSOR_N_BASE_STATIONS]  = {
+const baseStationGeometry_t lighthouseGeoData[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS]  = {
  {.valid = true, .origin = {-2.057947, 0.398319, 3.109704, }, .mat = {{0.807210, 0.002766, 0.590258, }, {0.067095, 0.993078, -0.096409, }, {-0.586439, 0.117426, 0.801437, }, }},
  {.valid = true, .origin = {0.866244, -2.566829, 3.132632, }, .mat = {{-0.043296, -0.997675, -0.052627, }, {0.766284, -0.066962, 0.639003, }, {-0.641042, -0.012661, 0.767401, }, }},
 };
 
-lighthouseCalibration_t lighthouseCalibrationData[PULSE_PROCESSOR_N_BASE_STATIONS] = {
+lighthouseCalibration_t lighthouseCalibrationData[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS] = {
   { // Base station 0
     .sweep = {
       {.tilt = -0.047353, .phase = 0.000000, .curve = 0.478887, .gibphase = 1.023093, .gibmag = 0.005071, .ogeephase = 1.136886, .ogeemag = -0.520102, },

--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -182,6 +182,15 @@ config DECK_LIGHTHOUSE_AS_GROUNDTRUTH
         position to the kalman estimator and you can 
         read out the positioning from the loggin lighthouse.x.y.z
 
+config DECK_LIGHTHOUSE_MAX_N_BS
+  int "Max number of base stations"
+  depends on DECK_LIGHTHOUSE
+  default 2
+  range 2 16
+  help
+      Set the max number of base stations supported. NOTE: This is only
+      valid for Lighthouse V2.
+
 config DECK_LOCO
     bool "Support the Loco positioning deck"
     default y

--- a/src/modules/src/crtp_localization_service.c
+++ b/src/modules/src/crtp_localization_service.c
@@ -49,6 +49,8 @@
 
 #include "num.h"
 
+#include "autoconf.h"
+
 #define NBR_OF_RANGES_IN_PACKET   5
 #define NBR_OF_SWEEPS_IN_PACKET   2
 #define NBR_OF_SENSOR_DIFFS_IN_PACKET   3
@@ -247,7 +249,7 @@ static void lhPersistDataWorker(void* arg) {
 
   bool result = true;
 
-  for (int baseStation = 0; baseStation < PULSE_PROCESSOR_N_BASE_STATIONS; baseStation++) {
+  for (int baseStation = 0; baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; baseStation++) {
     uint16_t mask = 1 << baseStation;
     bool storeGeo = (args->geoDataBsField & mask) != 0;
     bool storeCalibration = (args->calibrationDataBsField & mask) != 0;

--- a/src/modules/src/lighthouse/lighthouse_core.c
+++ b/src/modules/src/lighthouse/lighthouse_core.c
@@ -84,7 +84,7 @@ static STATS_CNT_RATE_DEFINE(cycleRate, ONE_SECOND);
 
 static STATS_CNT_RATE_DEFINE(bs0Rate, HALF_SECOND);
 static STATS_CNT_RATE_DEFINE(bs1Rate, HALF_SECOND);
-static statsCntRateLogger_t* bsRates[PULSE_PROCESSOR_N_BASE_STATIONS] = {&bs0Rate, &bs1Rate};
+static statsCntRateLogger_t* bsRates[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS] = {&bs0Rate, &bs1Rate};
 
 
 // A bitmap that indicates which base staions that are received
@@ -307,7 +307,7 @@ static void usePulseResultSweeps(pulseProcessor_t *appState, pulseProcessorResul
 
 static void convertV2AnglesToV1Angles(pulseProcessorResult_t* angles) {
   for (int sensor = 0; sensor < PULSE_PROCESSOR_N_SENSORS; sensor++) {
-    for (int bs = 0; bs < PULSE_PROCESSOR_N_BASE_STATIONS; bs++) {
+    for (int bs = 0; bs < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; bs++) {
       pulseProcessorBaseStationMeasuremnt_t* from = &angles->sensorMeasurementsLh2[sensor].baseStatonMeasurements[bs];
       pulseProcessorBaseStationMeasuremnt_t* to = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[bs];
 
@@ -362,7 +362,7 @@ static void usePulseResult(pulseProcessor_t *appState, pulseProcessorResult_t* a
 }
 
 static void useCalibrationData(pulseProcessor_t *appState) {
-  for (int baseStation = 0; baseStation < PULSE_PROCESSOR_N_BASE_STATIONS; baseStation++) {
+  for (int baseStation = 0; baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; baseStation++) {
     if (appState->ootxDecoder[baseStation].isFullyDecoded) {
       lighthouseCalibration_t newData;
       lighthouseCalibrationInitFromFrame(&newData, &appState->ootxDecoder[baseStation].frame);
@@ -506,7 +506,7 @@ void lighthouseCoreTask(void *param) {
 }
 
 void lighthouseCoreSetCalibrationData(const uint8_t baseStation, const lighthouseCalibration_t* calibration) {
-  if (baseStation < PULSE_PROCESSOR_N_BASE_STATIONS) {
+  if (baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
     lighthouseCoreState.bsCalibration[baseStation] = *calibration;
     lighthousePositionCalibrationDataWritten(baseStation);
   }

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -46,7 +46,7 @@
 static STATS_CNT_RATE_DEFINE(positionRate, ONE_SECOND);
 static STATS_CNT_RATE_DEFINE(estBs0Rate, HALF_SECOND);
 static STATS_CNT_RATE_DEFINE(estBs1Rate, HALF_SECOND);
-static statsCntRateLogger_t* bsEstRates[PULSE_PROCESSOR_N_BASE_STATIONS] = {&estBs0Rate, &estBs1Rate};
+static statsCntRateLogger_t* bsEstRates[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS] = {&estBs0Rate, &estBs1Rate};
 
 // The light planes in LH2 are tilted +- 30 degrees
 static const float t30 = M_PI / 6;
@@ -78,7 +78,7 @@ static void modifyBit(uint16_t *bitmap, const int index, const bool value) {
 }
 
 void lighthousePositionEstInit() {
-  for (int i = 0; i < PULSE_PROCESSOR_N_BASE_STATIONS; i++) {
+  for (int i = 0; i < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; i++) {
     lighthousePositionGeometryDataUpdated(i);
   }
   memoryRegisterHandler(&memDef);
@@ -90,7 +90,7 @@ static bool handleMemRead(const uint32_t memAddr, const uint8_t readLen, uint8_t
   if (memAddr < calibStartAddr) {
     uint32_t index = memAddr / pageSize;
     uint32_t inPageAddr = memAddr % pageSize;
-    if (index < PULSE_PROCESSOR_N_BASE_STATIONS) {
+    if (index < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
       if (inPageAddr + readLen <= sizeof(baseStationGeometry_t)) {
         uint8_t* start = (uint8_t*)&lighthouseCoreState.bsGeometry[index];
         memcpy(buffer, start + inPageAddr, readLen);
@@ -102,7 +102,7 @@ static bool handleMemRead(const uint32_t memAddr, const uint8_t readLen, uint8_t
     uint32_t calibOffsetAddr = memAddr - calibStartAddr;
     uint32_t index = calibOffsetAddr / pageSize;
     uint32_t inPageAddr = calibOffsetAddr % pageSize;
-    if (index < PULSE_PROCESSOR_N_BASE_STATIONS) {
+    if (index < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
       if (inPageAddr + readLen <= sizeof(lighthouseCalibration_t)) {
         uint8_t* start = (uint8_t*)&lighthouseCoreState.bsCalibration[index];
         memcpy(buffer, start + inPageAddr, readLen);
@@ -121,7 +121,7 @@ static bool handleMemWrite(const uint32_t memAddr, const uint8_t writeLen, const
   if (memAddr < calibStartAddr) {
     uint32_t index = memAddr / pageSize;
     uint32_t inPageAddr = memAddr % pageSize;
-    if (index < PULSE_PROCESSOR_N_BASE_STATIONS) {
+    if (index < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
       if (inPageAddr + writeLen <= sizeof(baseStationGeometry_t)) {
         // Mark the geometry as invalid since this write probably only will update part of it
         // If this is the last write in this block, the valid flag will be part of the data and set appropriately
@@ -140,7 +140,7 @@ static bool handleMemWrite(const uint32_t memAddr, const uint8_t writeLen, const
     uint32_t calibOffsetAddr = memAddr - calibStartAddr;
     uint32_t index = calibOffsetAddr / pageSize;
     uint32_t inPageAddr = calibOffsetAddr % pageSize;
-    if (index < PULSE_PROCESSOR_N_BASE_STATIONS) {
+    if (index < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
       if (inPageAddr + writeLen <= sizeof(lighthouseCalibration_t)) {
         // Mark the calibration data as invalid since this write probably only will update part of it
         // If this is the last write in this block, the valid flag will be part of the data and set appropriately
@@ -161,7 +161,7 @@ static bool handleMemWrite(const uint32_t memAddr, const uint8_t writeLen, const
 }
 
 void lighthousePositionCalibrationDataWritten(const uint8_t baseStation) {
-  if (baseStation < PULSE_PROCESSOR_N_BASE_STATIONS) {
+  if (baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
     modifyBit(&lighthouseCoreState.baseStationCalibValidMap, baseStation, lighthouseCoreState.bsCalibration[baseStation].valid);
   }
 }
@@ -176,7 +176,7 @@ static void lighthousePositionGeometryDataUpdated(const int baseStation) {
 }
 
 void lighthousePositionSetGeometryData(const uint8_t baseStation, const baseStationGeometry_t* geometry) {
-  if (baseStation < PULSE_PROCESSOR_N_BASE_STATIONS) {
+  if (baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
     lighthouseCoreState.bsGeometry[baseStation] = *geometry;
     lighthousePositionGeometryDataUpdated(baseStation);
   }

--- a/src/modules/src/lighthouse/lighthouse_storage.c
+++ b/src/modules/src/lighthouse/lighthouse_storage.c
@@ -38,6 +38,8 @@
 #define DEBUG_MODULE "LH_STORE"
 #include "debug.h"
 
+#include "autoconf.h"
+
 // Persistent storage
 #define STORAGE_VERSION_KEY "lh/ver"
 #define CURRENT_STORAGE_VERSION "1"
@@ -64,7 +66,7 @@ bool lighthouseStoragePersistData(const uint8_t baseStation, const bool geoData,
   bool result = true;
   char key[KEY_LEN];
 
-  if (baseStation < PULSE_PROCESSOR_N_BASE_STATIONS) {
+  if (baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
     if (geoData) {
       generateStorageKey(key, STORAGE_KEY_GEO, baseStation);
       result = result && storageStore(key, &lighthouseCoreState.bsGeometry[baseStation], sizeof(lighthouseCoreState.bsGeometry[baseStation]));
@@ -89,7 +91,7 @@ static void lhPersistDataWorker(void* arg) {
 }
 
 void lighthouseStoragePersistCalibDataBackground(const uint8_t baseStation) {
-  if (baseStation < PULSE_PROCESSOR_N_BASE_STATIONS) {
+  if (baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
     workerSchedule(lhPersistDataWorker, (void*)(uint32_t)baseStation);
   }
 }
@@ -117,7 +119,7 @@ void lighthouseStorageVerifySetStorageVersion() {
 void lighthouseStorageInitializeGeoDataFromStorage() {
   char key[KEY_LEN];
 
-  for (int baseStation = 0; baseStation < PULSE_PROCESSOR_N_BASE_STATIONS; baseStation++) {
+  for (int baseStation = 0; baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; baseStation++) {
     if (!lighthouseCoreState.bsGeometry[baseStation].valid) {
       generateStorageKey(key, STORAGE_KEY_GEO, baseStation);
       const size_t geoSize = sizeof(geoBuffer);
@@ -132,7 +134,7 @@ void lighthouseStorageInitializeGeoDataFromStorage() {
 void lighthouseStorageInitializeCalibDataFromStorage() {
   char key[KEY_LEN];
 
-  for (int baseStation = 0; baseStation < PULSE_PROCESSOR_N_BASE_STATIONS; baseStation++) {
+  for (int baseStation = 0; baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; baseStation++) {
     if (!lighthouseCoreState.bsCalibration[baseStation].valid) {
       generateStorageKey(key, STORAGE_KEY_CALIB, baseStation);
       const size_t calibSize = sizeof(calibBuffer);

--- a/src/utils/interface/lighthouse/pulse_processor.h
+++ b/src/utils/interface/lighthouse/pulse_processor.h
@@ -36,8 +36,9 @@
 #include "lighthouse_calibration.h"
 #include "lighthouse_geometry.h"
 
+#include "autoconf.h"
+
 #define PULSE_PROCESSOR_N_SWEEPS 2
-#define PULSE_PROCESSOR_N_BASE_STATIONS 2
 #define PULSE_PROCESSOR_N_SENSORS 4
 #define PULSE_PROCRSSOR_N_CONCURRENT_BLOCKS 2
 #define PULSE_PROCESSOR_N_WORKSPACE (PULSE_PROCESSOR_N_SENSORS * PULSE_PROCRSSOR_N_CONCURRENT_BLOCKS)
@@ -199,14 +200,14 @@ typedef struct {
   pulseProcessorV2BlockWorkspace_t blockWorkspace;
 
   // Latest block from each base station. Used to pair both blocks (sweeps) from one rotaion of the rotor.
-  pulseProcessorV2SweepBlock_t blocks[PULSE_PROCESSOR_N_BASE_STATIONS];
+  pulseProcessorV2SweepBlock_t blocks[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
 
   // Timestamp of the rotor zero position for the latest processed slowbit
-  uint32_t ootxTimestamps[PULSE_PROCESSOR_N_BASE_STATIONS];
+  uint32_t ootxTimestamps[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
 } pulseProcessorV2_t;
 
 typedef struct pulseProcessor_s {
-  bool receivedBsSweep[PULSE_PROCESSOR_N_BASE_STATIONS];
+  bool receivedBsSweep[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
 
   union {
     struct {
@@ -218,10 +219,10 @@ typedef struct pulseProcessor_s {
     };
   };
 
-  ootxDecoderState_t ootxDecoder[PULSE_PROCESSOR_N_BASE_STATIONS];
-  lighthouseCalibration_t bsCalibration[PULSE_PROCESSOR_N_BASE_STATIONS];
-  baseStationGeometry_t bsGeometry[PULSE_PROCESSOR_N_BASE_STATIONS];
-  baseStationGeometryCache_t bsGeoCache[PULSE_PROCESSOR_N_BASE_STATIONS];
+  ootxDecoderState_t ootxDecoder[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
+  lighthouseCalibration_t bsCalibration[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
+  baseStationGeometry_t bsGeometry[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
+  baseStationGeometryCache_t bsGeoCache[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
 
   // Health check data
   uint32_t healthFirstSensorTs;
@@ -241,14 +242,14 @@ typedef struct {
 } pulseProcessorBaseStationMeasuremnt_t;
 
 typedef struct {
-  pulseProcessorBaseStationMeasuremnt_t baseStatonMeasurements[PULSE_PROCESSOR_N_BASE_STATIONS];
+  pulseProcessorBaseStationMeasuremnt_t baseStatonMeasurements[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
 } pulseProcessorSensorMeasurement_t;
 
 typedef struct {
   pulseProcessorSensorMeasurement_t sensorMeasurementsLh1[PULSE_PROCESSOR_N_SENSORS];
   pulseProcessorSensorMeasurement_t sensorMeasurementsLh2[PULSE_PROCESSOR_N_SENSORS];
   lighthouseBaseStationType_t measurementType;
-  uint64_t lastUsecTimestamp[PULSE_PROCESSOR_N_BASE_STATIONS];
+  uint64_t lastUsecTimestamp[CONFIG_DECK_LIGHTHOUSE_MAX_N_BS];
 } pulseProcessorResult_t;
 
 /**

--- a/src/utils/src/lighthouse/pulse_processor.c
+++ b/src/utils/src/lighthouse/pulse_processor.c
@@ -30,6 +30,7 @@
 #include "pulse_processor_v1.h"
 #include "pulse_processor_v2.h"
 #include "cf_math.h"
+#include "autoconf.h"
 
 
 /**
@@ -77,7 +78,7 @@ void pulseProcessorClearOutdated(pulseProcessor_t *appState, pulseProcessorResul
   // Repeated sweep from the same basestation. So in theory we did a cycle, so we should have had all basestations.
   // If not, cleanup the basestation that we didn't receive.
   if(appState->receivedBsSweep[basestation]) {
-    for(int bs=0; bs != PULSE_PROCESSOR_N_BASE_STATIONS; bs++){
+    for(int bs=0; bs != CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; bs++){
       if(!appState->receivedBsSweep[bs]){
         pulseProcessorClear(angles, bs);
       }
@@ -127,7 +128,7 @@ void pulseProcessorClear(pulseProcessorResult_t* angles, int baseStation)
  */
 void pulseProcessorAllClear(pulseProcessorResult_t* angles)
 {
-  for (int baseStation = 0; baseStation < PULSE_PROCESSOR_N_BASE_STATIONS; baseStation++) {
+  for (int baseStation = 0; baseStation < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; baseStation++) {
     for (size_t sensor = 0; sensor < PULSE_PROCESSOR_N_SENSORS; sensor++) {
       angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[baseStation].validCount = 0;
       angles->sensorMeasurementsLh2[sensor].baseStatonMeasurements[baseStation].validCount = 0;

--- a/src/utils/src/lighthouse/pulse_processor_v1.c
+++ b/src/utils/src/lighthouse/pulse_processor_v1.c
@@ -32,6 +32,7 @@
 #include <math.h>
 #include "test_support.h"
 #include "physicalConstants.h"
+#include "autoconf.h"
 
 // Decoding contants
 // Times are expressed in a 24MHz clock
@@ -503,5 +504,5 @@ void pulseProcessorV1ProcessValidAngles(pulseProcessorResult_t* angles, int base
 }
 
 uint8_t pulseProcessorV1AnglesQuality() {
-  return __builtin_popcount(validAngles)*1.0/(PULSE_PROCESSOR_N_SWEEPS*PULSE_PROCESSOR_N_SENSORS*PULSE_PROCESSOR_N_BASE_STATIONS)*255;
+  return __builtin_popcount(validAngles)*1.0/(PULSE_PROCESSOR_N_SWEEPS*PULSE_PROCESSOR_N_SENSORS*CONFIG_DECK_LIGHTHOUSE_MAX_N_BS)*255;
 }

--- a/src/utils/src/lighthouse/pulse_processor_v2.c
+++ b/src/utils/src/lighthouse/pulse_processor_v2.c
@@ -33,6 +33,7 @@
 #include "math3d.h"
 #include "test_support.h"
 #include "debug.h"
+#include "autoconf.h"
 
 static const uint32_t MAX_TICKS_SENSOR_TO_SENSOR = 10000;
 static const uint32_t MAX_TICKS_BETWEEN_SWEEP_STARTS_TWO_BLOCKS = 10;
@@ -59,7 +60,7 @@ static inline uint32_t cyclePeriodToMicroseconds(uint32_t cyclePeriod) {
 // Reset angles after fixed period to avoid using stale data
 static void clearStaleAnglesAfterTimeout(pulseProcessorResult_t *angles) {
     uint64_t timestamp = usecTimestamp();
-    for (int bs = 0; bs < PULSE_PROCESSOR_N_BASE_STATIONS; ++bs) {
+    for (int bs = 0; bs < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; ++bs) {
         uint64_t elapsed_us = timestamp - angles->lastUsecTimestamp[bs];
         if (elapsed_us > cyclePeriodToMicroseconds(CYCLE_PERIODS[bs])) {
             pulseProcessorClear(angles, bs);
@@ -277,7 +278,7 @@ TESTABLE_STATIC bool isBlockPairGood(const pulseProcessorV2SweepBlock_t* latest,
 TESTABLE_STATIC bool handleCalibrationData(pulseProcessor_t *state, const pulseProcessorFrame_t* frameData) {
     bool isFullMessage = false;
 
-    if (frameData->channelFound && frameData->channel < PULSE_PROCESSOR_N_BASE_STATIONS) {
+    if (frameData->channelFound && frameData->channel < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
         const uint8_t channel = frameData->channel;
         if (frameData->offset != NO_OFFSET) {
             const uint32_t prevTimestamp0 = state->v2.ootxTimestamps[channel];
@@ -303,7 +304,7 @@ bool handleAngles(pulseProcessor_t *state, const pulseProcessorFrame_t* frameDat
     for (int i = 0; i < nrOfBlocks; i++) {
         const pulseProcessorV2SweepBlock_t* block = &state->v2.blockWorkspace.blocks[i];
         const uint8_t channel = block->channel;
-        if (channel < PULSE_PROCESSOR_N_BASE_STATIONS) {
+        if (channel < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS) {
             pulseProcessorV2SweepBlock_t* previousBlock = &state->v2.blocks[channel];
             if (isBlockPairGood(block, previousBlock)) {
                 calculateAngles(block, previousBlock, angles);

--- a/test/modules/src/lighthouse/test_lighthouse_storage.c
+++ b/test/modules/src/lighthouse/test_lighthouse_storage.c
@@ -88,7 +88,7 @@ void testInitializationOfGeoIsDoneFromStorage() {
   int geoSize = sizeof(baseStationGeometry_t);
   const void* ignored = 0;
 
-  for (int i = 0; i < PULSE_PROCESSOR_N_BASE_STATIONS; i++) {
+  for (int i = 0; i < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; i++) {
     storageFetch_ExpectAndReturn("Ignored", ignored, geoSize, geoSize);
     storageFetch_IgnoreArg_key();
     storageFetch_IgnoreArg_buffer();
@@ -120,7 +120,7 @@ void testInitializationOfCalibIsDoneFromStorage() {
   int calibSize = sizeof(lighthouseCalibration_t);
   const void* ignored = 0;
 
-  for (int i = 0; i < PULSE_PROCESSOR_N_BASE_STATIONS; i++) {
+  for (int i = 0; i < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; i++) {
     storageFetch_ExpectAndReturn("Ignored", ignored, calibSize, calibSize);
     storageFetch_IgnoreArg_key();
     storageFetch_IgnoreArg_buffer();

--- a/test/utils/src/lighthouse/test_pulse_processor_v2.c
+++ b/test/utils/src/lighthouse/test_pulse_processor_v2.c
@@ -440,7 +440,7 @@ void testThatSlowBitIsNotProcessedIfChannelIsMissing() {
 
 void testThatSlowBitIsNotProcessedIfChannelIsOutOfBounds() {
     // Fixture
-    slowbitFrame.channel = PULSE_PROCESSOR_N_BASE_STATIONS + 1;
+    slowbitFrame.channel = CONFIG_DECK_LIGHTHOUSE_MAX_N_BS + 1;
 
     setUpOotxDecoderProcessBitCallCounter();
 
@@ -680,7 +680,7 @@ static void setUpSlowbitFrame(){
 }
 
 static void clearSlowbitState() {
-    for (int i = 0; i < PULSE_PROCESSOR_N_BASE_STATIONS; i++) {
+    for (int i = 0; i < CONFIG_DECK_LIGHTHOUSE_MAX_N_BS; i++) {
         state.v2.ootxTimestamps[i] = 0;
         state.bsCalibration[i].valid = false;
     }


### PR DESCRIPTION
This adds a setting to the `Expansion deck configuration` menu for setting the max number of Lighthouse base stations. This will also effect the Lighthouse V1 implementation, but using settings where the number of base stations is greater than 2 has been tested and is working.