### PR TITLE
Add assert dump functionality

### DIFF
--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -82,6 +82,7 @@
 static bool selftestPassed;
 static bool armed = ARM_INIT;
 static bool forceArm;
+static uint8_t dumpAssertInfo = 0;
 static bool isInit;
 
 static char nrf_version[16];
@@ -384,6 +385,11 @@ void vApplicationIdleHook( void )
     watchdogReset();
   }
 
+  if (dumpAssertInfo != 0) {
+    printAssertSnapshotData();
+    dumpAssertInfo = 0;
+  }
+
   // Enter sleep mode. Does not work when debugging chip with SWD.
   // Currently saves about 20mA STM32F405 current consumption (~30%).
 #ifndef DEBUG
@@ -433,7 +439,12 @@ PARAM_ADD_CORE(PARAM_INT8 | PARAM_RONLY, selftestPassed, &selftestPassed)
  */
 PARAM_ADD(PARAM_INT8 | PARAM_PERSISTENT, forceArm, &forceArm)
 
-PARAM_GROUP_STOP(sytem)
+/**
+ * @brief Set to nonzero to trigger dump of assert information to the log.
+ */
+PARAM_ADD(PARAM_UINT8, assertInfo, &dumpAssertInfo)
+
+PARAM_GROUP_STOP(system)
 
 /**
  *  System loggable variables to check different system states.

--- a/src/utils/src/cfassert.c
+++ b/src/utils/src/cfassert.c
@@ -124,10 +124,6 @@ void storeAssertTextData(const char *text)
   snapshot.text.text = text;
 }
 
-static void clearAssertData() {
-  snapshot.type = SnapshotTypeNone;
-}
-
 void printAssertSnapshotData()
 {
   if (MAGIC_ASSERT_INDICATOR == snapshot.magicNumber) {
@@ -169,7 +165,6 @@ bool cfAssertNormalStartTest(void) {
 		wasNormalStart = false;
 		DEBUG_PRINT("The system resumed after a failed assert [WARNING]\n");
 		printAssertSnapshotData();
-    clearAssertData();
 	}
 
 	return wasNormalStart;


### PR DESCRIPTION
After a faild assert, the Crazyflie restarts and information about the assert is  logged to the console. In some cases when a client already was connected to the Crazyflie before the assert, it will re-connect and consume the logs. This makes it hard to debug as the assert infomation is lost.

This PR adds functionality to trigger a dump of the assert information again to the console log. This way a client can re-connect to the Crazyflie and trigger a dump for post-mortum investigations.