### PR TITLE
Correct wall following demo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,6 +114,7 @@ jobs:
         - examples/app_peer_to_peer
         - examples/demos/app_push_demo
         - examples/demos/swarm_demo
+        - examples/demos/app_wall_following_demo
     env:
       EXAMPLE: ${{ matrix.example }}
 

--- a/examples/demos/app_wall_following_demo/src/Kbuild
+++ b/examples/demos/app_wall_following_demo/src/Kbuild
@@ -1,2 +1,2 @@
 obj-y += wall_following.o
-obj-y += wall_following_multiranger_onboard.o
+obj-y += wallfollowing_multiranger_onboard.o


### PR DESCRIPTION
The app does not build due to wrong file name. This PR corrects the problem and adds the app to the CI build.

Fixes #1013