### PR TITLE
Fixed syslink DMA by guarding a none-atimic read.

### DIFF
--- a/src/drivers/src/uart_syslink.c
+++ b/src/drivers/src/uart_syslink.c
@@ -317,7 +317,11 @@ void uartslkSendDataDmaBlocking(uint32_t size, uint8_t* data)
     // Enable the Transfer Complete interrupt
     DMA_ITConfig(UARTSLK_DMA_TX_STREAM, DMA_IT_TC, ENABLE);
     // Enable USART DMA TX Requests
+    // Critical section is needed as the RX DMA that runs form interrupt can
+    // change the same USARTx->CR3 register at the wrong point (not atomic).
+    taskENTER_CRITICAL();
     USART_DMACmd(UARTSLK_TYPE, USART_DMAReq_Tx, ENABLE);
+    taskEXIT_CRITICAL();
     // Clear transfer complete
     USART_ClearFlag(UARTSLK_TYPE, USART_FLAG_TC);
     // Enable DMA USART TX Stream
@@ -475,15 +479,11 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
       cksum[1] += cksum[0];
       dataIndex = 0;
 #ifdef CONFIG_SYSLINK_RX_DMA
-      if (c > 1)
+      if (c >= 1)
       {
         rxState = waitForFirstStart;
         // For efficiency receive using DMA
         uartslkReceiveDMA(slp.length + UARTSLK_CLKSUM_SIZE);
-      }
-      else if (c == 1)
-      {
-        rxState = waitForData;
       }
       else // zero length
       {

--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -15,7 +15,7 @@ menu "Communication"
 
 config SYSLINK_RX_DMA
     bool "Use DMA to receive uart syslink data instead of interrupts"
-    default n
+    default y
     help
         Using DMA to receive uart data reduces CPU load and will free
         up recources for other things. DMA is a shared resource though


### PR DESCRIPTION
The hangup of the syslink RX DMA read was due to that the USART_DMACmd function is not atomic and called from uartslkSendDataDmaBlocking as well as uartslkReceiveDMA which is run from an interrupt.
```
void USART_DMACmd(USART_TypeDef* USARTx, uint16_t USART_DMAReq, FunctionalState NewState)
{
  /* Check the parameters */
  assert_param(IS_USART_ALL_PERIPH(USARTx));
  assert_param(IS_USART_DMAREQ(USART_DMAReq));  
  assert_param(IS_FUNCTIONAL_STATE(NewState)); 

  if (NewState != DISABLE)
  {
    /* Enable the DMA transfer for selected requests by setting the DMAT and/or
       DMAR bits in the USART CR3 register */
    USARTx->CR3 |= USART_DMAReq;
  }
  else
  {
    /* Disable the DMA transfer for selected requests by clearing the DMAT and/or
       DMAR bits in the USART CR3 register */
    USARTx->CR3 &= (uint16_t)~USART_DMAReq;
  }
}
```
The USARTx->CR3 |= USART_DMAReq; translates to a read-modify-write operation and if the uart RX interupt happened just in the modify state it would write the wrong value to the register.

Syslink DMA RX will be used with only one byte payload as well as it tuns out to be more efficient. 

Syslink DMA RX has been enabled again in kbuild.
