### PR TITLE
Do not use DMA by default for syslink UART

### DIFF
--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -15,7 +15,7 @@ menu "Communication"
 
 config SYSLINK_RX_DMA
     bool "Use DMA to receive uart syslink data instead of interrupts"
-    default y
+    default n
     help
         Using DMA to receive uart data reduces CPU load and will free
         up recources for other things. DMA is a shared resource though


### PR DESCRIPTION
There are still instabilities in syslink when using the DMA, also after #1116. This PR disables the DMA by default to get to a more stable state. 
Related to #1107 