### PR TITLE
Add params for tdoa stddev

### DIFF
--- a/src/deck/drivers/src/lpsTdoa2Tag.c
+++ b/src/deck/drivers/src/lpsTdoa2Tag.c
@@ -89,6 +89,7 @@ static float logClockCorrection[LOCODECK_NR_OF_TDOA2_ANCHORS];
 static uint16_t logAnchorDistance[LOCODECK_NR_OF_TDOA2_ANCHORS];
 
 static bool rangingOk;
+static float stdDev = TDOA_ENGINE_MEASUREMENT_NOISE_STD;
 
 // The default receive time in the anchors for messages from other anchors is 0
 // and is overwritten with the actual receive time when a packet arrives.
@@ -277,6 +278,9 @@ static uint32_t onEvent(dwDevice_t *dev, uwbEvent_t event) {
 
 
 static void sendTdoaToEstimatorCallback(tdoaMeasurement_t* tdoaMeasurement) {
+  // Override the default standard deviation set by the TDoA engine.
+  tdoaMeasurement->stdDev = stdDev;
+
   estimatorEnqueueTDOA(tdoaMeasurement);
 
   #ifdef CONFIG_DECK_LOCO_2D_POSITION
@@ -392,3 +396,11 @@ LOG_ADD(LOG_UINT16, dist4-5, &logAnchorDistance[5])
 LOG_ADD(LOG_UINT16, dist5-6, &logAnchorDistance[6])
 LOG_ADD(LOG_UINT16, dist6-7, &logAnchorDistance[7])
 LOG_GROUP_STOP(tdoa2)
+
+PARAM_GROUP_START(tdoa2)
+/**
+ * @brief The measurement noise to use when sending TDoA measurements to the estimator.
+ */
+PARAM_ADD(PARAM_FLOAT, stddev, &stdDev)
+
+PARAM_GROUP_STOP(tdoa2)

--- a/src/utils/interface/tdoa/tdoaEngine.h
+++ b/src/utils/interface/tdoa/tdoaEngine.h
@@ -4,6 +4,8 @@
 #include "tdoaStorage.h"
 #include "tdoaStats.h"
 
+#define TDOA_ENGINE_MEASUREMENT_NOISE_STD 0.15f
+
 typedef void (*tdoaEngineSendTdoaToEstimator)(tdoaMeasurement_t* tdoaMeasurement);
 
 typedef enum {

--- a/src/utils/src/tdoa/tdoaEngine.c
+++ b/src/utils/src/tdoa/tdoaEngine.c
@@ -53,8 +53,6 @@ The implementation must handle
 #include "clockCorrectionEngine.h"
 #include "physicalConstants.h"
 
-#define MEASUREMENT_NOISE_STD 0.15f
-
 void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm) {
   tdoaStorageInitialize(engineState->anchorInfoArray);
   tdoaStatsInit(&engineState->stats, now_ms);
@@ -69,7 +67,7 @@ static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorC
   tdoaStats_t* stats = &engineState->stats;
 
   tdoaMeasurement_t tdoa = {
-    .stdDev = MEASUREMENT_NOISE_STD,
+    .stdDev = TDOA_ENGINE_MEASUREMENT_NOISE_STD,
     .distanceDiff = distanceDiff
   };
 


### PR DESCRIPTION
It can be usefull to adjust the measurement noise of TDoA samples, for instance based on system configuration. This PR adds parameters for the measurement noise in TDoA2 and TDoA3