### PR TITLE
Remove tilt compensation

### DIFF
--- a/src/modules/interface/sensfusion6.h
+++ b/src/modules/interface/sensfusion6.h
@@ -34,6 +34,5 @@ void sensfusion6UpdateQ(float gx, float gy, float gz, float ax, float ay, float 
 void sensfusion6GetQuaternion(float* qx, float* qy, float* qz, float* qw);
 void sensfusion6GetEulerRPY(float* roll, float* pitch, float* yaw);
 float sensfusion6GetAccZWithoutGravity(const float ax, const float ay, const float az);
-float sensfusion6GetInvThrustCompensationForTilt();
 
 #endif /* SENSORFUSION6_H_ */

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -3,7 +3,6 @@
 #include "stabilizer_types.h"
 
 #include "attitude_controller.h"
-#include "sensfusion6.h"
 #include "position_controller.h"
 #include "controller_pid.h"
 
@@ -12,8 +11,6 @@
 #include "math3d.h"
 
 #define ATTITUDE_UPDATE_DT    (float)(1.0f/ATTITUDE_RATE)
-
-static bool tiltCompensationEnabled = false;
 
 static attitude_t attitudeDesired;
 static attitude_t rateDesired;
@@ -136,14 +133,7 @@ void controllerPid(control_t *control, setpoint_t *setpoint,
     accelz = sensors->acc.z;
   }
 
-  if (tiltCompensationEnabled)
-  {
-    control->thrust = actuatorThrust / sensfusion6GetInvThrustCompensationForTilt();
-  }
-  else
-  {
-    control->thrust = actuatorThrust;
-  }
+  control->thrust = actuatorThrust;
 
   if (control->thrust == 0)
   {
@@ -232,13 +222,3 @@ LOG_ADD(LOG_FLOAT, pitchRate, &rateDesired.pitch)
 LOG_ADD(LOG_FLOAT, yawRate,   &rateDesired.yaw)
 LOG_GROUP_STOP(controller)
 
-
-/**
- * Controller parameters
- */
-PARAM_GROUP_START(controller)
-/**
- * @brief Nonzero for tilt compensation enabled (default: 0)
- */
-PARAM_ADD(PARAM_UINT8, tiltComp, &tiltCompensationEnabled)
-PARAM_GROUP_STOP(controller)

--- a/src/modules/src/sensfusion6.c
+++ b/src/modules/src/sensfusion6.c
@@ -279,13 +279,6 @@ float sensfusion6GetAccZWithoutGravity(const float ax, const float ay, const flo
   return sensfusion6GetAccZ(ax, ay, az) - baseZacc;
 }
 
-float sensfusion6GetInvThrustCompensationForTilt()
-{
-  // Return the z component of the estimated gravity direction
-  // (0, 0, 1) dot G
-  return gravZ;
-}
-
 //---------------------------------------------------------------------------------------------------
 // Fast inverse square-root
 // See: http://en.wikipedia.org/wiki/Fast_inverse_square_root


### PR DESCRIPTION
* Remove sensfusion6GetInvThrustCompensationForTilt and the single use
  of it in controller_pid.c (which was disabled by default)
* While tilt compensation might be useful, its current implementation
  does not seem to be correct in the first place (since it does not
  rely on the actual tilt of the quadrotor)
* As discussed in #1017, it might be best to remove the feature and
  re-add it properly later, if the need arises.