### PR TITLE
Workaround for waiting for all bootloader writes to be finished

### DIFF
--- a/src/deck/drivers/interface/aideck.h
+++ b/src/deck/drivers/interface/aideck.h
@@ -112,3 +112,12 @@ bool cpxSendPacket(const CPXPacket_t * packet, uint32_t timeout);
  * @param route Pointer to the route data to initialize
  */
 void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const CPXFunction_t function, CPXRouting_t* route);
+
+/**
+ * @brief Forward bootloader message.
+ *
+ * Used as a work around to send data from the bootloader down to the AI deck driver.
+ *
+ * @param packet packet that was received
+ */
+void cpxBootloaderMessage(const CPXPacket_t * packet);

--- a/src/deck/drivers/src/aideck-router.c
+++ b/src/deck/drivers/src/aideck-router.c
@@ -86,6 +86,9 @@ static void cxpRxTest(void *param)
           consolePrintf("UNKNOWN: %s", cpxRx.data);
         }
         break;
+      case CPX_F_BOOTLOADER:
+        cpxBootloaderMessage(&cpxRx);
+        break;
       default:
         DEBUG_PRINT("Not handling function [0x%02X] from [0x%02X]\n", cpxRx.route.function, cpxRx.route.source);
     }

--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -89,6 +89,7 @@ typedef struct {
 } __attribute__((packed)) ESP32SysPacket_t;
 
 #define GAP8_BL_CMD_START_WRITE (0x02)
+#define GAP8_BL_CMD_MD5         (0x04)
 
 #define ESP32_SYS_CMD_RESET_GAP8 (0x10)
 
@@ -119,6 +120,9 @@ static EventGroupHandle_t evGroup;
 #define ESP_CTS_EVENT (1 << 0)
 #define ESP_CTR_EVENT (1 << 1)
 #define ESP_TXQ_EVENT (1 << 2)
+
+static EventGroupHandle_t bootloaderSync;
+#define CPX_WAIT_FOR_BOOTLOADER_REPLY (1<<0)
 
 static void assemblePacket(const CPXPacket_t *packet, uart_transport_packet_t * txp);
 
@@ -328,6 +332,10 @@ void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const
     route->lastPacket = true;
 }
 
+void cpxBootloaderMessage(const CPXPacket_t * packet) {
+  xEventGroupSetBits(bootloaderSync, CPX_WAIT_FOR_BOOTLOADER_REPLY);
+}
+
 static CPXPacket_t bootPacket;
 
 #define FLASH_BUFFER_SIZE 64
@@ -372,6 +380,24 @@ static bool gap8DeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen,
       flashBufferIndex += sizeLeftToBuffer;
     }
   }
+
+  if (memAddr + writeLen == *(memDef->newFwSizeP)) {
+    // Request the MD5 checksum of the flashed data. This is only done
+    // for synchronizing and making sure everything has been written,
+    // we do not care about the results.
+    GAP8BlCmdPacket_t* gap8BlPacket = (GAP8BlCmdPacket_t*)bootPacket.data;
+    gap8BlPacket->cmd = GAP8_BL_CMD_MD5;
+    gap8BlPacket->startAddress = 0x40000;
+    gap8BlPacket->writeSize = *(memDef->newFwSizeP);
+    bootPacket.dataLength = sizeof(GAP8BlCmdPacket_t);
+    cpxSendPacketBlocking(&bootPacket);
+    
+    xEventGroupWaitBits(bootloaderSync,
+                        CPX_WAIT_FOR_BOOTLOADER_REPLY,
+                        pdTRUE,  // Clear bits before returning
+                        pdFALSE, // Wait for any bit
+                        portMAX_DELAY);
+}
 
   return true;
 }
@@ -466,6 +492,7 @@ static void aideckInit(DeckInfo *info)
   espRxQueue = xQueueCreate(ESP_RX_QUEUE_LENGTH, sizeof(uart_transport_packet_t));
 
   evGroup = xEventGroupCreate();
+  bootloaderSync = xEventGroupCreate();
 
   // Pull reset for GAP8/ESP32
   pinMode(DECK_GPIO_IO4, OUTPUT);


### PR DESCRIPTION
This fixes the issue https://github.com/bitcraze/crazyflie-lib-python/issues/330 where the library/CF would reset the GAP8 before all the bootloader writes had been handled in the GAP8 (since this is asynchronous). This was especially problematic when the last part of the binary crossed a page boundary which triggers an erase (erases takes extra time).

In this workaround we're requesting the MD5 checksum of what we've written after the last write has been sent. This is to make sure that all write packages has been processed (they are processed in order in the GAP8), when we get the result we know that the writes have taken place. But we do not care about the results of the checksum.