### PR TITLE
High-Level flight: plan shortest rotation to reach the desired yaw

### DIFF
--- a/src/modules/interface/math3d.h
+++ b/src/modules/interface/math3d.h
@@ -45,6 +45,35 @@ SOFTWARE.
 static inline float fsqr(float x) { return x * x; }
 static inline float radians(float degrees) { return (M_PI_F / 180.0f) * degrees; }
 static inline float degrees(float radians) { return (180.0f / M_PI_F) * radians; }
+
+// Normalize radians to be in range [-pi,pi]
+// See https://stackoverflow.com/questions/4633177/c-how-to-wrap-a-float-to-the-interval-pi-pi
+static inline float normalize_radians(float radians)
+{
+	// Copy the sign of the value in radians to the value of pi.
+	float signed_pi = copysignf(M_PI_F, radians);
+	// Set the value of difference to the appropriate signed value between pi and -pi.
+	radians = fmodf(radians + signed_pi, 2 * M_PI_F) - signed_pi;
+	return radians;
+}
+
+// modulo operation that uses the floored definition (as in Python), rather than
+// the truncated definition used for the % operator in C
+// See https://en.wikipedia.org/wiki/Modulo_operation
+static inline float fmodf_floored(float x, float n)
+{
+	return x - floorf(x / n) * n;
+}
+
+// compute shortest signed angle between two given angles (in range [-pi, pi])
+// See https://stackoverflow.com/questions/1878907/how-can-i-find-the-difference-between-two-angles
+static inline float shortest_signed_angle_radians(float start, float goal)
+{
+	float diff = goal - start;
+	float signed_diff = fmodf_floored(diff + M_PI_F, 2 * M_PI_F) - M_PI_F;
+	return signed_diff;
+}
+
 static inline float clamp(float value, float min, float max) {
   if (value < min) return min;
   if (value > max) return max;

--- a/test_python/test_math3d.py
+++ b/test_python/test_math3d.py
@@ -13,3 +13,27 @@ def test_that_vec_is_converted_to_numpy_array():
     # Assert
     expected = np.array([1, 2, 3])
     assert np.allclose(expected, actual)
+
+
+def test_normalize_radians():
+    # Fixture
+    angles = [-100, -5, 0, np.pi + 0.1, -np.pi - 0.1, 100]
+
+    for angle in angles:
+        # Test
+        actual = cffirmware.normalize_radians(angle)
+        # Assert
+        expected = np.arctan2(np.sin(angle), np.cos(angle))
+        assert np.allclose(expected, actual)
+
+
+def test_shortest_signed_angle_radians():
+    # Fixture
+    angle_pairs = [(-np.pi/2, np.pi), (np.pi/2, np.pi), (np.pi, -np.pi/3)]
+
+    for start, goal in angle_pairs:
+        # Test
+        actual = cffirmware.shortest_signed_angle_radians(start, goal)
+        # Assert
+        expected = np.arctan2(np.sin(goal - start), np.cos(goal - start))
+        assert np.allclose(expected, actual)


### PR DESCRIPTION
* Adds new helper functions (and tests) to math3d:
  normalize_radians and shortest_signed_angle_radians
* For takeoff, landing, and goTo: plan the yaw motion such that always
  the shortest rotation is used.