### PR TITLE
Removed waiting for system start in memory subsystem

### DIFF
--- a/src/modules/src/mem.c
+++ b/src/modules/src/mem.c
@@ -150,7 +150,9 @@ void memoryRegisterOwHandler(const MemoryOwHandlerDef_t* handlerDef){
 static void memTask(void* param) {
 	crtpInitTaskQueue(CRTP_PORT_MEM);
 
-  systemWaitStart();
+  // This should be synced with decks starting up, otherwise
+  // there might be late arrivals for the registration that will
+  // trigger assert.
 
   // Do not allow registration of new handlers after this point as clients now can start
   // to query for available memories


### PR DESCRIPTION
If one or more of the self-tests fails (red LED blinking rapidly) there's an issue when connecting to the Crazyflie where we will not get callbacks for connected or connection failed, it will just hangs.

The reason for this hanging is due to the following:
* In the Crazyflie
  * The STM32 is powered
  * The memory subsystem is started and the task handling incoming requests will wait on ```systemWaitStart()```
  * Crazyflie starts up and one or more self test fail. Because of the failing tests the call to ```systemStart()``` will not be made and the memory subsystem task will not be unlocked
* In the crazyflie-python-libraray
  * A connection is requested
  * A number of requests are made in sequence, log TOC, memory information and param TOC etc.
  * In this chain the number of memories is queried, because of the hanging memory subsystem a reply is never received and the connection procedure hangs
  * No callbacks are triggered for the connection, so nighter ```connected``` or ```connection_failed``` is called
  * The connection hangs

The solution in this PR is not great since it possibly creates a race condition when registering memories. Registration cannot be done after the task has started, but it's not certain that all the modules and/or deck drivers have registered what they need by then. So if the registration is late and assert will be triggered.
