### PR TITLE
Increase priority of syslink flow control interrupt

### DIFF
--- a/src/config/nvicconf.h
+++ b/src/config/nvicconf.h
@@ -81,6 +81,7 @@
 #define NVIC_RADIO_PRI        11
 #define NVIC_ADC_PRI          12
 #define NVIC_CPPM_PRI         14
+#define NVIC_SYSLINK_FLOW_PRI 4
 #define NVIC_SYSLINK_UART_PRI 5
 #define NVIC_SYSLINK_DMA_PRI  7
 #define NVIC_SPI_PRI          7
@@ -100,7 +101,7 @@
 #define EXTI1_PRI NVIC_LOW_PRI
 #define EXTI2_PRI NVIC_LOW_PRI
 #define EXTI3_PRI NVIC_LOW_PRI
-#define EXTI4_PRI NVIC_SYSLINK_UART_PRI // this serves the syslink UART
+#define EXTI4_PRI NVIC_SYSLINK_FLOW_PRI // this is used for flow control when STM sends data to the NRF on the syslink UART
 #define EXTI9_5_PRI NVIC_LOW_PRI
 #define EXTI15_10_PRI NVIC_MID_PRI // this serves the decks and sensors
 


### PR DESCRIPTION
This PR increases the priority of the syslink flow control interrupt. 
The syslink receive UART in the NRF (STM to NRF) is 
connected to the STM for flow control. When the RX buffer is full, the STM is notified and is supposed to pause the transmission until the buffer is handled. On the STM side this flow control is handled by an interrupt and we suspect that the interrupt sometimes is a bit too slow. This leads to packet loss on the syslink from STM to the NRF (and on to a client on a PC).
This PR increases the priority of the flow control interrupt. 
If the suspisions are correct, this should solve #998 but more tests need to be carried out in the stability lab.