### PR TITLE
Reduce TX power on CF2.1 when Loco deck is mounted

### DIFF
--- a/src/platform/src/platform_cf2.c
+++ b/src/platform/src/platform_cf2.c
@@ -48,7 +48,7 @@ static platformConfig_t configs[] = {
     .deviceType = "CF21",
     .deviceTypeName = "Crazyflie 2.1",
     .sensorImplementation = SensorImplementation_bmi088_bmp388,
-    .physicalLayoutAntennasAreClose = false, // TA: TODO This looks wrong
+    .physicalLayoutAntennasAreClose = true,
     .motorMap = motorMapDefaultBrushed,
   },
   {


### PR DESCRIPTION
There seems to be a miss-configuration in the CF2.1 configuration. The TX power of the radio should be reduced when a loco deck is mounted to reduce interference, but it is not. 
This PR corrects the problem.