### PR TITLE
Persistent parameters for PIDs fixed.

### DIFF
--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -49,12 +49,41 @@ static inline int16_t saturateSignedInt16(float in)
     return (int16_t)in;
 }
 
-PidObject pidRollRate;
-PidObject pidPitchRate;
-PidObject pidYawRate;
-PidObject pidRoll;
-PidObject pidPitch;
-PidObject pidYaw;
+PidObject pidRollRate = {
+  .kp = PID_ROLL_RATE_KP,
+  .ki = PID_ROLL_RATE_KI,
+  .kd = PID_ROLL_RATE_KD,
+};
+
+PidObject pidPitchRate = {
+  .kp = PID_PITCH_RATE_KP,
+  .ki = PID_PITCH_RATE_KI,
+  .kd = PID_PITCH_RATE_KD,
+};
+
+PidObject pidYawRate = {
+  .kp = PID_YAW_RATE_KP,
+  .ki = PID_YAW_RATE_KI,
+  .kd = PID_YAW_RATE_KD,
+};
+
+PidObject pidRoll = {
+  .kp = PID_ROLL_KP,
+  .ki = PID_ROLL_KI,
+  .kd = PID_ROLL_KD,
+};
+
+PidObject pidPitch = {
+  .kp = PID_ROLL_KP,
+  .ki = PID_ROLL_KI,
+  .kd = PID_ROLL_KD,
+};
+
+PidObject pidYaw = {
+  .kp = PID_ROLL_KP,
+  .ki = PID_ROLL_KI,
+  .kd = PID_ROLL_KD,
+};
 
 static int16_t rollOutput;
 static int16_t pitchOutput;
@@ -68,22 +97,22 @@ void attitudeControllerInit(const float updateDt)
     return;
 
   //TODO: get parameters from configuration manager instead
-  pidInit(&pidRollRate,  0, PID_ROLL_RATE_KP,  PID_ROLL_RATE_KI,  PID_ROLL_RATE_KD,
+  pidInit(&pidRollRate,  0, pidRollRate.kp,  pidRollRate.ki,  pidRollRate.kd,
       updateDt, ATTITUDE_RATE, ATTITUDE_RATE_LPF_CUTOFF_FREQ, ATTITUDE_RATE_LPF_ENABLE);
-  pidInit(&pidPitchRate, 0, PID_PITCH_RATE_KP, PID_PITCH_RATE_KI, PID_PITCH_RATE_KD,
+  pidInit(&pidPitchRate, 0, pidPitchRate.kp, pidPitchRate.ki, pidPitchRate.kd,
       updateDt, ATTITUDE_RATE, ATTITUDE_RATE_LPF_CUTOFF_FREQ, ATTITUDE_RATE_LPF_ENABLE);
-  pidInit(&pidYawRate,   0, PID_YAW_RATE_KP,   PID_YAW_RATE_KI,   PID_YAW_RATE_KD,
+  pidInit(&pidYawRate,   0, pidYawRate.kp,   pidYawRate.ki,   pidYawRate.kd,
       updateDt, ATTITUDE_RATE, ATTITUDE_RATE_LPF_CUTOFF_FREQ, ATTITUDE_RATE_LPF_ENABLE);
 
   pidSetIntegralLimit(&pidRollRate,  PID_ROLL_RATE_INTEGRATION_LIMIT);
   pidSetIntegralLimit(&pidPitchRate, PID_PITCH_RATE_INTEGRATION_LIMIT);
   pidSetIntegralLimit(&pidYawRate,   PID_YAW_RATE_INTEGRATION_LIMIT);
 
-  pidInit(&pidRoll,  0, PID_ROLL_KP,  PID_ROLL_KI,  PID_ROLL_KD,  updateDt,
+  pidInit(&pidRoll,  0, pidRoll.kp,  pidRoll.ki,  pidRoll.kd,  updateDt,
       ATTITUDE_RATE, ATTITUDE_LPF_CUTOFF_FREQ, ATTITUDE_LPF_ENABLE);
-  pidInit(&pidPitch, 0, PID_PITCH_KP, PID_PITCH_KI, PID_PITCH_KD, updateDt,
+  pidInit(&pidPitch, 0, pidPitch.kp, pidPitch.ki, pidPitch.kd, updateDt,
       ATTITUDE_RATE, ATTITUDE_LPF_CUTOFF_FREQ, ATTITUDE_LPF_ENABLE);
-  pidInit(&pidYaw,   0, PID_YAW_KP,   PID_YAW_KI,   PID_YAW_KD,   updateDt,
+  pidInit(&pidYaw,   0, pidYaw.kp,   pidYaw.ki,   pidYaw.kd,   updateDt,
       ATTITUDE_RATE, ATTITUDE_LPF_CUTOFF_FREQ, ATTITUDE_LPF_ENABLE);
 
   pidSetIntegralLimit(&pidRoll,  PID_ROLL_INTEGRATION_LIMIT);

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -34,17 +34,11 @@
 #include "num.h"
 #include "position_controller.h"
 
-struct pidInit_s {
-  float kp;
-  float ki;
-  float kd;
-};
 
 struct pidAxis_s {
   PidObject pid;
 
-  struct pidInit_s init;
-    stab_mode_t previousMode;
+  stab_mode_t previousMode;
   float setpoint;
 
   float output;
@@ -95,16 +89,16 @@ float velZFiltCutoff = 20.0f;
 #ifndef UNIT_TEST
 static struct this_s this = {
   .pidVX = {
-    .init = {
-      .kp = 25.0f,
-      .ki = 1.0f,
-      .kd = 0.0f,
+    .pid = {
+        .kp = 25.0f,
+        .ki = 1.0f,
+        .kd = 0.0f,
     },
     .pid.dt = DT,
   },
 
   .pidVY = {
-    .init = {
+    .pid = {
       .kp = 25.0f,
       .ki = 1.0f,
       .kd = 0.0f,
@@ -113,7 +107,7 @@ static struct this_s this = {
   },
   #ifdef IMPROVED_BARO_Z_HOLD
     .pidVZ = {
-      .init = {
+      .pid = {
         .kp = 3.0f,
         .ki = 1.0f,
         .kd = 1.5f, //kd can be lowered for improved stability, but results in slower response time.
@@ -122,7 +116,7 @@ static struct this_s this = {
     },
   #else
     .pidVZ = {
-      .init = {
+      .pid = {
         .kp = 25.0f,
         .ki = 15.0f,
         .kd = 0,
@@ -131,7 +125,7 @@ static struct this_s this = {
     },
   #endif
   .pidX = {
-    .init = {
+    .pid = {
       .kp = 2.0f,
       .ki = 0.0f,
       .kd = 0.0f,
@@ -140,7 +134,7 @@ static struct this_s this = {
   },
 
   .pidY = {
-    .init = {
+    .pid = {
       .kp = 2.0f,
       .ki = 0.0f,
       .kd = 0.0f,
@@ -149,7 +143,7 @@ static struct this_s this = {
   },
 
   .pidZ = {
-    .init = {
+    .pid = {
       .kp = 2.0f,
       .ki = 0.5f,
       .kd = 0.0f,
@@ -167,18 +161,18 @@ static struct this_s this = {
 
 void positionControllerInit()
 {
-  pidInit(&this.pidX.pid, this.pidX.setpoint, this.pidX.init.kp, this.pidX.init.ki, this.pidX.init.kd,
+  pidInit(&this.pidX.pid, this.pidX.setpoint, this.pidX.pid.kp, this.pidX.pid.ki, this.pidX.pid.kd,
       this.pidX.pid.dt, POSITION_RATE, posFiltCutoff, posFiltEnable);
-  pidInit(&this.pidY.pid, this.pidY.setpoint, this.pidY.init.kp, this.pidY.init.ki, this.pidY.init.kd,
+  pidInit(&this.pidY.pid, this.pidY.setpoint, this.pidY.pid.kp, this.pidY.pid.ki, this.pidY.pid.kd,
       this.pidY.pid.dt, POSITION_RATE, posFiltCutoff, posFiltEnable);
-  pidInit(&this.pidZ.pid, this.pidZ.setpoint, this.pidZ.init.kp, this.pidZ.init.ki, this.pidZ.init.kd,
+  pidInit(&this.pidZ.pid, this.pidZ.setpoint, this.pidZ.pid.kp, this.pidZ.pid.ki, this.pidZ.pid.kd,
       this.pidZ.pid.dt, POSITION_RATE, posZFiltCutoff, posZFiltEnable);
 
-  pidInit(&this.pidVX.pid, this.pidVX.setpoint, this.pidVX.init.kp, this.pidVX.init.ki, this.pidVX.init.kd,
+  pidInit(&this.pidVX.pid, this.pidVX.setpoint, this.pidVX.pid.kp, this.pidVX.pid.ki, this.pidVX.pid.kd,
       this.pidVX.pid.dt, POSITION_RATE, velFiltCutoff, velFiltEnable);
-  pidInit(&this.pidVY.pid, this.pidVY.setpoint, this.pidVY.init.kp, this.pidVY.init.ki, this.pidVY.init.kd,
+  pidInit(&this.pidVY.pid, this.pidVY.setpoint, this.pidVY.pid.kp, this.pidVY.pid.ki, this.pidVY.pid.kd,
       this.pidVY.pid.dt, POSITION_RATE, velFiltCutoff, velFiltEnable);
-  pidInit(&this.pidVZ.pid, this.pidVZ.setpoint, this.pidVZ.init.kp, this.pidVZ.init.ki, this.pidVZ.init.kd,
+  pidInit(&this.pidVZ.pid, this.pidVZ.setpoint, this.pidVZ.pid.kp, this.pidVZ.pid.ki, this.pidVZ.pid.kd,
       this.pidVZ.pid.dt, POSITION_RATE, velZFiltCutoff, velZFiltEnable);
 }
 


### PR DESCRIPTION
This fixes the problem that the persistent parameters for the PIDs (rate, attitude, pos) did not work. This is not the final solution but a first fixing step.

Testing has been done with all related persistent PID parameters making sure they are persistent after a reboot.