### PR TITLE
Improved internal parameter set/get functions

### DIFF
--- a/src/modules/interface/param_logic.h
+++ b/src/modules/interface/param_logic.h
@@ -114,24 +114,14 @@ int paramGetInt(paramVarId_t varid);
  */
 unsigned int paramGetUint(paramVarId_t varid);
 
-/**
- * Set param with [index] to data
- *
- * @param index  The param index
- * @param data  The variable data
- *
- * @return number of bytes set
- **/
-int paramSet(uint16_t index, void *data);
-
-/** Set int value of a parameter
+/** Set int value of an int parameter (1-4 bytes)
  *
  * @param varId variable ID, returned by paramGetVarId()
  * @param valuei Value to set in the variable
  */
 void paramSetInt(paramVarId_t varid, int valuei);
 
-/** Set float value of a parameter
+/** Set float value of a float parameter
  *
  * @param varId variable ID, returned by paramGetVarId()
  * @param valuef Value to set in the variable

--- a/test/modules/src/test_param_logic.c
+++ b/test/modules/src/test_param_logic.c
@@ -32,6 +32,7 @@ static int8_t myInt8 = 0;
 static int16_t myInt16 = 0;
 static int32_t myInt32 = 0;
 static int32_t myPersistent = 0;
+static float myPersistentFloat = 0;
 static int8_t myShortPersistent = 0;
 static float myFloat = 0.0f;
 
@@ -50,6 +51,7 @@ PARAM_ADD(PARAM_INT16, myInt16, &myInt16)
 PARAM_ADD(PARAM_INT32, myInt32, &myInt32)
 PARAM_ADD(PARAM_FLOAT, myFloat, &myFloat)
 PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, myPersistent, &myPersistent)
+PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, myPersistentFloat, &myPersistentFloat)
 PARAM_ADD_CORE(PARAM_INT8 | PARAM_PERSISTENT, myShortPersistent, &myShortPersistent)
 PARAM_GROUP_STOP(myGroup)
 
@@ -255,6 +257,23 @@ void testGetFloat(void) {
 
   // Test
   const float actual = paramGetFloat(varid);
+
+  // Assert
+  TEST_ASSERT_EQUAL_FLOAT(expected, actual);
+}
+
+void testPersistentSetGetFloat(void) {
+  // Fixture
+  float expected = 10.88f;
+  float actual;
+
+  paramVarId_t varid = paramGetVarId("myGroup", "myPersistentFloat");
+
+  crtpSendPacketBlock_StubWithCallback(crtpReply);
+
+  // Test
+  paramSetFloat(varid, expected);
+  actual = paramGetFloat(varid);
 
   // Assert
   TEST_ASSERT_EQUAL_FLOAT(expected, actual);


### PR DESCRIPTION
As a first step this PR will fix #1073 but it will need more work as the functions to internally set/get params need a clearer definition and error handling.

The checks to evaluate the type of param has been moved to an assert and made simpler. For the future I'm not so sure asserts are such a good idea but this would have to be part of a bigger redesign of the firmware. I am now only checking the type (PARAM_TYPE_INT and PARAM_TYPE_FLOAT) and if it is setting a param with PARAM_RONLY.