### PR TITLE
Python bindings for power distribution

### DIFF
--- a/bindings/cffirmware.i
+++ b/bindings/cffirmware.i
@@ -18,6 +18,7 @@
 #include "filter.h"
 #include "num.h"
 #include "controller_mellinger.h"
+#include "power_distribution.h"
 %}
 
 %include "math3d.h"
@@ -28,6 +29,7 @@
 %include "controller_pid.h"
 %include "imu_types.h"
 %include "controller_mellinger.h"
+%include "power_distribution.h"
 
 %inline %{
 struct poly4d* piecewise_get(struct piecewise_traj *pp, int i)

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -9,6 +9,7 @@ include = [
     "src/hal/interface",
     "src/utils/interface/lighthouse",
     "src/utils/interface",
+    "build/include/generated",
 ]
 
 fw_sources = [
@@ -23,6 +24,7 @@ fw_sources = [
     "src/utils/src/filter.c",
     "src/utils/src/num.c",
     "src/modules/src/controller_mellinger.c",
+    "src/modules/src/power_distribution_stock.c",
 ]
 
 cffirmware = Extension(

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -10,6 +10,8 @@ include = [
     "src/utils/interface/lighthouse",
     "src/utils/interface",
     "build/include/generated",
+    "src/config",
+    "src/drivers/interface",
 ]
 
 fw_sources = [

--- a/src/drivers/interface/motors.h
+++ b/src/drivers/interface/motors.h
@@ -255,6 +255,11 @@ void motorsDeInit(const MotorPerifDef** motorMapSelect);
 bool motorsTest(void);
 
 /**
+ * Stops all the motors.
+ */
+void motorsStop();
+
+/**
  * Set the PWM ratio of the motor 'id'
  */
 void motorsSetRatio(uint32_t id, uint16_t ratio);

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -320,17 +320,11 @@ void motorsStop()
 void motorsSetRatio(uint32_t id, uint16_t ithrust)
 {
   if (isInit) {
-    uint16_t ratio;
+    uint16_t ratio = ithrust;
 
     ASSERT(id < NBR_OF_MOTORS);
 
     motorPower[id] = ithrust;
-
-    if (motorSetEnable) {
-      ratio = motorPowerSet[id];
-    } else {
-      ratio = ithrust;
-    }
 
 #ifdef ENABLE_THRUST_BAT_COMPENSATED
     if (motorMap[id]->drvType == BRUSHED)
@@ -342,6 +336,11 @@ void motorsSetRatio(uint32_t id, uint16_t ithrust)
       motor_ratios[id] = ratio;
     }
 #endif
+
+    if (motorSetEnable) {
+      ratio = motorPowerSet[id];
+    }
+
     if (motorMap[id]->drvType == BRUSHLESS)
     {
       motorMap[id]->setCompare(motorMap[id]->tim, motorsBLConv16ToBits(ratio));
@@ -481,19 +480,19 @@ PARAM_GROUP_STOP(motorPowerSet)
  */
 LOG_GROUP_START(motor)
 /**
- * @brief Motor power (PWM value) for M1 [0 - UINT16_MAX]
+ * @brief Requested motor power (PWM value) for M1 [0 - UINT16_MAX]
  */
 LOG_ADD_CORE(LOG_UINT32, m1, &motorPower[0])
 /**
- * @brief Motor power (PWM value) for M2 [0 - UINT16_MAX]
+ * @brief Requested motor power (PWM value) for M2 [0 - UINT16_MAX]
  */
 LOG_ADD_CORE(LOG_UINT32, m2, &motorPower[1])
 /**
- * @brief Motor power (PWM value) for M3 [0 - UINT16_MAX]
+ * @brief Requested motor power (PWM value) for M3 [0 - UINT16_MAX]
  */
 LOG_ADD_CORE(LOG_UINT32, m3, &motorPower[2])
 /**
- * @brief Motor power (PWM value) for M4 [0 - UINT16_MAX]
+ * @brief Requested motor power (PWM value) for M4 [0 - UINT16_MAX]
  */
 LOG_ADD_CORE(LOG_UINT32, m4, &motorPower[3])
 LOG_GROUP_STOP(motor)

--- a/src/drivers/src/nvic.c
+++ b/src/drivers/src/nvic.c
@@ -26,7 +26,6 @@
 #include "exti.h"
 #include "led.h"
 #include "motors.h"
-#include "power_distribution.h"
 #include "cfassert.h"
 
 #include "uart1.h"
@@ -129,7 +128,7 @@ void DONT_DISCARD printHardFault(uint32_t* hardfaultArgs)
   UART_PRINT("DFSR = %x\n", (*((volatile unsigned int *)(0xE000ED30))));
   UART_PRINT("AFSR = %x\n", (*((volatile unsigned int *)(0xE000ED3C))));
 
-  powerStop();
+  motorsStop();
   ledShowFaultPattern();
 
   storeAssertHardfaultData(
@@ -151,7 +150,7 @@ void DONT_DISCARD MemManage_Handler(void)
 {
   /* Go to infinite loop when Memory Manage exception occurs */
   ledShowFaultPattern();
-  powerStop();
+  motorsStop();
 
   storeAssertTextData("MemManage");
   while (1)
@@ -164,7 +163,7 @@ void DONT_DISCARD MemManage_Handler(void)
 void DONT_DISCARD BusFault_Handler(void)
 {
   /* Go to infinite loop when Bus Fault exception occurs */
-  powerStop();
+  motorsStop();
   ledShowFaultPattern();
 
   storeAssertTextData("BusFault");
@@ -178,7 +177,7 @@ void DONT_DISCARD BusFault_Handler(void)
 void DONT_DISCARD UsageFault_Handler(void)
 {
   /* Go to infinite loop when Usage Fault exception occurs */
-  powerStop();
+  motorsStop();
   ledShowFaultPattern();
 
   storeAssertTextData("UsageFault");

--- a/src/hal/src/freeRTOSdebug.c
+++ b/src/hal/src/freeRTOSdebug.c
@@ -33,7 +33,7 @@
 #include "debug.h"
 #include "nvicconf.h"
 #include "led.h"
-#include "power_distribution.h"
+#include "motors.h"
 
 uint32_t traceTickCount;
 
@@ -43,7 +43,7 @@ void vApplicationMallocFailedHook( void )
   DEBUG_PRINT("\nMalloc failed!\n");
   ledSet(ERR_LED1, 1);
   ledSet(ERR_LED2, 1);
-  powerStop();
+  motorsStop();
   storeAssertTextData("Malloc failed");
   while(1);
 }
@@ -55,7 +55,7 @@ void vApplicationStackOverflowHook(TaskHandle_t xTask, char * pcTaskName)
   DEBUG_PRINT("\nStack overflow!\n");
   ledSet(ERR_LED1, 1);
   ledSet(ERR_LED2, 1);
-  powerStop();
+  motorsStop();
   storeAssertTextData("Stack overflow");
   while(1);
 }

--- a/src/modules/interface/power_distribution.h
+++ b/src/modules/interface/power_distribution.h
@@ -28,10 +28,9 @@
 
 #include "stabilizer_types.h"
 
+
 void powerDistributionInit(void);
 bool powerDistributionTest(void);
-void powerDistribution(const control_t *control);
-void powerStop();
-
+void powerDistribution(motors_thrust_t* motorPower, const control_t *control);
 
 #endif //__POWER_DISTRIBUTION_H__

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -174,6 +174,13 @@ typedef struct control_s {
   float thrust;
 } control_t;
 
+typedef struct motors_thrust_s {
+  uint16_t m1;  // PWM ratio
+  uint16_t m2;  // PWM ratio
+  uint16_t m3;  // PWM ratio
+  uint16_t m4;  // PWM ratio
+} motors_thrust_t;
+
 typedef enum mode_e {
   modeDisable = 0,
   modeAbs,

--- a/src/modules/src/power_distribution_stock.c
+++ b/src/modules/src/power_distribution_stock.c
@@ -31,6 +31,7 @@
 #include "param.h"
 #include "num.h"
 #include "autoconf.h"
+#include "config.h" // Important, since this defines QUAD_FORMATION_X
 
 #ifndef CONFIG_MOTORS_DEFAULT_IDLE_THRUST
 #  define DEFAULT_IDLE_THRUST 0

--- a/src/modules/src/power_distribution_stock.c
+++ b/src/modules/src/power_distribution_stock.c
@@ -23,7 +23,6 @@
  *
  * power_distribution_stock.c - Crazyflie stock power distribution code
  */
-#define DEBUG_MODULE "PWR_DIST"
 
 #include "power_distribution.h"
 
@@ -31,26 +30,7 @@
 #include "log.h"
 #include "param.h"
 #include "num.h"
-#include "platform.h"
-#include "motors.h"
-#include "debug.h"
 #include "autoconf.h"
-
-static bool motorSetEnable = false;
-
-static struct {
-  uint32_t m1;
-  uint32_t m2;
-  uint32_t m3;
-  uint32_t m4;
-} motorPower;
-
-static struct {
-  uint16_t m1;
-  uint16_t m2;
-  uint16_t m3;
-  uint16_t m4;
-} motorPowerSet;
 
 #ifndef CONFIG_MOTORS_DEFAULT_IDLE_THRUST
 #  define DEFAULT_IDLE_THRUST 0
@@ -62,108 +42,49 @@ static uint32_t idleThrust = DEFAULT_IDLE_THRUST;
 
 void powerDistributionInit(void)
 {
-  motorsInit(platformConfigGetMotorMapping());
 }
 
 bool powerDistributionTest(void)
 {
   bool pass = true;
-
-  pass &= motorsTest();
-
   return pass;
 }
 
 #define limitThrust(VAL) limitUint16(VAL)
 
-void powerStop()
-{
-  motorsSetRatio(MOTOR_M1, 0);
-  motorsSetRatio(MOTOR_M2, 0);
-  motorsSetRatio(MOTOR_M3, 0);
-  motorsSetRatio(MOTOR_M4, 0);
-}
-
-void powerDistribution(const control_t *control)
+void powerDistribution(motors_thrust_t* motorPower, const control_t *control)
 {
   #ifdef QUAD_FORMATION_X
     int16_t r = control->roll / 2.0f;
     int16_t p = control->pitch / 2.0f;
-    motorPower.m1 = limitThrust(control->thrust - r + p + control->yaw);
-    motorPower.m2 = limitThrust(control->thrust - r - p - control->yaw);
-    motorPower.m3 =  limitThrust(control->thrust + r - p + control->yaw);
-    motorPower.m4 =  limitThrust(control->thrust + r + p - control->yaw);
+    motorPower->m1 = limitThrust(control->thrust - r + p + control->yaw);
+    motorPower->m2 = limitThrust(control->thrust - r - p - control->yaw);
+    motorPower->m3 =  limitThrust(control->thrust + r - p + control->yaw);
+    motorPower->m4 =  limitThrust(control->thrust + r + p - control->yaw);
   #else // QUAD_FORMATION_NORMAL
-    motorPower.m1 = limitThrust(control->thrust + control->pitch +
+    motorPower->m1 = limitThrust(control->thrust + control->pitch +
                                control->yaw);
-    motorPower.m2 = limitThrust(control->thrust - control->roll -
+    motorPower->m2 = limitThrust(control->thrust - control->roll -
                                control->yaw);
-    motorPower.m3 =  limitThrust(control->thrust - control->pitch +
+    motorPower->m3 =  limitThrust(control->thrust - control->pitch +
                                control->yaw);
-    motorPower.m4 =  limitThrust(control->thrust + control->roll -
+    motorPower->m4 =  limitThrust(control->thrust + control->roll -
                                control->yaw);
   #endif
 
-  if (motorSetEnable)
-  {
-    motorsSetRatio(MOTOR_M1, motorPowerSet.m1);
-    motorsSetRatio(MOTOR_M2, motorPowerSet.m2);
-    motorsSetRatio(MOTOR_M3, motorPowerSet.m3);
-    motorsSetRatio(MOTOR_M4, motorPowerSet.m4);
+  if (motorPower->m1 < idleThrust) {
+    motorPower->m1 = idleThrust;
   }
-  else
-  {
-    if (motorPower.m1 < idleThrust) {
-      motorPower.m1 = idleThrust;
-    }
-    if (motorPower.m2 < idleThrust) {
-      motorPower.m2 = idleThrust;
-    }
-    if (motorPower.m3 < idleThrust) {
-      motorPower.m3 = idleThrust;
-    }
-    if (motorPower.m4 < idleThrust) {
-      motorPower.m4 = idleThrust;
-    }
-
-    motorsSetRatio(MOTOR_M1, motorPower.m1);
-    motorsSetRatio(MOTOR_M2, motorPower.m2);
-    motorsSetRatio(MOTOR_M3, motorPower.m3);
-    motorsSetRatio(MOTOR_M4, motorPower.m4);
+  if (motorPower->m2 < idleThrust) {
+    motorPower->m2 = idleThrust;
+  }
+  if (motorPower->m3 < idleThrust) {
+    motorPower->m3 = idleThrust;
+  }
+  if (motorPower->m4 < idleThrust) {
+    motorPower->m4 = idleThrust;
   }
 }
-
-/**
- * Override power distribution to motors.
- */
-PARAM_GROUP_START(motorPowerSet)
-
-/**
- * @brief Nonzero to override controller with set values
- */
-PARAM_ADD_CORE(PARAM_UINT8, enable, &motorSetEnable)
-
-/**
- * @brief motor power for m1: `0 - UINT16_MAX`
- */
-PARAM_ADD_CORE(PARAM_UINT16, m1, &motorPowerSet.m1)
-
-/**
- * @brief motor power for m2: `0 - UINT16_MAX`
- */
-PARAM_ADD_CORE(PARAM_UINT16, m2, &motorPowerSet.m2)
-
-/**
- * @brief motor power for m3: `0 - UINT16_MAX`
- */
-PARAM_ADD_CORE(PARAM_UINT16, m3, &motorPowerSet.m3)
-
-/**
- * @brief motor power for m4: `0 - UINT16_MAX`
- */
-PARAM_ADD_CORE(PARAM_UINT16, m4, &motorPowerSet.m4)
-
-PARAM_GROUP_STOP(motorPowerSet)
 
 /**
  * Power distribution parameters
@@ -178,25 +99,3 @@ PARAM_GROUP_START(powerDist)
  */
 PARAM_ADD_CORE(PARAM_UINT32 | PARAM_PERSISTENT, idleThrust, &idleThrust)
 PARAM_GROUP_STOP(powerDist)
-
-/**
- * Motor output related log variables.
- */
-LOG_GROUP_START(motor)
-/**
- * @brief Motor power (PWM value) for M1 [0 - UINT16_MAX]
- */
-LOG_ADD_CORE(LOG_UINT32, m1, &motorPower.m1)
-/**
- * @brief Motor power (PWM value) for M2 [0 - UINT16_MAX]
- */
-LOG_ADD_CORE(LOG_UINT32, m2, &motorPower.m2)
-/**
- * @brief Motor power (PWM value) for M3 [0 - UINT16_MAX]
- */
-LOG_ADD_CORE(LOG_UINT32, m3, &motorPower.m3)
-/**
- * @brief Motor power (PWM value) for M4 [0 - UINT16_MAX]
- */
-LOG_ADD_CORE(LOG_UINT32, m4, &motorPower.m4)
-LOG_GROUP_STOP(motor)

--- a/src/utils/src/cfassert.c
+++ b/src/utils/src/cfassert.c
@@ -30,7 +30,7 @@
 #include "FreeRTOS.h"
 #include "cfassert.h"
 #include "led.h"
-#include "power_distribution.h"
+#include "motors.h"
 #include "debug.h"
 
 #define MAGIC_ASSERT_INDICATOR 0x2f8a001f
@@ -81,7 +81,7 @@ void assertFail(char *exp, char *file, int line)
   storeAssertFileData(file, line);
   DEBUG_PRINT("Assert failed %s:%d\n", file, line);
 
-  powerStop();
+  motorsStop();
   ledShowFaultPattern();
 
   NVIC_SystemReset();

--- a/test_python/test_power_distribution.py
+++ b/test_python/test_power_distribution.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import cffirmware
+
+def test_controller_mellinger():
+
+    cffirmware.controllerMellingerInit()
+
+    motorPower = cffirmware.motors_thrust_t()
+    control = cffirmware.control_t()
+    control.thrust = 10
+    control.roll = 0
+    control.pitch = 0
+    control.yaw = 0
+
+    cffirmware.powerDistribution(motorPower, control)
+    # control.thrust will be at a (tuned) hover-state
+    assert motorPower.m1 == control.thrust
+    assert motorPower.m2 == control.thrust
+    assert motorPower.m3 == control.thrust
+    assert motorPower.m4 == control.thrust


### PR DESCRIPTION
The current firmware code mixes power distribution and motor control,
so this change also includes refactoring for improved separation:

* powerDistribution() now outputs motors_thrust_t
* All low-level motor functionality (including logging and motorSet
  params) are moved to motors.c
* powerStop() is renamed to motorsStop() to reflect the source module
* stabilizer initializes the motors and has a more verbose call for the
  actual actuation