### PR TITLE
LH crossing beam support for 2+ base stations

### DIFF
--- a/src/modules/interface/lighthouse/lighthouse_position_est.h
+++ b/src/modules/interface/lighthouse/lighthouse_position_est.h
@@ -48,5 +48,5 @@ void lighthousePositionSetGeometryData(const uint8_t baseStation, const baseStat
  */
 void lighthousePositionCalibrationDataWritten(const uint8_t baseStation);
 
-void lighthousePositionEstimatePoseCrossingBeams(const pulseProcessor_t *state, pulseProcessorResult_t* angles, int baseStation);
+void lighthousePositionEstimatePoseCrossingBeams(const pulseProcessor_t *state, pulseProcessorResult_t* angles, int baseStation1, int baseStation2);
 void lighthousePositionEstimatePoseSweeps(const pulseProcessor_t *state, pulseProcessorResult_t* angles, int baseStation);

--- a/src/modules/src/lighthouse/lighthouse_core.c
+++ b/src/modules/src/lighthouse/lighthouse_core.c
@@ -67,7 +67,7 @@ static lighthouseBsIdentificationData_t bsIdentificationData;
 
 // Stats
 
-typedef enum uwbEvent_e {
+typedef enum {
   statusNotReceiving = 0,
   statusMissingData = 1,
   statusToEstimator = 2,
@@ -299,15 +299,15 @@ static void usePulseResultCrossingBeams(pulseProcessor_t *appState, pulseProcess
   pulseProcessorClearOutdated(appState, angles, basestation);
 
   if (basestation == 1) {
+    int otherBaseStation = 0;
     STATS_CNT_RATE_EVENT(&cycleRate);
 
-    lighthousePositionEstimatePoseCrossingBeams(appState, angles, 1);
+    lighthousePositionEstimatePoseCrossingBeams(appState, angles, basestation, otherBaseStation);
 
-    pulseProcessorProcessed(angles, 0);
-    pulseProcessorProcessed(angles, 1);
+    pulseProcessorProcessed(angles, basestation);
+    pulseProcessorProcessed(angles, otherBaseStation);
   }
 }
-
 
 static void usePulseResultSweeps(pulseProcessor_t *appState, pulseProcessorResult_t* angles, int basestation) {
   STATS_CNT_RATE_EVENT(&cycleRate);
@@ -859,7 +859,7 @@ PARAM_ADD_CORE(PARAM_UINT8, systemType, &systemType)
  * @brief Bit field that indicates which base stations that are supported by the system
  *
  * The lowest bit maps to base station channel 1 and the highest to channel 16.
- * 
+ *
  * Deprecated since 2022-08-15
  */
 PARAM_ADD_CORE(PARAM_UINT16 | PARAM_RONLY, bsAvailable, &baseStationAvailabledMap)

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -234,11 +234,11 @@ static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulsePr
   // Average over all sensors with valid data
   for (size_t sensor = 0; sensor < PULSE_PROCESSOR_N_SENSORS; sensor++) {
       // LH2 angles are converted to LH1 angles, so it is OK to use sensorMeasurementsLh1
-      pulseProcessorBaseStationMeasuremnt_t* measurement1 = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[baseStation1];
-      pulseProcessorBaseStationMeasuremnt_t* measurement2 = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[baseStation2];
+    pulseProcessorBaseStationMeasuremnt_t* measurement1 = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[baseStation1];
+    pulseProcessorBaseStationMeasuremnt_t* measurement2 = &angles->sensorMeasurementsLh1[sensor].baseStatonMeasurements[baseStation2];
 
-      if (measurement1->validCount == PULSE_PROCESSOR_N_SWEEPS && measurement2->validCount == PULSE_PROCESSOR_N_SWEEPS) {
-        lighthouseGeometryGetPositionFromRayIntersection(geo1, geo2, measurement1->correctedAngles, measurement2->correctedAngles, position, &delta);
+    if (measurement1->validCount == PULSE_PROCESSOR_N_SWEEPS && measurement2->validCount == PULSE_PROCESSOR_N_SWEEPS) {
+      if (lighthouseGeometryGetPositionFromRayIntersection(geo1, geo2, measurement1->correctedAngles, measurement2->correctedAngles, position, &delta)) {
 
         deltaSum += delta;
 
@@ -248,6 +248,7 @@ static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulsePr
         sensorsUsed++;
 
         STATS_CNT_RATE_EVENT(&positionRate);
+      }
     }
   }
 

--- a/src/utils/interface/lighthouse/lighthouse_geometry.h
+++ b/src/utils/interface/lighthouse/lighthouse_geometry.h
@@ -17,15 +17,16 @@ typedef struct {
 } baseStationGeometryCache_t;
 
 /**
- * @brief Find closest point between rays from two bases stations.
+ * @brief Find closest point between rays from two base stations.
  *
- * @param baseStations - Geometry data for the two base statsions (position and orientation)
+ * @param geo1 - Geometry data for base station 1 (position and orientation)
+ * @param geo2 - Geometry data for base station 2 (position and orientation)
  * @param angles1 - array with 2 angles, horizontal and vertical sweep angle for base station 1
  * @param angles2 - array with 2 angles, horizontal and vertical sweep angle for base station 2
  * @param position - (output) the closest point between the rays
  * @param postion_delta - (output) the distance between the rays at the closest point
  */
-bool lighthouseGeometryGetPositionFromRayIntersection(const baseStationGeometry_t baseStations[2], float angles1[2], float angles2[2], vec3d position, float *position_delta);
+bool lighthouseGeometryGetPositionFromRayIntersection(const baseStationGeometry_t* geo1, const baseStationGeometry_t* geo2, float angles1[2], float angles2[2], vec3d position, float *position_delta);
 
 /**
  * @brief Get the base station position from the base station geometry in world reference frame. This position can be seen as the

--- a/src/utils/src/lighthouse/lighthouse_geometry.c
+++ b/src/utils/src/lighthouse/lighthouse_geometry.c
@@ -102,15 +102,15 @@ static bool intersect_lines(vec3d orig1, vec3d vec1, vec3d orig2, vec3d vec2, ve
     return true;
 }
 
-bool lighthouseGeometryGetPositionFromRayIntersection(const baseStationGeometry_t baseStations[2], float angles1[2], float angles2[2], vec3d position, float *position_delta)
+bool lighthouseGeometryGetPositionFromRayIntersection(const baseStationGeometry_t* geo1, const baseStationGeometry_t* geo2, float angles1[2], float angles2[2], vec3d position, float *position_delta)
 {
     static vec3d ray1, ray2, origin1, origin2;
 
-    lighthouseGeometryGetRay(&baseStations[0], angles1[0], angles1[1], ray1);
-    lighthouseGeometryGetBaseStationPosition(&baseStations[0], origin1);
+    lighthouseGeometryGetRay(geo1, angles1[0], angles1[1], ray1);
+    lighthouseGeometryGetBaseStationPosition(geo1, origin1);
 
-    lighthouseGeometryGetRay(&baseStations[1], angles2[0], angles2[1], ray2);
-    lighthouseGeometryGetBaseStationPosition(&baseStations[1], origin2);
+    lighthouseGeometryGetRay(geo2, angles2[0], angles2[1], ray2);
+    lighthouseGeometryGetBaseStationPosition(geo2, origin2);
 
     return intersect_lines(origin1, ray1, origin2, ray2, position, position_delta);
 }

--- a/src/utils/src/lighthouse/lighthouse_geometry.c
+++ b/src/utils/src/lighthouse/lighthouse_geometry.c
@@ -55,14 +55,11 @@ static void vec_add(const vec3d a, const vec3d b, vec3d r) {
 
 static float vec_length(const vec3d vec) {
     float pow = vec_dot(vec, vec);
-
-    float res;
-    arm_sqrt_f32(pow, &res);
-    return res;
+    return arm_sqrt(pow);
 }
 
 static bool intersect_lines(vec3d orig1, vec3d vec1, vec3d orig2, vec3d vec2, vec3d res, float *dist) {
-    // Algoritm: http://geomalgorithms.com/a07-_distance.html#Distance-between-Lines
+    // Algorithm: http://geomalgorithms.com/a07-_distance.html#Distance-between-Lines
 
     vec3d w0 = {};
     arm_sub_f32(orig1, orig2, w0, vec3d_size);
@@ -75,8 +72,9 @@ static bool intersect_lines(vec3d orig1, vec3d vec1, vec3d orig2, vec3d vec2, ve
     arm_dot_prod_f32(vec2, w0, vec3d_size, &e);
 
     float denom = a * c - b * b;
-    if (fabsf(denom) < 1e-5f)
+    if (fabsf(denom) < 1e-5f) {
         return false;
+    }
 
     // Closest point to 2nd line on 1st line
     float t1 = (b * e - c * d) / denom;


### PR DESCRIPTION
The current crossing beam method in the lighthouse system was originally implemented for LH1 and only uses base stations 1 and 2. This PR makes it possible to use the crossing beam method with more than 2 base stations in a LH2 system.