### PR TITLE
Improve building of Python bindings in KBuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,12 +204,10 @@ ifeq ($(KBUILD_SRC),)
 MOD_INC = src/modules/interface
 MOD_SRC = src/modules/src
 
-bindings_python: bindings/setup.py bin/cffirmware_wrap.c $(MOD_SRC)/*.c
+bindings_python: bindings/setup.py $(MOD_SRC)/*.c
+	swig -python -I$(MOD_INC) -o build/cffirmware_wrap.c bindings/cffirmware.i
 	$(PYTHON) bindings/setup.py build_ext --inplace
-
-bin/cffirmware_wrap.c cffirmware.py: bindings/cffirmware.i $(MOD_INC)/*.h
-	swig -python -I$(MOD_INC) -o bin/cffirmware_wrap.c bindings/cffirmware.i
-	mv bin/cffirmware.py cffirmware.py
+	mv build/cffirmware.py cffirmware.py
 
 test_python: bindings_python
 	$(PYTHON) -m pytest test_python

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -22,7 +22,7 @@ fw_sources = [os.path.join(fw_dir, "src/modules/src", mod) for mod in modules]
 cffirmware = Extension(
     "_cffirmware",
     include_dirs=include,
-    sources=fw_sources + ["bin/cffirmware_wrap.c"],
+    sources=fw_sources + ["build/cffirmware_wrap.c"],
     extra_compile_args=[
         "-O3",
         # The following flags are also used for compiling the actual firmware
@@ -35,7 +35,7 @@ cffirmware = Extension(
 class BuildCommand(distutils.command.build.build):
     def initialize_options(self):
         distutils.command.build.build.initialize_options(self)
-        self.build_base = "bin"
+        self.build_base = "build"
 
 setup(
     name="cffirmware",

--- a/tools/make/targets.mk
+++ b/tools/make/targets.mk
@@ -62,10 +62,8 @@ clean_o: clean_version
 	@$(if $(QUIET), ,echo $(CLEAN_O_COMMAND$(VERBOSE)) )
 	@$(CLEAN_O_COMMAND)
 
-CLEAN_COMMAND=rm -f *.elf *.hex *.bin *.dfu *.map *.py _cf*.so
-CLEAN_COMMAND_SILENT="  CLEAN"
 clean_cf:
-	@$(if $(QUIET), ,echo $(CLEAN_COMMAND$(VERBOSE)) )
-	@$(CLEAN_COMMAND)
 	@rm -f $(srctree)/$(PROG).*
+	@rm -f $(srctree)/cffirmware.py
+	@rm -f $(srctree)/_cffirmware*.so
 	


### PR DESCRIPTION
* Use build rather than bin folder
* Properly clean the the generated files with `make clean`
* Fix dependencies for python binding input files

Fixes #1016 