### PR TITLE
Update UART2 to work better with the AI-deck

### DIFF
--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -486,6 +486,9 @@ static void aideckInit(DeckInfo *info)
 
   aideckRouterInit();
 
+  // Make sure a full CPX packet can be stored in the UART2 RX buffer
+  ASSERT(UART2_RX_QUEUE_LENGTH > sizeof(uart_transport_packet_t));
+
   isInit = true;
 }
 

--- a/src/drivers/interface/uart2.h
+++ b/src/drivers/interface/uart2.h
@@ -103,7 +103,7 @@ int uart2Putchar(int ch);
  */
 void uart2GetPacketBlocking(SyslinkPacket* slp);
 
-#else
+#endif
 
 /**
  * Read a byte of data from incoming queue with a timeout
@@ -129,8 +129,6 @@ void uart2Getchar(char * ch);
  * @return true if an overrun condition has happened
  */
 bool uart2DidOverrun();
-
-#endif
 
 /**
  * Uart printf macro that uses eprintf

--- a/src/drivers/interface/uart2.h
+++ b/src/drivers/interface/uart2.h
@@ -57,6 +57,8 @@
 #define UART2_GPIO_AF_TX       GPIO_AF_USART2
 #define UART2_GPIO_AF_RX       GPIO_AF_USART2
 
+#define UART2_RX_QUEUE_LENGTH 128
+
 /**
  * Initialize the UART.
  */

--- a/src/drivers/src/uart1.c
+++ b/src/drivers/src/uart1.c
@@ -276,18 +276,18 @@ void __attribute__((used)) DMA1_Stream3_IRQHandler(void)
   DMA_Cmd(UART1_DMA_STREAM, DISABLE);
 
   xSemaphoreGiveFromISR(waitUntilSendDone, &xHigherPriorityTaskWoken);
+  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 #endif
 
 void __attribute__((used)) USART3_IRQHandler(void)
 {
-  uint8_t rxData;
-  portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
-
   if (USART_GetITStatus(UART1_TYPE, USART_IT_RXNE))
   {
-    rxData = USART_ReceiveData(UART1_TYPE) & 0x00FF;
+    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+    uint8_t rxData = USART_ReceiveData(UART1_TYPE) & 0x00FF;
     xQueueSendFromISR(uart1queue, &rxData, &xHigherPriorityTaskWoken);
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
   } else {
     /** if we get here, the error is most likely caused by an overrun!
      * - PE (Parity error), FE (Framing error), NE (Noise error), ORE (OverRun error)

--- a/src/drivers/src/uart2.c
+++ b/src/drivers/src/uart2.c
@@ -328,6 +328,25 @@ void uart2HandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTaskWo
   }
 }
 
+bool uart2GetDataWithTimeout(uint8_t *c, const uint32_t timeoutTicks) {
+  ASSERT_FAILED();
+  return false;
+}
+
+bool uart2GetDataWithDefaultTimeout(uint8_t *c) {
+  ASSERT_FAILED();
+  return false;
+}
+
+void uart2Getchar(char * ch) {
+  ASSERT_FAILED();
+}
+
+bool uart2DidOverrun() {
+  ASSERT_FAILED();
+  return false;
+}
+
 #else
 
 bool uart2GetDataWithTimeout(uint8_t *c, const uint32_t timeoutTicks)

--- a/src/drivers/src/uart2.c
+++ b/src/drivers/src/uart2.c
@@ -71,7 +71,7 @@ static void uart2HandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorit
 #else
 
 static xQueueHandle uart2queue;
-STATIC_MEM_QUEUE_ALLOC(uart2queue, 64, sizeof(uint8_t));
+STATIC_MEM_QUEUE_ALLOC(uart2queue, UART2_RX_QUEUE_LENGTH, sizeof(uint8_t));
 
 static bool hasOverrun = false;
 


### PR DESCRIPTION
We decided to NOT make any major changes to the UART implementations for now, instead we increased the buffer size for incoming data to be large enough for a full CPX packet.

Also added missing yields in interrupt handlers and fixed build problems when the UART2_LINK_COMM flag is enabled. 

(hopefully) Fixes #1036