### PR TITLE
Updated AI deck param name to match deck name

### DIFF
--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -544,7 +544,7 @@ PARAM_GROUP_START(deck)
 /**
  * @brief Nonzero if [AI deck](%https://store.bitcraze.io/collections/decks/products/ai-deck-1-1) is attached
  */
-PARAM_ADD_CORE(PARAM_UINT8 | PARAM_RONLY, bcAIDeck, &isInit)
+PARAM_ADD_CORE(PARAM_UINT8 | PARAM_RONLY, bcAI, &isInit)
 
 PARAM_GROUP_STOP(deck)
 


### PR DESCRIPTION
The name of the parameter that identifies that the AI-deck is attached, has the wrong name and this PR corrects it to match the naming in other decks.

deck.bcAIDeck --> deck.bcAI

Note: The parameter is marked as CORE but we decided to change it now anyway (without a deprecation process) as the deck is not out of early access yet