### PR TITLE
Update DFU flashing and new docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
         "**/generated": true,
         "**/node_modules": true,
         "**/bower_components": true
+    },
+    "files.associations": {
+        "bootloader.h": "c"
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,17 @@ flash_verify:
 	$(OPENOCD) -d2 -f $(OPENOCD_INTERFACE) $(OPENOCD_CMDS) -f $(OPENOCD_TARGET) -c init -c targets -c "reset halt" \
                  -c "verify_image $(PROG).bin $(LOAD_ADDRESS) bin" -c "reset run" -c shutdown
 
-flash_dfu:
-	$(PYTHON) tools/make/usb-bootloader.py
-	$(DFU_UTIL) -d 0483:df11 -a 0 -D $(PROG).dfu -s :leave
+#sends a usb message to the CF to place it in DFU mode, then updates firmware over usb
+flash_dfu: set_dfu_mode flash_dfu_manual
+
+#uses python script to place usb connected CF into DFU mode	
+set_dfu_mode:
+	$(PYTHON) $(srctree)/tools/make/usb-bootloader.py
+
+#uses the dfu utility to flash the firmware at 0x08004000, just after the bootloader
+#call this target directly if CF cannont be flashed automatically through flash_dfu
+flash_dfu_manual:
+	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08004000 -D $(PROG).bin -s :leave
 
 #STM utility targets
 halt:

--- a/Makefile
+++ b/Makefile
@@ -162,16 +162,14 @@ flash_verify:
                  -c "verify_image $(PROG).bin $(LOAD_ADDRESS) bin" -c "reset run" -c shutdown
 
 #sends a usb message to the CF to place it in DFU mode, then updates firmware over usb
-flash_dfu: set_dfu_mode flash_dfu_manual
-
-#uses python script to place usb connected CF into DFU mode	
-set_dfu_mode:
+flash_dfu:
 	$(PYTHON) $(srctree)/tools/make/usb-bootloader.py
+	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08004000:leave -D $(PROG).bin 
 
 #uses the dfu utility to flash the firmware at 0x08004000, just after the bootloader
 #call this target directly if CF cannont be flashed automatically through flash_dfu
 flash_dfu_manual:
-	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08004000 -D $(PROG).bin -s :leave
+	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08004000:leave -D $(PROG).bin 
 
 #STM utility targets
 halt:
@@ -221,5 +219,5 @@ test_python: cffirmware.py
 	$(PYTHON) -m pytest test_python
 endif
 
-.PHONY: all clean build compile unit prep erase flash check_submodules trace openocd gdb halt reset flash_dfu flash_verify cload size print_version clean_version bindings_python
+.PHONY: all clean build compile unit prep erase flash check_submodules trace openocd gdb halt reset flash_dfu flash_dfu_manual flash_verify cload size print_version clean_version bindings_python
 

--- a/docs/development/dfu.md
+++ b/docs/development/dfu.md
@@ -8,19 +8,38 @@ redirects:
 
 This page explains how to flash bin files over the micro usb connection.
 
-__The DFU update mode should mainly be considered as a recovery mode in
-which you can load new firmware to the STM32F405 MCU. Do not use it if you do not know what it is__
+__The DFU (Device Firmware Update) mode should mainly be considered as a recovery mode in
+which you can load new firmware to the STM32F405 MCU or as a mass firmware update mode. Do not use it if you do not know what it is__
 
 The OTA (Over The
-Air) update mode is much more convenient and save and it can also update the
+Air) update mode is much safer and more convenient, it can also update the
 nRF51 MCU at the same time.
 
 
 ## Linux (Ubuntu)
 
+
+### Automatic DFU Flashing
+This method requires that the Crazyflie is turned on and running normally. The automatic DFU update mode will automatically put the Crazyflie into DFU mode, flash the new firmware to the correct address, and reboot the Crazyflie into the new firmware.
+
 Install the dfu-util if you don\'t already have it with apt-get
 
     apt-get install dfu-util
+
+Compile the Crazyflie firmware as normal with `make`.
+
+Now power on the Crazyflie and connect it to your computer via a micro-USB cable.
+
+Next, run the following from the root of the Crazyflie firmware to begin flashing. Do not unplug the Crazyflie, it will reboot when flashing has finished.
+
+    make flash_dfu
+
+Once the Crazyflie has rebooted and the command has finished executing, you can disconnect the Crazyflie from your computer and use it as normal.
+
+### Manual DFU Flashing
+If the Crazyflie cannot boot into the normal firmware, or some other issue prevents the automatic method from putting the Crazyflie into DFU mode, we will have to manually put the Crazyflie into DFU mode and flash the cf2.bin file.
+
+First compile the firmware as normal with `make`.
 
 Now it is time to boot the STM32F405 in the DFU update mode
 
@@ -38,18 +57,17 @@ With the STM32F405 in DFU mode you should be able to find it with lsusb
     Bus XXX Device XXX: ID 0483:df11 STMicroelectronics STM Device in DFU Mode
     ...
 
-### BIN firmware file DFU flashing
+Now we can flash the compiled cf2.bin file by running the following
 
-Now the STM32F405 can be updated. Currently we only build binary files
-.bin and not .dfu files so we need to specify more things to dfu-util.
-If the Crazyflie 2.X firmware was compiled with CLOAD=1 (default option)
-the binary should be flashed _after the bootloader_ at address 0x08004000.
+    make flash_dfu_manual
 
-    sudo dfu-util -d 0483:df11 -a 0 -s 0x08004000 -D cflie.bin
+This will flash the binary _after the bootloader_ at address 0x08004000.
+Details for what command actually does the flashing can be found in the Makefile under the 
+target `flash_dfu_manual`
 
-### BIN bootloader recovery
+### Bootloader recovery
 
-If for some reason, the dfu-utils overflashed the bootloader by flashing the firmware on the wrong address, you can recover the bootloader by getting the [latest release bootloader bin file](https://github.com/bitcraze/crazyflie2-stm-bootloader/releases). The bootloader can then be correctly flashed by typing this in the terminal.
+If for some reason, the dfu-utils overflashed the bootloader by flashing the firmware on the wrong address, you can recover the bootloader by getting the [latest release bootloader bin file](https://github.com/bitcraze/crazyflie2-stm-bootloader/releases). The bootloader can then be correctly flashed by manually putting the Crazyflie into DFU mode and running this command in the terminal.
 
     sudo dfu-util -d 0483:df11 -a 0 -s 0x08000000 -D cf2loader-1.0.bin
 

--- a/docs/development/dfu.md
+++ b/docs/development/dfu.md
@@ -65,6 +65,8 @@ This will flash the binary _after the bootloader_ at address 0x08004000.
 Details for what command actually does the flashing can be found in the Makefile under the 
 target `flash_dfu_manual`
 
+Once the utility has finished downloading the firmware to the Crazyflie, you can disconnect the USB and battery and you're are good to go!
+
 ### Bootloader recovery
 
 If for some reason, the dfu-utils overflashed the bootloader by flashing the firmware on the wrong address, you can recover the bootloader by getting the [latest release bootloader bin file](https://github.com/bitcraze/crazyflie2-stm-bootloader/releases). The bootloader can then be correctly flashed by manually putting the Crazyflie into DFU mode and running this command in the terminal.
@@ -82,18 +84,22 @@ To flash with a .dfu file
 It takes a couple of seconds and the output should look something like
 this
 
-    cf@bitcraze:~/projects/crazyflie-firmware$ sudo dfu-util -a 0 -s 0x08004000 -D cflie.bin
-    dfu-util 0.5
+    cf@bitcraze:~/projects/crazyflie-firmware$make flash_dfu_manual
+    tools/kbuild/Makefile.kbuild:147: warning: overriding recipe for target 'flash_dfu_manual'
+    Makefile:172: warning: ignoring old recipe for target 'flash_dfu_manual'
+    dfu-util -d 0483:df11 -a 0 -s 0x08004000:leave -D cf2.bin 
+    dfu-util 0.9
 
-    (C) 2005-2008 by Weston Schmidt, Harald Welte and OpenMoko Inc.
-    (C) 2010-2011 Tormod Volden (DfuSe support)
+    Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+    Copyright 2010-2016 Tormod Volden and Stefan Schmidt
     This program is Free Software and has ABSOLUTELY NO WARRANTY
+    Please report bugs to http://sourceforge.net/p/dfu-util/tickets/
 
-    dfu-util does currently only support DFU version 1.0
-
-    Opening DFU USB device... ID 0483:df11
+    dfu-util: Invalid DFU suffix signature
+    dfu-util: A valid DFU suffix will be required in a future dfu-util release!!!
+    Opening DFU capable USB device...
+    ID 0483:df11
     Run-time device DFU version 011a
-    Found DFU: [0483:df11] devnum=0, cfg=1, intf=0, alt=0, name="@Internal Flash  /0x08000000/04*016Kg,01*064Kg,07*128Kg"
     Claiming USB DFU Interface...
     Setting Alternate Setting #0 ...
     Determining device status: state = dfuERROR, status = 10
@@ -102,9 +108,12 @@ this
     dfuIDLE, continuing
     DFU mode device DFU version 011a
     Device returned transfer size 2048
-    No valid DFU suffix signature
-    Warning: File has no DFU suffix
     DfuSe interface name: "Internal Flash  "
+    Downloading to address = 0x08004000, size = 243176
+    Download        [=========================] 100%       243176 bytes
+    Download done.
+    File downloaded successfully
+    Transitioning to dfuMANIFEST state
 
 Now you can disconnect the USB, connect the battery, and you are ready
 to go. (Actually the only way to reset it is to disconnect the power, if


### PR DESCRIPTION
From issue #923 

With this update I've fixed a few issues with the automatic DFU flashing. 
- I add the $(srctree) variable to python script call
- I added a `flash_dfu_manual` make target to flash the firmware assuming the crazyflie is already in DFU mode. This makes it easier for users to flash using DFU mode when the crazyflie cannot run the normal firmware to support the automatic reboot into DFU mode
- Finally, I updated the documentation to reflect the new make targets. I decided to leave the warning at the top of the documentation as DFU mode can still be dangerous for new/inexperienced users.

One issue that I've noted is dfu-util complains about an invalid suffix signature. This doesn't seem to cause any issues now but could in the future.

```
dfu-util: Invalid DFU suffix signature
dfu-util: A valid DFU suffix will be required in a future dfu-util release!!!
```

I've also noticed that the make file complains about old recipes for flash_dfu, this may be due to the .PHONY target, I'm not familiar with what its purpose is so I left it as is.

Let me know if any changes need to be made before merging. Thanks! 