### PR TITLE
Convert some LH logs to debug

### DIFF
--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -64,7 +64,6 @@
 #include "aideck.h"
 
 static bool isInit = false;
-static uint8_t byte;
 
 #define WIFI_SET_SSID_CMD         0x10
 #define WIFI_SET_KEY_CMD          0x11
@@ -165,7 +164,7 @@ static bool gap8DeckFlasherWrite(const uint32_t memAddr, const uint8_t writeLen,
     gap8BlPacket->writeSize = *(memDef->newFwSizeP);
     bootPacket.dataLength = sizeof(GAP8BlCmdPacket_t);
     cpxSendPacketBlocking(&bootPacket);
-    
+
     xEventGroupWaitBits(bootloaderSync,
                         CPX_WAIT_FOR_BOOTLOADER_REPLY,
                         pdTRUE,  // Clear bits before returning
@@ -315,8 +314,8 @@ static void aideckInit(DeckInfo *info)
 #ifdef CONFIG_DECK_AI_WIFI_NO_SETUP
   DEBUG_PRINT("Not setting up WiFi\n");
 #else
-  setupWiFi(); 
-#endif 
+  setupWiFi();
+#endif
 
   isInit = true;
 }
@@ -365,9 +364,6 @@ static const DeckDriver aideck_deck = {
     .test = aideckTest,
 };
 
-LOG_GROUP_START(aideck)
-LOG_ADD(LOG_UINT8, receivebyte, &byte)
-LOG_GROUP_STOP(aideck)
 
 /** @addtogroup deck
 */


### PR DESCRIPTION
Some logs in the lighthouse core modeule are converted to debug logs to reduce the size of the TOC. 

The logs changed are all sweepangles for sensors, except sensor 0 as well as variables used to develop the code and assess performance.

* lighthouse.angle0x_1
* lighthouse.angle0y_1
* lighthouse.angle1x_1
* lighthouse.angle1y_1
* lighthouse.angle0x_2
* lighthouse.angle0y_2
* lighthouse.angle1x_2
* lighthouse.angle1y_2
* lighthouse.angle0x_3
* lighthouse.angle0y_3
* lighthouse.angle1x_3
* lighthouse.angle1y_3
* lighthouse.serialFrameRate
* lighthouse.frameRate
* lighthouse.cycleRate
* lighthouse.bs0Rate
* lighthouse.bs1Rate
* lighthouse.width0
* lighthouse.width1
* lighthouse.width2
* lighthouse.width3