### PR TITLE
Add debug probe for radio setup

### DIFF
--- a/src/hal/interface/syslink.h
+++ b/src/hal/interface/syslink.h
@@ -1,6 +1,6 @@
 /*
- *    ||          ____  _ __                           
- * +------+      / __ )(_) /_______________ _____  ___ 
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
  * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
  * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
  *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
@@ -70,6 +70,9 @@
 
 #define SYSLINK_SYS_GROUP        0x30
 #define SYSLINK_SYS_NRF_VERSION  0x30
+
+#define SYSLINK_DEBUG_GROUP 0xF0
+#define SYSLINK_DEBUG_PROBE 0xF0
 
 typedef struct _SyslinkPacket
 {


### PR DESCRIPTION
Add code to collect debug data for #998.
Added functionality to request and dump data from the NRF that can be used on a CF that has a half configured radio.

We do not know what is causing this problem and this is a first step to collect data. This code should probably be removed when the problem is solved.