### PR TITLE
DTR Renaming p2p_interface file

### DIFF
--- a/examples/app_p2p_DTR/src/p2p_DTR_app.c
+++ b/examples/app_p2p_DTR/src/p2p_DTR_app.c
@@ -44,7 +44,7 @@
 #include "debug.h"
 
 #include "token_ring.h"
-#include "p2p_interface.h"
+#include "DTR_p2p_interface.h"
 
 #define INTERESTING_DATA 104
 

--- a/src/modules/interface/p2pDTR/DTR_p2p_interface.h
+++ b/src/modules/interface/p2pDTR/DTR_p2p_interface.h
@@ -22,7 +22,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- * p2p_interface.h
+ * DTR_p2p_interface.h
  * 
  */
 

--- a/src/modules/interface/p2pDTR/token_ring.h
+++ b/src/modules/interface/p2pDTR/token_ring.h
@@ -46,7 +46,7 @@
 
 #include "DTR_types.h"
 #include "DTR_handlers.h"
-#include "p2p_interface.h"
+#include "DTR_p2p_interface.h"
 #include "queueing.h"
 
 // #define UNUSED(...) ((void)sizeof((_Bool[]){__VA_ARGS__})); //Used to silence compiler warnings about unused parameters

--- a/src/modules/src/Kbuild
+++ b/src/modules/src/Kbuild
@@ -63,7 +63,7 @@ obj-$(CONFIG_ENABLE_CPX)          += cpx/cpxlink.o
 obj-$(CONFIG_ENABLE_CPX)          += cpx/cpx.o
 
 obj-y += p2pDTR/DTR_handlers.o
-obj-y += p2pDTR/p2p_interface.o
+obj-y += p2pDTR/DTR_p2p_interface.o
 obj-y += p2pDTR/queueing.o
 obj-y += p2pDTR/token_ring.o
 # Kalman core

--- a/src/modules/src/p2pDTR/DTR_p2p_interface.c
+++ b/src/modules/src/p2pDTR/DTR_p2p_interface.c
@@ -22,13 +22,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  *
- * p2p_interface.c
+ * DTR_p2p_interface.c
  *  
  */
 
 
 
-#include "p2p_interface.h"
+#include "DTR_p2p_interface.h"
 
 #define DEBUG_MODULE "DTR_P2P"
 #include "debug.h"


### PR DESCRIPTION
Renamed `"p2p_interface"` file used from the DTR protocol to `"DTR_p2p_interface"` since it was too generic and it is very likely to cause a file name conflict. (I already fell into this trap with my app) 