### PR TITLE
convert alternative pins loco deck to kbuild

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -203,6 +203,14 @@ config DECK_LOCO
         on-board of the Crazyflie and there is no need for an external
         computer for position estimation.
 
+  config DECK_LOCODECK_USE_ALT_PINS
+  bool "loco deck alternative IRQ and RESET pins"
+  default name
+  depends on DECK_LOCO
+  help
+       LOCO deck alternative IRQ and RESET pins(IO_2, IO_3) instead of
+       default (RX1, TX1), leaving UART1 free for use.
+
   config DECK_LOCO_NR_OF_ANCHORS
   int "The number of anchors in use"
   default 8

--- a/src/deck/drivers/src/locodeck.c
+++ b/src/deck/drivers/src/locodeck.c
@@ -62,7 +62,7 @@
 #define CS_PIN DECK_GPIO_IO1
 
 // LOCO deck alternative IRQ and RESET pins(IO_2, IO_3) instead of default (RX1, TX1), leaving UART1 free for use
-#ifdef LOCODECK_USE_ALT_PINS
+#ifdef CONFIG_DECK_LOCODECK_USE_ALT_PINS
   #define GPIO_PIN_IRQ 	  DECK_GPIO_IO2
 
   #ifndef LOCODECK_ALT_PIN_RESET
@@ -425,7 +425,7 @@ static void spiRead(dwDevice_t* dev, const void *header, size_t headerLength,
   STATS_CNT_RATE_EVENT(&spiReadCount);
 }
 
-#if LOCODECK_USE_ALT_PINS
+#if CONFIG_DECK_LOCODECK_USE_ALT_PINS
   void __attribute__((used)) EXTI5_Callback(void)
 #else
   void __attribute__((used)) EXTI11_Callback(void)
@@ -569,7 +569,7 @@ static const DeckDriver dwm1000_deck = {
   .pid = 0x06,
   .name = "bcDWM1000",
 
-#ifdef LOCODEC_USE_ALT_PINS
+#ifdef CONFIG_DECK_LOCODECK_USE_ALT_PINS
   .usedGpio = DECK_USING_IO_1 | DECK_USING_IO_2 | DECK_USING_IO_3,
 #else
    // (PC10/PC11 is UART1 TX/RX)


### PR DESCRIPTION
The loco deck alternative pins setting was not yet configured to kbuild.

I also noticed that somewhere the define had a typo initially, so probably was broken anyway.