### PR TITLE
Fixed estimator position stuck when no connection to client

### DIFF
--- a/src/modules/interface/param_logic.h
+++ b/src/modules/interface/param_logic.h
@@ -116,6 +116,12 @@ unsigned int paramGetUint(paramVarId_t varid);
 
 /** Set int value of an int parameter (1-4 bytes)
  *
+ *  An update is also send to the client 
+ *  NOTE: The update to the client will be added to the output queue. If 
+ *  the Crazyflie is not connected to a client, the queue may fill up and
+ *  this call will block until the queue is emptied.This could be avoided 
+ *  by setting the CONFIG_PARAM_SILENT_UPDATES flag.
+ * 
  * @param varId variable ID, returned by paramGetVarId()
  * @param valuei Value to set in the variable
  */
@@ -123,6 +129,12 @@ void paramSetInt(paramVarId_t varid, int valuei);
 
 /** Set float value of a float parameter
  *
+ *  An update is also send to the client 
+ *  NOTE: The update to the client will be added to the output queue. If 
+ *  the Crazyflie is not connected to a client, the queue may fill up and
+ *  this call will block until the queue is emptied.This could be avoided 
+ *  by setting the CONFIG_PARAM_SILENT_UPDATES flag.
+ * 
  * @param varId variable ID, returned by paramGetVarId()
  * @param valuef Value to set in the variable
  */

--- a/src/modules/src/estimator_kalman.c
+++ b/src/modules/src/estimator_kalman.c
@@ -216,7 +216,7 @@ static void kalmanTask(void* parameters) {
     // If the client triggers an estimator reset via parameter update
     if (resetEstimation) {
       estimatorKalmanInit();
-      paramSetInt(paramGetVarId("kalman", "resetEstimation"), 0);
+      resetEstimation = false;
     }
 
     // Tracks whether an update to the state has been made, and the state therefore requires finalization


### PR DESCRIPTION
Calling ```paramSetInt()``` and ```paramSetFloat()``` while having no connection to the client established leads to the output queue being filled up and the position being stuck after the resetting of the Kalman estimator. This can be handled by setting the CONFIG_PARAM_SILENT_UPDATES flag and the user should be careful when using these functions.