### PR TITLE
multiranger discard range measurements larger with bad status

### DIFF
--- a/src/deck/drivers/src/multiranger.c
+++ b/src/deck/drivers/src/multiranger.c
@@ -46,6 +46,7 @@
 static bool isInit = false;
 static bool isTested = false;
 static bool isPassed = false;
+static uint16_t filterMask = 1 << VL53L1_RANGESTATUS_RANGE_VALID;
 
 #define MR_PIN_UP PCA95X4_P0
 #define MR_PIN_FRONT PCA95X4_P4
@@ -97,10 +98,14 @@ static uint16_t mrGetMeasurementAndRestart(VL53L1_Dev_t *dev)
 
     status = VL53L1_GetRangingMeasurementData(dev, &rangingData);
 
-    if (rangingData.RangeStatus == VL53L1_RANGESTATUS_RANGE_VALID)
+    if (filterMask & (1 << rangingData.RangeStatus))
+    {
         range = rangingData.RangeMilliMeter;
+    }
     else
+    {
         range = 32767;
+    }
 
     VL53L1_StopMeasurement(dev);
     status = VL53L1_StartMeasurement(dev);
@@ -210,3 +215,11 @@ PARAM_GROUP_START(deck)
 PARAM_ADD_CORE(PARAM_UINT8 | PARAM_RONLY, bcMultiranger, &isInit)
 
 PARAM_GROUP_STOP(deck)
+
+PARAM_GROUP_START(multiranger)
+/**
+ * @brief Filter mask determining which range measurements is to be let through based on the range status of the VL53L1 chip
+ */
+PARAM_ADD(PARAM_UINT16, filterMask, &filterMask)
+
+PARAM_GROUP_STOP(multiranger)

--- a/src/deck/drivers/src/multiranger.c
+++ b/src/deck/drivers/src/multiranger.c
@@ -47,11 +47,11 @@ static bool isInit = false;
 static bool isTested = false;
 static bool isPassed = false;
 
-#define MR_PIN_UP     PCA95X4_P0
-#define MR_PIN_FRONT  PCA95X4_P4
-#define MR_PIN_BACK   PCA95X4_P1
-#define MR_PIN_LEFT   PCA95X4_P6
-#define MR_PIN_RIGHT  PCA95X4_P2
+#define MR_PIN_UP PCA95X4_P0
+#define MR_PIN_FRONT PCA95X4_P4
+#define MR_PIN_BACK PCA95X4_P1
+#define MR_PIN_LEFT PCA95X4_P6
+#define MR_PIN_RIGHT PCA95X4_P2
 
 NO_DMA_CCM_SAFE_ZERO_INIT static VL53L1_Dev_t devFront;
 NO_DMA_CCM_SAFE_ZERO_INIT static VL53L1_Dev_t devBack;
@@ -61,25 +61,25 @@ NO_DMA_CCM_SAFE_ZERO_INIT static VL53L1_Dev_t devRight;
 
 static bool mrInitSensor(VL53L1_Dev_t *pdev, uint32_t pca95pin, char *name)
 {
-  bool status;
+    bool status;
 
-  // Bring up VL53 by releasing XSHUT
-  pca95x4SetOutput(pca95pin);
-  // Let VL53 boot
-  vTaskDelay(M2T(2));
-  // Init VL53
-  if (vl53l1xInit(pdev, I2C1_DEV))
-  {
-      DEBUG_PRINT("Init %s sensor [OK]\n", name);
-      status = true;
-  }
-  else
-  {
-      DEBUG_PRINT("Init %s sensor [FAIL]\n", name);
-      status = false;
-  }
+    // Bring up VL53 by releasing XSHUT
+    pca95x4SetOutput(pca95pin);
+    // Let VL53 boot
+    vTaskDelay(M2T(2));
+    // Init VL53
+    if (vl53l1xInit(pdev, I2C1_DEV))
+    {
+        DEBUG_PRINT("Init %s sensor [OK]\n", name);
+        status = true;
+    }
+    else
+    {
+        DEBUG_PRINT("Init %s sensor [FAIL]\n", name);
+        status = false;
+    }
 
-  return status;
+    return status;
 }
 
 static uint16_t mrGetMeasurementAndRestart(VL53L1_Dev_t *dev)
@@ -96,7 +96,11 @@ static uint16_t mrGetMeasurementAndRestart(VL53L1_Dev_t *dev)
     }
 
     status = VL53L1_GetRangingMeasurementData(dev, &rangingData);
-    range = rangingData.RangeMilliMeter;
+
+    if (rangingData.RangeStatus == VL53L1_RANGESTATUS_RANGE_VALID)
+        range = rangingData.RangeMilliMeter;
+    else
+        range = 32767;
 
     VL53L1_StopMeasurement(dev);
     status = VL53L1_StartMeasurement(dev);
@@ -129,12 +133,11 @@ static void mrTask(void *param)
     while (1)
     {
         vTaskDelayUntil(&lastWakeTime, M2T(100));
-
-        rangeSet(rangeFront, mrGetMeasurementAndRestart(&devFront)/1000.0f);
-        rangeSet(rangeBack, mrGetMeasurementAndRestart(&devBack)/1000.0f);
-        rangeSet(rangeUp, mrGetMeasurementAndRestart(&devUp)/1000.0f);
-        rangeSet(rangeLeft, mrGetMeasurementAndRestart(&devLeft)/1000.0f);
-        rangeSet(rangeRight, mrGetMeasurementAndRestart(&devRight)/1000.0f);
+        rangeSet(rangeFront, mrGetMeasurementAndRestart(&devFront) / 1000.0f);
+        rangeSet(rangeBack, mrGetMeasurementAndRestart(&devBack) / 1000.0f);
+        rangeSet(rangeUp, mrGetMeasurementAndRestart(&devUp) / 1000.0f);
+        rangeSet(rangeLeft, mrGetMeasurementAndRestart(&devLeft) / 1000.0f);
+        rangeSet(rangeRight, mrGetMeasurementAndRestart(&devRight) / 1000.0f);
     }
 }
 
@@ -162,7 +165,7 @@ static void mrInit()
     isInit = true;
 
     xTaskCreate(mrTask, MULTIRANGER_TASK_NAME, MULTIRANGER_TASK_STACKSIZE, NULL,
-        MULTIRANGER_TASK_PRI, NULL);
+                MULTIRANGER_TASK_PRI, NULL);
 }
 
 static bool mrTest()


### PR DESCRIPTION
This should fix #874. Here in the multiranger, it will first check if the vl53l1 returns a valid range measurements status, and if not it will output the maximum value of an int16_t

Two questions here: 

1. Should I do this also for the z-ranger/flowdeck?
2. Do we want to still output the measurement but just include the ranging status in the logging variable?
