### PR TITLE
Made UART2_LINK_COMM to a kbuild selection CONFIG_CRTP_OVER_UART.

### DIFF
--- a/src/drivers/interface/uart2.h
+++ b/src/drivers/interface/uart2.h
@@ -28,8 +28,9 @@
 
 #include <stdbool.h>
 #include "eprintf.h"
+#include "autoconf.h"
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 #include "syslink.h"
 #endif
 
@@ -95,7 +96,7 @@ void uart2SendDataDmaBlocking(uint32_t size, uint8_t* data);
  */
 int uart2Putchar(int ch);
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 
 /**
  * Get data from rx queue. Blocks until data is available.

--- a/src/drivers/src/uart2.c
+++ b/src/drivers/src/uart2.c
@@ -42,7 +42,7 @@
 #include "nvicconf.h"
 #include "static_mem.h"
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 #include "queuemonitor.h"
 #endif
 
@@ -58,7 +58,7 @@ static uint8_t dmaBuffer[UART2_DMA_BUFFER_SIZE];
 static bool    isUartDmaInitialized;
 static uint32_t initialDMACount;
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 
 static xQueueHandle uart2PacketDelivery;
 STATIC_MEM_QUEUE_ALLOC(uart2PacketDelivery, 8, sizeof(SyslinkPacket));
@@ -103,7 +103,7 @@ static void uart2DmaInit(void)
   DMA_InitStructureShare.DMA_FIFOMode = DMA_FIFOMode_Disable;
   DMA_InitStructureShare.DMA_FIFOThreshold = DMA_FIFOThreshold_1QuarterFull ;
   DMA_InitStructureShare.DMA_Channel = UART2_DMA_CH;
-  #ifdef UART2_LINK_COMM
+  #ifdef CONFIG_CRTP_OVER_UART2
   DMA_InitStructureShare.DMA_Priority = DMA_Priority_High;
   #else
   DMA_InitStructureShare.DMA_Priority = DMA_Priority_Low;
@@ -112,7 +112,7 @@ static void uart2DmaInit(void)
   NVIC_InitStructure.NVIC_IRQChannel = UART2_DMA_IRQ;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-  #ifdef UART2_LINK_COMM
+  #ifdef CONFIG_CRTP_OVER_UART2
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_HIGH_PRI;
   #else
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_MID_PRI;
@@ -169,14 +169,14 @@ void uart2Init(const uint32_t baudrate)
   NVIC_InitStructure.NVIC_IRQChannel = UART2_IRQ;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-  #ifdef UART2_LINK_COMM
+  #ifdef CONFIG_CRTP_OVER_UART2
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_SYSLINK_PRI;
   #else
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_MID_PRI;
   #endif
   NVIC_Init(&NVIC_InitStructure);
 
-  #ifdef UART2_LINK_COMM
+  #ifdef CONFIG_CRTP_OVER_UART2
   uart2PacketDelivery = STATIC_MEM_QUEUE_CREATE(uart2PacketDelivery);
   DEBUG_QUEUE_MONITOR_REGISTER(uart2PacketDelivery);
   #else
@@ -245,7 +245,7 @@ int uart2Putchar(int ch)
     return (unsigned char)ch;
 }
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 
 void uart2GetPacketBlocking(SyslinkPacket* packet)
 {
@@ -397,7 +397,7 @@ void __attribute__((used)) DMA1_Stream6_IRQHandler(void)
 }
 #endif
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 
 void __attribute__((used)) USART2_IRQHandler(void)
 {

--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -10,3 +10,24 @@ config PM_AUTO_SHUTDOWN
         occured.
 
 endmenu
+
+menu "Communication"
+
+config CRTP_OVER_UART2
+    bool "Move CRTP communication to UART2 instead of over radio"
+    default n
+    help
+        The CRTP (Crazy Real Time Protocol) communication is normally
+        sent over the radio link (via Syslink). By enabling this the
+        communication will instead be sent over UART2 to communicate
+        with e.g. a companion computer instead.
+
+config CRTP_OVER_UART2_BAUDRATE
+    int "CRTP over UART2 baudrate"
+    depends on CRTP_OVER_UART2
+    range 9600 2000000
+    default 512000
+    help
+        Uart baudrate to be used.
+        
+endmenu

--- a/src/hal/src/syslink.c
+++ b/src/hal/src/syslink.c
@@ -35,6 +35,7 @@
 #include "semphr.h"
 
 #include "config.h"
+#include "autoconf.h"
 #include "debug.h"
 #include "syslink.h"
 #include "radiolink.h"
@@ -45,7 +46,7 @@
 #include "static_mem.h"
 #include "system.h"
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 #include "uart2.h"
 #endif
 
@@ -70,7 +71,7 @@ static void syslinkTask(void *param)
   }
 }
 
-#ifdef UART2_LINK_COMM
+#ifdef CONFIG_CRTP_OVER_UART2
 
 STATIC_MEM_TASK_ALLOC(uart2Task, UART2_TASK_STACKSIZE);
 
@@ -126,8 +127,8 @@ void syslinkInit()
 
   STATIC_MEM_TASK_CREATE(syslinkTask, syslinkTask, SYSLINK_TASK_NAME, NULL, SYSLINK_TASK_PRI);
 
-  #ifdef UART2_LINK_COMM
-  uart2Init(512000);
+  #ifdef CONFIG_CRTP_OVER_UART2
+  uart2Init(CONFIG_CRTP_OVER_UART2_BAUDRATE);
   STATIC_MEM_TASK_CREATE(uart2Task, uart2Task, UART2_TASK_NAME, NULL, UART2_TASK_PRI);
   #endif
 
@@ -171,7 +172,7 @@ int syslinkSendPacket(SyslinkPacket *slp)
   sendBuffer[dataSize-2] = cksum[0];
   sendBuffer[dataSize-1] = cksum[1];
 
-  #ifdef UART2_LINK_COMM
+  #ifdef CONFIG_CRTP_OVER_UART2
   uint8_t groupType;
   groupType = slp->type & SYSLINK_GROUP_MASK;
   switch (groupType)

--- a/test/deck/drivers/esp32/src/test_esp_slip.c
+++ b/test/deck/drivers/esp32/src/test_esp_slip.c
@@ -1,7 +1,7 @@
 // File under test esp_slip.crftq
 #include "esp_slip.h"
 
-#define UART2_LINK_COMM 1
+#define CONFIG_CRTP_OVER_UART2 1
 
 #include <string.h>
 


### PR DESCRIPTION
Moving the CRTP communication to UART can now be build with a kbuild config setting: "communication->CRTP_OVER_UART"

This implements #1041 