### PR TITLE
fix: fix unit tests on arm64

### DIFF
--- a/test/modules/src/test_param_logic.c
+++ b/test/modules/src/test_param_logic.c
@@ -171,7 +171,7 @@ void testGetUint8(void) {
   paramVarId_t varid = paramGetVarId("myGroup", "myUint8");
 
   // Test
-  const float actual = paramGetInt(varid);
+  const uint8_t actual = paramGetInt(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_UINT8(expected, actual);
@@ -185,7 +185,7 @@ void testGetUint16(void) {
   paramVarId_t varid = paramGetVarId("myGroup", "myUint16");
 
   // Test
-  const float actual = paramGetInt(varid);
+  const uint16_t actual = paramGetInt(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_UINT16(expected, actual);
@@ -199,7 +199,7 @@ void testGetUint32(void) {
   paramVarId_t varid = paramGetVarId("myGroup", "myUint32");
 
   // Test
-  const float actual = paramGetInt(varid);
+  const uint32_t actual = paramGetInt(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_UINT32(expected, actual);
@@ -213,7 +213,7 @@ void testGetInt8(void) {
   paramVarId_t varid = paramGetVarId("myGroup", "myInt8");
 
   // Test
-  const float actual = paramGetInt(varid);
+  const int8_t actual = paramGetInt(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_INT8(expected, actual);
@@ -227,7 +227,7 @@ void testGetInt16(void) {
   paramVarId_t varid = paramGetVarId("myGroup", "myInt16");
 
   // Test
-  const float actual = paramGetInt(varid);
+  const int16_t actual = paramGetInt(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_INT16(expected, actual);
@@ -241,7 +241,7 @@ void testGetInt32(void) {
   paramVarId_t varid = paramGetVarId("myGroup", "myInt32");
 
   // Test
-  const float actual = paramGetInt(varid);
+  const int32_t actual = paramGetInt(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_INT32(expected, actual);

--- a/test/utils/src/test_eprintf.c
+++ b/test/utils/src/test_eprintf.c
@@ -240,17 +240,21 @@ void testThatAllIntTypesArePrinted() {
   // Assert
   verify("255", "%u", (uint8_t)255);
   verify("65535", "%u", (uint16_t)65535);
-  verify("4294967295", "%lu", (uint32_t)4294967295);
+  // second cast needed here because sizeof(unsigned long) != sizeof(uint32_t)
+  // on arm64
+  verify("4294967295", "%lu", (unsigned long)(uint32_t)4294967295);
   verify("18446744073709551615", "%llu", (uint64_t)18446744073709551615u);
 
   verify("127", "%i", (int8_t)127);
   verify("32767", "%i", (int16_t)32767);
-  verify("2147483647", "%li", (int32_t)2147483647);
+  // second cast needed here because sizeof(long) != sizeof(int32_t) on arm64
+  verify("2147483647", "%li", (long)(int32_t)2147483647);
   verify("9223372036854775807", "%lli", (int64_t)9223372036854775807);
 
   verify("FF", "%X", (uint8_t)0xFF);
   verify("FFFF", "%X", (uint16_t)0xFFFF);
-  verify("FFFFFFFF", "%lX", (uint32_t)0xFFFFFFFF);
+  // second cast needed here because sizeof(unsigned long) != sizeof(uint32_t) on arm64
+  verify("FFFFFFFF", "%lX", (unsigned long)(uint32_t)0xFFFFFFFF);
   verify("FFFFFFFFFFFFFFFF", "%llX", (uint64_t)0xFFFFFFFFFFFFFFFF);
 }
 


### PR DESCRIPTION
This PR fixes the unit tests on `arm64` CPUs (e.g., Apple Silicon). There are two fixes worth mentioning:

1. Forcing an `uint32_t` into a `float` might result in loss of precision as floats cannot represent all integers above 2^23-1.
2. On `arm64`, `sizeof(uint32_t) != sizeof(unsigned long)` (unsigned longs are 8 byte, at least on Apple Silicon), so calling `eprintf` with an `uint32_t` where the corresponding format specifier is `%lu` is incorrect; the function would take 8 bytes from the stack and print a different number. This is now fixed.