### PR TITLE
Specify wifi password minimum size

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -49,7 +49,7 @@ menu "Credentials for access-point"
         string "WiFi Password"
         default "mypassword"
         help
-            WiFi password
+            WiFi password (Minimum length of 8)
 endmenu   
 
 config DECK_BIGQUAD


### PR DESCRIPTION
If given smaller password than 8 the esp32 on ai-deck appears to die silently.

Or not initialize properly.