### PR TITLE
Fixed prop test not working with DSHOT and some small DSHOT efficiency improvements

### DIFF
--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -157,10 +157,7 @@ void healthRunTests(sensorData_t *sensors)
     minSingleLoadedVoltage[MOTOR_M3] = minLoadedVoltage;
     minSingleLoadedVoltage[MOTOR_M4] = minLoadedVoltage;
     // Make sure motors are stopped first.
-    motorsSetRatio(MOTOR_M1, 0);
-    motorsSetRatio(MOTOR_M2, 0);
-    motorsSetRatio(MOTOR_M3, 0);
-    motorsSetRatio(MOTOR_M4, 0);
+    motorsStop();
   }
   if (testState == measureNoiseFloor)
   {
@@ -251,10 +248,7 @@ void healthRunTests(sensorData_t *sensors)
     }
     else if (i == 50)
     {
-      motorsSetRatio(MOTOR_M1, 0);
-      motorsSetRatio(MOTOR_M2, 0);
-      motorsSetRatio(MOTOR_M3, 0);
-      motorsSetRatio(MOTOR_M4, 0);
+      motorsStop();
       testState = evaluateBatResult;
       i = 0;
     }

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -290,9 +290,6 @@ static void stabilizerTask(void* param)
         motorsSetRatio(MOTOR_M2, motorPower.m2);
         motorsSetRatio(MOTOR_M3, motorPower.m3);
         motorsSetRatio(MOTOR_M4, motorPower.m4);
-#ifdef CONFIG_MOTORS_ESC_PROTOCOL_DSHOT
-        motorsBurstDshot();
-#endif
       }
 
 #ifdef CONFIG_DECK_USD
@@ -314,6 +311,9 @@ static void stabilizerTask(void* param)
         }
       }
     }
+#ifdef CONFIG_MOTORS_ESC_PROTOCOL_DSHOT
+    motorsBurstDshot();
+#endif
   }
 }
 


### PR DESCRIPTION
DSHOT has one function, motorsBurstDshot() that sends out all motor signals at once which is a bit different then the timer generated signals. This did not work during the propeller test as the motorsBurstDshot() function was never called. As a fix this was moved to the end of the update loop in stabilizer. At the same time, while debugging, a did some small efficiency improvements. E.g. the DMA reload is only a DMA_Stream->NDTR update instead of a full re-init with DMA_Init(...)