### PR TITLE
Improved support extRx (CPPM)

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -97,6 +97,59 @@ config DECK_CPPM
     help
       Combined PPM / PPM-Sum driver.
 
+choice
+  prompt "ExtRx CPPM pin"
+  depends on DECK_CPPM
+  default DECK_CPPM_USE_PA7
+
+config DECK_CPPM_USE_PB4
+    bool "PB4/IO_3"
+
+config DECK_CPPM_USE_PB5
+    bool "PB5/IO_2"
+
+config DECK_CPPM_USE_PB8
+    bool "PB8/IO_1"
+
+config DECK_CPPM_USE_PA2
+    bool "PA2/TX2"
+
+config DECK_CPPM_USE_PA3
+    bool "PA3/RX2"
+
+config DECK_CPPM_USE_PA7
+    bool "PA7/MOSI"
+
+endchoice  
+
+config DECK_EXTRX_ALT_HOLD
+    bool "Enable altitude hold via ExtRx"
+    default n
+    depends on DECK_CPPM || DECK_BIGQUAD_ENABLE || DECK_FLAPPER_ENABLE
+    help
+        Switch to altitude hold via ch4 of the external receiver.
+
+config DECK_EXTRX_ARMING
+    bool "Enable arming via ExtRx"
+    default n
+    depends on DECK_CPPM || DECK_BIGQUAD_ENABLE
+    help
+        Arming via ch5 of the external receiver.
+
+config DECK_EXTRX_MODE_RATE
+    bool "Enable rate mode via ExtRx"
+    default n
+    depends on DECK_CPPM || DECK_BIGQUAD_ENABLE
+    help
+        Switch to rate mode via ch6 of the external receiver.
+
+config DECK_EXTRX_TAER
+    bool "Use TAER channel mapping"
+    default n
+    depends on DECK_CPPM || DECK_BIGQUAD_ENABLE
+    help
+        Expecting TAER channel mapping instead of the default AETR.
+
 config DECK_FLOW
     bool "Support the Flow (v1 and v2) deck"
     default y

--- a/src/drivers/src/cppm.c
+++ b/src/drivers/src/cppm.c
@@ -40,35 +40,35 @@
 #include "debug.h"
 #include "log.h"
 
-#ifdef CPPM_USE_PB4
+#ifdef CONFIG_DECK_CPPM_USE_PB4
   #define CPPM_TIMER_NUMBER            3
   #define CPPM_TIMER_CHANNEL           1
   #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOB
   #define CPPM_GPIO_PORT               GPIOB
   #define CPPM_GPIO_PIN                GPIO_Pin_4
   #define CPPM_GPIO_SOURCE             GPIO_PinSource4
-#elif defined(CPPM_USE_PB5) 
+#elif defined(CONFIG_DECK_CPPM_USE_PB5) 
   #define CPPM_TIMER_NUMBER            3
   #define CPPM_TIMER_CHANNEL           2
   #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOB
   #define CPPM_GPIO_PORT               GPIOB
   #define CPPM_GPIO_PIN                GPIO_Pin_5
   #define CPPM_GPIO_SOURCE             GPIO_PinSource5
-#elif defined(CPPM_USE_PB8)
+#elif defined(CONFIG_DECK_CPPM_USE_PB8)
   #define CPPM_TIMER_NUMBER            10
   #define CPPM_TIMER_CHANNEL           1
   #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOB
   #define CPPM_GPIO_PORT               GPIOB
   #define CPPM_GPIO_PIN                GPIO_Pin_8
   #define CPPM_GPIO_SOURCE             GPIO_PinSource8
-#elif defined(CPPM_USE_PA2)
+#elif defined(CONFIG_DECK_CPPM_USE_PA2)
   #define CPPM_TIMER_NUMBER            9
   #define CPPM_TIMER_CHANNEL           1
   #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOA
   #define CPPM_GPIO_PORT               GPIOA
   #define CPPM_GPIO_PIN                GPIO_Pin_2
   #define CPPM_GPIO_SOURCE             GPIO_PinSource2
-#elif defined(CPPM_USE_PA3)
+#elif defined(CONFIG_DECK_CPPM_USE_PA3)
   #define CPPM_TIMER_NUMBER            9
   #define CPPM_TIMER_CHANNEL           2
   #define CPPM_GPIO_RCC                RCC_AHB1Periph_GPIOA

--- a/src/modules/interface/crtp_commander.h
+++ b/src/modules/interface/crtp_commander.h
@@ -34,4 +34,10 @@ void crtpCommanderInit(void);
 void crtpCommanderRpytDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk);
 void crtpCommanderGenericDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk);
 
+float getCPPMRollScale();
+float getCPPMRollRateScale();
+float getCPPMPitchScale();
+float getCPPMPitchRateScale();
+float getCPPMYawRateScale();
+
 #endif /* CRTP_COMMANDER_H_ */

--- a/src/modules/interface/extrx.h
+++ b/src/modules/interface/extrx.h
@@ -28,4 +28,5 @@
 #include <stdint.h>
 
 void extRxInit(void);
+float extRxGetNormalizedChannelValue(uint8_t channel);
 

--- a/src/modules/src/crtp_commander_generic.c
+++ b/src/modules/src/crtp_commander_generic.c
@@ -147,15 +147,21 @@ static void zDistanceDecoder(setpoint_t *setpoint, uint8_t type, const void *dat
   setpoint->attitude.pitch = values->pitch;
 }
 
-/* cppmEmuDecoder
- * CRTP packet containing an emulation of CPPM channels
+/**
+ * The CPPM (Combined Pulse Position Modulation) commander packet contains
+ * an emulation of CPPM channels transmitted in a CRTP packet that can be sent
+ * from e.g. a RC Transmitter. Often running custom firmware such as Deviation.
+ *
  * Channels have a range of 1000-2000 with a midpoint of 1500
  * Supports the ordinary RPYT channels plus up to MAX_AUX_RC_CHANNELS auxiliary channels.
  * Auxiliary channels are optional and transmitters do not have to transmit all the data
  * unless a given channel is actually in use (numAuxChannels must be set accordingly)
  *
  * Current aux channel assignments:
- * - AuxChannel0: set high to enable self-leveling, low to disable
+ *  AuxChannel0: set high to enable self-leveling, low to disable
+ *
+ * The scaling can be configured using s_CppmEmuRollMax... parameters, setting the maximum
+ * angle/rate output given a maximum stick input (1000 or 2000).
  */
 #define MAX_AUX_RC_CHANNELS 10
 
@@ -181,6 +187,31 @@ static inline float getChannelUnitMultiplier(uint16_t channelValue, uint16_t cha
 {
   // Compute a float from -1 to 1 based on the RC channel value, midpoint, and total range magnitude
   return ((float)channelValue - (float)channelMidpoint) / (float)channelRange;
+}
+
+float getCPPMRollScale()
+{
+  return s_CppmEmuRollMaxAngleDeg;
+}
+
+float getCPPMRollRateScale()
+{
+  return s_CppmEmuRollMaxRateDps;
+}
+
+float getCPPMPitchScale()
+{
+  return s_CppmEmuPitchMaxAngleDeg;
+}
+
+float getCPPMPitchRateScale()
+{
+  return s_CppmEmuPitchMaxRateDps;
+}
+
+float getCPPMYawRateScale()
+{
+  return s_CppmEmuYawMaxRateDps;
 }
 
 static void cppmEmuDecoder(setpoint_t *setpoint, uint8_t type, const void *data, size_t datalen)
@@ -400,22 +431,13 @@ void crtpCommanderGenericDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk)
 }
 
 /**
- * The CPPM (Combined Pulse Position Modulation) commander packet contains
- * an emulation of CPPM channels transmitted in a CRTP packet that can be sent
- * from e.g. a RC Transmitter. Often running custom firmware such as Deviation.
- *
- * Channels have a range of 1000-2000 with a midpoint of 1500
- * Supports the ordinary RPYT channels plus up to MAX_AUX_RC_CHANNELS auxiliary channels.
- * Auxiliary channels are optional and transmitters do not have to transmit all the data
- * unless a given channel is actually in use (numAuxChannels must be set accordingly)
- *
- * Current aux channel assignments:
- *  AuxChannel0: set high to enable self-leveling, low to disable
- *
- * The scaling can be configured using the parameters, setting the maximum
- * angle/rate output given a maximum stick input (1000 or 2000).
+ * The CPPM (Combined Pulse Position Modulation) parameters
+ * configure the maximum angle/rate output given a maximum stick input
+ * for CRTP packets with emulated CPPM channels (e.g. RC transmitters connecting
+ * directly to the NRF radio, often with a 4-in-1 Multimodule), or for CPPM channels
+ * from an external receiver.  
  */
-PARAM_GROUP_START(cmdrCPPM)
+PARAM_GROUP_START(cppm)
 
 /**
  * @brief Config of max roll rate at max stick input [DPS] (default: 720)
@@ -438,4 +460,4 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, angRoll, &s_CppmEmuRollMaxAngleDeg)
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, rateYaw, &s_CppmEmuYawMaxRateDps)
 
-PARAM_GROUP_STOP(cmdrCPPM)
+PARAM_GROUP_STOP(cppm)


### PR DESCRIPTION
This PR improves the support of external CPPM receivers:
- enabling rate mode
- reusing "cmdrCPPM" permanent parameters also for extRx channel scaling (until now used only for CRTP packets with emulated CPPM channels). New name "cppm" instead of "cmdrCPPM" is proposed
- pin configuration moved to Kconfig
- enabling Althold, Arming and Mode switches moved to Kconfig
- enabling TAER mapping moved to Kconfig

