### PR TITLE
Blocking GAP8 reading to avoid printing 0 in console

### DIFF
--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -225,7 +225,7 @@ static void Gap8Task(void *param)
   // Read out the byte the Gap8 sends and immediately send it to the console.
   while (1)
   {
-    uart1GetDataWithDefaultTimeout(&byte);
+    uart1GetDataWithTimeout(&byte, portMAX_DELAY);
     consolePutchar(byte);
   }
 }


### PR DESCRIPTION
There was a timeout on the GAP8 UART reception which caused 0 to be printed in the Crazyflie client console, the return was not checked. This replaces it with an infinite timeout.