### PR TITLE
Correct platform defaults

### DIFF
--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "autoconf.h"
+
 #define __INCLUDED_FROM_PLATFORM_DEFAULTS__
 
 #ifdef CONFIG_PLATFORM_CF2


### PR DESCRIPTION
The autoconfig.h was not included in platform_defaults.h which cased no platform specific defines to not being included.