### PR TITLE
Add support for fullStateSetpoint in PID controller

### DIFF
--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -75,8 +75,12 @@ void controllerPid(control_t *control, setpoint_t *setpoint,
           attitudeDesired.yaw = state->attitude.yaw - YAW_MAX_DELTA;
         }
       #endif
-    } else {
+    } else if (setpoint->mode.yaw == modeAbs) {
       attitudeDesired.yaw = setpoint->attitude.yaw;
+    } else if (setpoint->mode.quat == modeAbs) {
+      struct quat setpoint_quat = mkquat(setpoint->attitudeQuaternion.x, setpoint->attitudeQuaternion.y, setpoint->attitudeQuaternion.z, setpoint->attitudeQuaternion.w);
+      struct vec rpy = quat2rpy(setpoint_quat);
+      attitudeDesired.yaw = degrees(rpy.z);
     }
 
     attitudeDesired.yaw = capAngle(attitudeDesired.yaw);


### PR DESCRIPTION
When using fullState CRTP package, the desired rotation is encoded as a
quaternion. The Mellinger controller correctly computes the desired yaw
in this case. In the PID controller, this is currently ignored. This
change adds the same logic.

Test case: Crazyswarm2 teleoperation.