### PR TITLE
Migrating default PID gains and filter settings to platform defaults and Kconfig

### DIFF
--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -12,6 +12,7 @@ include = [
     "build/include/generated",
     "src/config",
     "src/drivers/interface",
+    "src/platform/interface",
 ]
 
 fw_sources = [

--- a/src/hal/interface/imu.h
+++ b/src/hal/interface/imu.h
@@ -60,17 +60,4 @@ bool imu6IsCalibrated(void);
 bool imuHasBarometer(void);
 bool imuHasMangnetometer(void);
 
-// Euler angles defining IMU orientation on the airframe
-#ifndef IMU_PHI
-#define IMU_PHI 0.0f
-#endif
-#ifndef IMU_THETA
-#define IMU_THETA 0.0f
-#endif
-#ifndef IMU_PSI
-#define IMU_PSI 0.0f
-#endif
-
-
-
 #endif /* IMU_H_ */

--- a/src/hal/src/sensors_bmi088_bmp388.c
+++ b/src/hal/src/sensors_bmi088_bmp388.c
@@ -54,6 +54,7 @@
 #include "estimator.h"
 
 #include "sensors_bmi088_common.h"
+#include "platform_defaults.h"
 
 #define GYRO_ADD_RAW_AND_VARIANCE_LOG_VALUES
 
@@ -88,6 +89,7 @@
 #define GYRO_VARIANCE_THRESHOLD_Z       (GYRO_VARIANCE_BASE)
 
 #define SENSORS_ACC_SCALE_SAMPLES  200
+
 
 typedef struct
 {
@@ -145,13 +147,10 @@ static void applyAxis3fLpf(lpf2pData *data, Axis3f* in);
 static bool isBarometerPresent = false;
 static uint8_t baroMeasDelayMin = SENSORS_DELAY_BARO;
 
-// Precalculated values for IMU alignment
-static float sphi   = sinf(IMU_PHI * (float) M_PI / 180);
-static float cphi   = cosf(IMU_PHI * (float) M_PI / 180);
-static float stheta = sinf(IMU_THETA * (float) M_PI / 180);
-static float ctheta = cosf(IMU_THETA * (float) M_PI / 180);
-static float spsi   = sinf(IMU_PSI * (float) M_PI / 180);
-static float cpsi   = cosf(IMU_PSI * (float) M_PI / 180);
+// IMU alignment Euler angles
+static float imuPhi = IMU_PHI;
+static float imuTheta = IMU_THETA;
+static float imuPsi = IMU_PSI;
 
 static float R[3][3];
 
@@ -879,6 +878,14 @@ bool sensorsBmi088Bmp388ManufacturingTest(void)
  */
 static void sensorsAlignToAirframe(Axis3f* in, Axis3f* out)
 {
+  // IMU alignment
+  float sphi   = sinf(imuPhi * (float) M_PI / 180);
+  float cphi   = cosf(imuPhi * (float) M_PI / 180);
+  float stheta = sinf(imuTheta * (float) M_PI / 180);
+  float ctheta = cosf(imuTheta * (float) M_PI / 180);
+  float spsi   = sinf(imuPsi * (float) M_PI / 180);
+  float cpsi   = cosf(imuPsi * (float) M_PI / 180);
+
   R[0][0] = ctheta * cpsi;
   R[0][1] = ctheta * spsi;
   R[0][2] = -stheta;
@@ -992,4 +999,20 @@ PARAM_GROUP_START(imu_sensors)
  * @brief Nonzero if BMP388 barometer is present
  */
 PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, BMP388, &isBarometerPresent)
+
+/**
+ * @brief Euler angle Phi defining IMU orientation on the airframe (in degrees)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Phi, &imuPhi)
+
+/**
+ * @brief Euler angle Theta defining IMU orientation on the airframe (in degrees)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Theta, &imuTheta)
+
+/**
+ * @brief Euler angle Psi defining IMU orientation on the airframe (in degrees)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Psi, &imuPsi)
+
 PARAM_GROUP_STOP(imu_sensors)

--- a/src/hal/src/sensors_bmi088_bmp388.c
+++ b/src/hal/src/sensors_bmi088_bmp388.c
@@ -879,12 +879,14 @@ bool sensorsBmi088Bmp388ManufacturingTest(void)
 static void sensorsAlignToAirframe(Axis3f* in, Axis3f* out)
 {
   // IMU alignment
-  float sphi   = sinf(imuPhi * (float) M_PI / 180);
-  float cphi   = cosf(imuPhi * (float) M_PI / 180);
-  float stheta = sinf(imuTheta * (float) M_PI / 180);
-  float ctheta = cosf(imuTheta * (float) M_PI / 180);
-  float spsi   = sinf(imuPsi * (float) M_PI / 180);
-  float cpsi   = cosf(imuPsi * (float) M_PI / 180);
+  static float sphi, cphi, stheta, ctheta, spsi, cpsi;
+
+  sphi   = sinf(imuPhi * (float) M_PI / 180);
+  cphi   = cosf(imuPhi * (float) M_PI / 180);
+  stheta = sinf(imuTheta * (float) M_PI / 180);
+  ctheta = cosf(imuTheta * (float) M_PI / 180);
+  spsi   = sinf(imuPsi * (float) M_PI / 180);
+  cpsi   = cosf(imuPsi * (float) M_PI / 180);
 
   R[0][0] = ctheta * cpsi;
   R[0][1] = ctheta * spsi;

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -869,12 +869,14 @@ void __attribute__((used)) EXTI13_Callback(void)
 static void sensorsAlignToAirframe(Axis3f* in, Axis3f* out)
 {
   // IMU alignment
-  float sphi   = sinf(imuPhi * (float) M_PI / 180);
-  float cphi   = cosf(imuPhi * (float) M_PI / 180);
-  float stheta = sinf(imuTheta * (float) M_PI / 180);
-  float ctheta = cosf(imuTheta * (float) M_PI / 180);
-  float spsi   = sinf(imuPsi * (float) M_PI / 180);
-  float cpsi   = cosf(imuPsi * (float) M_PI / 180);
+  static float sphi, cphi, stheta, ctheta, spsi, cpsi;
+   
+  sphi   = sinf(imuPhi * (float) M_PI / 180);
+  cphi   = cosf(imuPhi * (float) M_PI / 180);
+  stheta = sinf(imuTheta * (float) M_PI / 180);
+  ctheta = cosf(imuTheta * (float) M_PI / 180);
+  spsi   = sinf(imuPsi * (float) M_PI / 180);
+  cpsi   = cosf(imuPsi * (float) M_PI / 180);
 
   R[0][0] = ctheta * cpsi;
   R[0][1] = ctheta * spsi;

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -51,6 +51,7 @@
 #include "filter.h"
 #include "static_mem.h"
 #include "estimator.h"
+#include "platform_defaults.h"
 
 #define SENSORS_ENABLE_PRESSURE_LPS25H
 //#define GYRO_ADD_RAW_AND_VARIANCE_LOG_VALUES
@@ -142,13 +143,10 @@ static bool isMpu6500TestPassed = false;
 static bool isAK8963TestPassed = false;
 static bool isLPS25HTestPassed = false;
 
-// Precalculated values for IMU alignment
-static float sphi   = sinf(IMU_PHI * (float) M_PI / 180);
-static float cphi   = cosf(IMU_PHI * (float) M_PI / 180);
-static float stheta = sinf(IMU_THETA * (float) M_PI / 180);
-static float ctheta = cosf(IMU_THETA * (float) M_PI / 180);
-static float spsi   = sinf(IMU_PSI * (float) M_PI / 180);
-static float cpsi   = cosf(IMU_PSI * (float) M_PI / 180);
+// IMU alignment Euler angles
+static float imuPhi = IMU_PHI;
+static float imuTheta = IMU_THETA;
+static float imuPsi = IMU_PSI;
 
 static float R[3][3];
 
@@ -433,10 +431,10 @@ static void sensorsDeviceInit(void)
   }
 #endif
 
-  cosPitch = cosf(configblockGetCalibPitch() * (float) M_PI/180);
-  sinPitch = sinf(configblockGetCalibPitch() * (float) M_PI/180);
-  cosRoll = cosf(configblockGetCalibRoll() * (float) M_PI/180);
-  sinRoll = sinf(configblockGetCalibRoll() * (float) M_PI/180);
+  cosPitch = cosf(configblockGetCalibPitch() * (float) M_PI / 180);
+  sinPitch = sinf(configblockGetCalibPitch() * (float) M_PI / 180);
+  cosRoll = cosf(configblockGetCalibRoll() * (float) M_PI / 180);
+  sinRoll = sinf(configblockGetCalibRoll() * (float) M_PI / 180);
 }
 
 
@@ -870,6 +868,14 @@ void __attribute__((used)) EXTI13_Callback(void)
  */
 static void sensorsAlignToAirframe(Axis3f* in, Axis3f* out)
 {
+  // IMU alignment
+  float sphi   = sinf(imuPhi * (float) M_PI / 180);
+  float cphi   = cosf(imuPhi * (float) M_PI / 180);
+  float stheta = sinf(imuTheta * (float) M_PI / 180);
+  float ctheta = cosf(imuTheta * (float) M_PI / 180);
+  float spsi   = sinf(imuPsi * (float) M_PI / 180);
+  float cpsi   = cosf(imuPsi * (float) M_PI / 180);
+
   R[0][0] = ctheta * cpsi;
   R[0][1] = ctheta * spsi;
   R[0][2] = -stheta;
@@ -986,5 +992,20 @@ PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, AK8963, &isAK8963TestPassed)
  * @brief Nonzero if the LPS25H self-test passes
  */
 PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, LPS25H, &isLPS25HTestPassed)
+
+/**
+ * @brief Euler angle Phi defining IMU orientation on the airframe (in degrees)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Phi, &imuPhi)
+
+/**
+ * @brief Euler angle Theta defining IMU orientation on the airframe (in degrees)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Theta, &imuTheta)
+
+/**
+ * @brief Euler angle Psi defining IMU orientation on the airframe (in degrees)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Psi, &imuPsi)
 
 PARAM_GROUP_STOP(imu_tests)

--- a/src/modules/interface/attitude_controller.h
+++ b/src/modules/interface/attitude_controller.h
@@ -73,5 +73,10 @@ void attitudeControllerResetAllPID(void);
  */
 void attitudeControllerGetActuatorOutput(int16_t* roll, int16_t* pitch, int16_t* yaw);
 
+/**
+ * Get yaw max delta
+ */
+float attitudeControllerGetYawMaxDelta(void);
+
 
 #endif /* ATTITUDE_CONTROLLER_H_ */

--- a/src/modules/interface/pid.h
+++ b/src/modules/interface/pid.h
@@ -30,37 +30,6 @@
 #include <stdbool.h>
 #include "filter.h"
 
-#define PID_ROLL_RATE_KP  250.0
-#define PID_ROLL_RATE_KI  500.0
-#define PID_ROLL_RATE_KD  2.5
-#define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
-
-#define PID_PITCH_RATE_KP  250.0
-#define PID_PITCH_RATE_KI  500.0
-#define PID_PITCH_RATE_KD  2.5
-#define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
-
-#define PID_YAW_RATE_KP  120.0
-#define PID_YAW_RATE_KI  16.7
-#define PID_YAW_RATE_KD  0.0
-#define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
-
-#define PID_ROLL_KP  6.0
-#define PID_ROLL_KI  3.0
-#define PID_ROLL_KD  0.0
-#define PID_ROLL_INTEGRATION_LIMIT    20.0
-
-#define PID_PITCH_KP  6.0
-#define PID_PITCH_KI  3.0
-#define PID_PITCH_KD  0.0
-#define PID_PITCH_INTEGRATION_LIMIT   20.0
-
-#define PID_YAW_KP  6.0
-#define PID_YAW_KI  1.0
-#define PID_YAW_KD  0.35
-#define PID_YAW_INTEGRATION_LIMIT     360.0
-
-
 #define DEFAULT_PID_INTEGRATION_LIMIT 5000.0
 #define DEFAULT_PID_OUTPUT_LIMIT      0.0
 
@@ -201,4 +170,3 @@ void pidSetDt(PidObject* pid, const float dt);
 void filterReset(PidObject* pid, const float samplingRate, const float cutoffFreq, bool enableDFilter);
 
 #endif /* PID_H_ */
-  

--- a/src/modules/interface/pid.h
+++ b/src/modules/interface/pid.h
@@ -44,9 +44,11 @@ typedef struct
   float kp;           //< proportional gain
   float ki;           //< integral gain
   float kd;           //< derivative gain
+  float kff;          //< feedforward gain
   float outP;         //< proportional output (debugging)
   float outI;         //< integral output (debugging)
   float outD;         //< derivative output (debugging)
+  float outFF;        //< feedforward output (debugging)
   float iLimit;       //< integral limit, absolute value. '0' means no limit.
   float outputLimit;  //< total PID output limit, absolute value. '0' means no limit.
   float dt;           //< delta-time dt
@@ -62,13 +64,14 @@ typedef struct
  * @param[in] kp        The proportional gain
  * @param[in] ki        The integral gain
  * @param[in] kd        The derivative gain
+ * @param[in] kff       The feedforward gain
  * @param[in] dt        Delta time since the last call
  * @param[in] samplingRate Frequency the update will be called
  * @param[in] cutoffFreq   Frequency to set the low pass filter cutoff at
  * @param[in] enableDFilter Enable setting for the D lowpass filter
  */
  void pidInit(PidObject* pid, const float desired, const float kp,
-              const float ki, const float kd, const float dt,
+              const float ki, const float kd, const float kff, const float dt,
               const float samplingRate, const float cutoffFreq,
               bool enableDFilter);
 
@@ -150,6 +153,14 @@ void pidSetKi(PidObject* pid, const float ki);
  * @param[in] kd    The derivative gain
  */
 void pidSetKd(PidObject* pid, const float kd);
+
+/**
+ * Set a new feed-froward gain for the PID.
+ *
+ * @param[in] pid   A pointer to the pid object.
+ * @param[in] kff    The new proportional gain
+ */
+void pidSetKff(PidObject* pid, const float kff);
 
 /**
  * Set a new dt gain for the PID. Defaults to IMU_UPDATE_DT upon construction

--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -14,6 +14,18 @@ config CONTROLLER_PID
     help
         Use the PID (proportional–integral–derivative) controller as default
 
+config CONTROLLER_PID_FILTER_ALL
+    bool "Apply LPF filter to all PID components"
+    depends on CONTROLLER_PID
+    help
+        Apply a low pass filter to all PID components instead of only the D component (default)
+
+config CONTROLLER_PID_IMPROVED_BARO_Z_HOLD
+    bool "Use improved baro z hold"
+    depends on CONTROLLER_PID_FILTER_ALL
+    help
+        Uses an improved z hold based on barometric pressure
+
 config CONTROLLER_INDI
     bool "INDI controller"
     help

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -145,12 +145,7 @@ void attitudeControllerCorrectRatePID(
 
   pidSetDesired(&pidYawRate, yawRateDesired);
 
-  // there is probably a more elegant way to get the yaw rate setpoint...
-  static setpoint_t setpoint;
-  static state_t state;
-  commanderGetSetpoint(&setpoint, &state);
-  // adding a feedforward term
-  yawOutput = saturateSignedInt16(pidUpdate(&pidYawRate, yawRateActual, true) + yawFeedForw*setpoint.attitudeRate.yaw);
+  yawOutput = saturateSignedInt16(pidUpdate(&pidYawRate, yawRateActual, true));
 }
 
 void attitudeControllerCorrectAttitudePID(
@@ -334,10 +329,6 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_ki, &pidYaw.ki)
  * @brief Derivative gain for the PID yaw controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kd, &pidYaw.kd)
-/**
- * @brief Feedforward gain for the yaw controller
- */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yawFeedForw, &yawFeedForw)
 /**
  * @brief If nonzero, yaw setpoint can only be set within +/- yawMaxDelta from the current yaw
  */

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -35,14 +35,13 @@
 #include "platform_defaults.h"
 
 
-bool attFiltEnable = ATTITUDE_LPF_ENABLE;
-bool rateFiltEnable = ATTITUDE_RATE_LPF_ENABLE;
-float attFiltCutoff = ATTITUDE_LPF_CUTOFF_FREQ;
-float omxFiltCutoff = ATTITUDE_ROLL_RATE_LPF_CUTOFF_FREQ;
-float omyFiltCutoff = ATTITUDE_PITCH_RATE_LPF_CUTOFF_FREQ;
-float omzFiltCutoff = ATTITUDE_YAW_RATE_LPF_CUTOFF_FREQ;
-float yawFeedForw = ATTITUDE_RATE_FF_YAW;
-float yawMaxDelta = YAW_MAX_DELTA;
+static bool attFiltEnable = ATTITUDE_LPF_ENABLE;
+static bool rateFiltEnable = ATTITUDE_RATE_LPF_ENABLE;
+static float attFiltCutoff = ATTITUDE_LPF_CUTOFF_FREQ;
+static float omxFiltCutoff = ATTITUDE_ROLL_RATE_LPF_CUTOFF_FREQ;
+static float omyFiltCutoff = ATTITUDE_PITCH_RATE_LPF_CUTOFF_FREQ;
+static float omzFiltCutoff = ATTITUDE_YAW_RATE_LPF_CUTOFF_FREQ;
+static float yawMaxDelta = YAW_MAX_DELTA;
 
 static inline int16_t saturateSignedInt16(float in)
 {

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -226,6 +226,10 @@ LOG_ADD(LOG_FLOAT, roll_outI, &pidRoll.outI)
  */
 LOG_ADD(LOG_FLOAT, roll_outD, &pidRoll.outD)
 /**
+ * @brief Feedforward output roll
+ */
+LOG_ADD(LOG_FLOAT, roll_outFF, &pidRoll.outFF)
+/**
  * @brief Proportional output pitch
  */
 LOG_ADD(LOG_FLOAT, pitch_outP, &pidPitch.outP)
@@ -238,6 +242,10 @@ LOG_ADD(LOG_FLOAT, pitch_outI, &pidPitch.outI)
  */
 LOG_ADD(LOG_FLOAT, pitch_outD, &pidPitch.outD)
 /**
+ * @brief Feedforward output pitch
+ */
+LOG_ADD(LOG_FLOAT, pitch_outFF, &pidPitch.outFF)
+/**
  * @brief Proportional output yaw
  */
 LOG_ADD(LOG_FLOAT, yaw_outP, &pidYaw.outP)
@@ -249,6 +257,10 @@ LOG_ADD(LOG_FLOAT, yaw_outI, &pidYaw.outI)
  * @brief Derivative output yaw
  */
 LOG_ADD(LOG_FLOAT, yaw_outD, &pidYaw.outD)
+/**
+ * @brief Feedforward output yaw
+ */
+LOG_ADD(LOG_FLOAT, yaw_outFF, &pidYaw.outFF)
 LOG_GROUP_STOP(pid_attitude)
 
 /**
@@ -268,6 +280,10 @@ LOG_ADD(LOG_FLOAT, roll_outI, &pidRollRate.outI)
  */
 LOG_ADD(LOG_FLOAT, roll_outD, &pidRollRate.outD)
 /**
+ * @brief Feedforward output roll rate
+ */
+LOG_ADD(LOG_FLOAT, roll_outFF, &pidRollRate.outFF)
+/**
  * @brief Proportional output pitch rate
  */
 LOG_ADD(LOG_FLOAT, pitch_outP, &pidPitchRate.outP)
@@ -280,6 +296,10 @@ LOG_ADD(LOG_FLOAT, pitch_outI, &pidPitchRate.outI)
  */
 LOG_ADD(LOG_FLOAT, pitch_outD, &pidPitchRate.outD)
 /**
+ * @brief Feedforward output pitch rate
+ */
+LOG_ADD(LOG_FLOAT, pitch_outFF, &pidPitchRate.outFF)
+/**
  * @brief Proportional output yaw rate
  */
 LOG_ADD(LOG_FLOAT, yaw_outP, &pidYawRate.outP)
@@ -291,6 +311,10 @@ LOG_ADD(LOG_FLOAT, yaw_outI, &pidYawRate.outI)
  * @brief Derivative output yaw rate
  */
 LOG_ADD(LOG_FLOAT, yaw_outD, &pidYawRate.outD)
+/**
+ * @brief Feedforward output yaw rate
+ */
+LOG_ADD(LOG_FLOAT, yaw_outFF, &pidYawRate.outFF)
 LOG_GROUP_STOP(pid_rate)
 
 /**

--- a/src/modules/src/attitude_pid_controller.c
+++ b/src/modules/src/attitude_pid_controller.c
@@ -59,36 +59,42 @@ PidObject pidRollRate = {
   .kp = PID_ROLL_RATE_KP,
   .ki = PID_ROLL_RATE_KI,
   .kd = PID_ROLL_RATE_KD,
+  .kff = PID_ROLL_RATE_KFF,
 };
 
 PidObject pidPitchRate = {
   .kp = PID_PITCH_RATE_KP,
   .ki = PID_PITCH_RATE_KI,
   .kd = PID_PITCH_RATE_KD,
+  .kff = PID_PITCH_RATE_KFF,
 };
 
 PidObject pidYawRate = {
   .kp = PID_YAW_RATE_KP,
   .ki = PID_YAW_RATE_KI,
   .kd = PID_YAW_RATE_KD,
+  .kff = PID_YAW_RATE_KFF,
 };
 
 PidObject pidRoll = {
   .kp = PID_ROLL_KP,
   .ki = PID_ROLL_KI,
   .kd = PID_ROLL_KD,
+  .kff = PID_ROLL_KFF,
 };
 
 PidObject pidPitch = {
   .kp = PID_PITCH_KP,
   .ki = PID_PITCH_KI,
   .kd = PID_PITCH_KD,
+  .kff = PID_PITCH_KFF,
 };
 
 PidObject pidYaw = {
   .kp = PID_YAW_KP,
   .ki = PID_YAW_KI,
   .kd = PID_YAW_KD,
+  .kff = PID_YAW_KFF,
 };
 
 static int16_t rollOutput;
@@ -104,21 +110,21 @@ void attitudeControllerInit(const float updateDt)
 
   //TODO: get parameters from configuration manager instead - now (partly) implemented
   pidInit(&pidRollRate,  0, pidRollRate.kp,  pidRollRate.ki,  pidRollRate.kd,
-      updateDt, ATTITUDE_RATE, omxFiltCutoff, rateFiltEnable);
+       pidRollRate.kff,  updateDt, ATTITUDE_RATE, omxFiltCutoff, rateFiltEnable);
   pidInit(&pidPitchRate, 0, pidPitchRate.kp, pidPitchRate.ki, pidPitchRate.kd,
-      updateDt, ATTITUDE_RATE, omyFiltCutoff, rateFiltEnable);
+       pidPitchRate.kff, updateDt, ATTITUDE_RATE, omyFiltCutoff, rateFiltEnable);
   pidInit(&pidYawRate,   0, pidYawRate.kp,   pidYawRate.ki,   pidYawRate.kd,
-      updateDt, ATTITUDE_RATE, omzFiltCutoff, rateFiltEnable);
+       pidYawRate.kff,   updateDt, ATTITUDE_RATE, omzFiltCutoff, rateFiltEnable);
 
   pidSetIntegralLimit(&pidRollRate,  PID_ROLL_RATE_INTEGRATION_LIMIT);
   pidSetIntegralLimit(&pidPitchRate, PID_PITCH_RATE_INTEGRATION_LIMIT);
   pidSetIntegralLimit(&pidYawRate,   PID_YAW_RATE_INTEGRATION_LIMIT);
 
-  pidInit(&pidRoll,  0, pidRoll.kp,  pidRoll.ki,  pidRoll.kd,  updateDt,
+  pidInit(&pidRoll,  0, pidRoll.kp,  pidRoll.ki,  pidRoll.kd,  pidRoll.kff,  updateDt,
       ATTITUDE_RATE, attFiltCutoff, attFiltEnable);
-  pidInit(&pidPitch, 0, pidPitch.kp, pidPitch.ki, pidPitch.kd, updateDt,
+  pidInit(&pidPitch, 0, pidPitch.kp, pidPitch.ki, pidPitch.kd, pidPitch.kff, updateDt,
       ATTITUDE_RATE, attFiltCutoff, attFiltEnable);
-  pidInit(&pidYaw,   0, pidYaw.kp,   pidYaw.ki,   pidYaw.kd,   updateDt,
+  pidInit(&pidYaw,   0, pidYaw.kp,   pidYaw.ki,   pidYaw.kd,   pidYaw.kff,   updateDt,
       ATTITUDE_RATE, attFiltCutoff, attFiltEnable);
 
   pidSetIntegralLimit(&pidRoll,  PID_ROLL_INTEGRATION_LIMIT);
@@ -306,6 +312,10 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_ki, &pidRoll.ki)
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_kd, &pidRoll.kd)
 /**
+ * @brief Feedforward gain for the PID roll controller
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_kff, &pidRoll.kff)
+/**
  * @brief Proportional gain for the PID pitch controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_kp, &pidPitch.kp)
@@ -318,6 +328,10 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_ki, &pidPitch.ki)
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_kd, &pidPitch.kd)
 /**
+ * @brief Feedforward gain for the PID pitch controller
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_kff, &pidPitch.kff)
+/**
  * @brief Proportional gain for the PID yaw controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kp, &pidYaw.kp)
@@ -329,6 +343,10 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_ki, &pidYaw.ki)
  * @brief Derivative gain for the PID yaw controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kd, &pidYaw.kd)
+/**
+ * @brief Feedforward gain for the PID yaw controller
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kff, &pidYaw.kff)
 /**
  * @brief If nonzero, yaw setpoint can only be set within +/- yawMaxDelta from the current yaw
  */
@@ -361,6 +379,10 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_ki, &pidRollRate.ki)
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_kd, &pidRollRate.kd)
 /**
+ * @brief Feedforward gain for the PID roll rate controller
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_kff, &pidRollRate.kff)
+/**
  * @brief Proportional gain for the PID pitch rate controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_kp, &pidPitchRate.kp)
@@ -373,6 +395,10 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_ki, &pidPitchRate.ki)
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_kd, &pidPitchRate.kd)
 /**
+ * @brief Feedforward gain for the PID pitch rate controller
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, pitch_kff, &pidPitchRate.kff)
+/**
  * @brief Proportional gain for the PID yaw rate controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kp, &pidYawRate.kp)
@@ -384,6 +410,10 @@ PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_ki, &pidYawRate.ki)
  * @brief Derivative gain for the PID yaw rate controller
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kd, &pidYawRate.kd)
+/**
+ * @brief Feedforward gain for the PID yaw rate controller
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, yaw_kff, &pidYawRate.kff)
 /**
  * @brief Low pass filter enable
  */

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -63,18 +63,20 @@ void controllerPid(control_t *control, setpoint_t *setpoint,
     if (setpoint->mode.yaw == modeVelocity) {
       attitudeDesired.yaw = capAngle(attitudeDesired.yaw + setpoint->attitudeRate.yaw * ATTITUDE_UPDATE_DT);
        
-      #ifdef YAW_MAX_DELTA
+      float yawMaxDelta = attitudeControllerGetYawMaxDelta();
+      if (yawMaxDelta != 0.0f)
+      {
       float delta = capAngle(attitudeDesired.yaw-state->attitude.yaw);
-      // keep the yaw setpoint within +/- YAW_MAX_DELTA from the current yaw
-        if (delta > YAW_MAX_DELTA)
+      // keep the yaw setpoint within +/- yawMaxDelta from the current yaw
+        if (delta > yawMaxDelta)
         {
-          attitudeDesired.yaw = state->attitude.yaw + YAW_MAX_DELTA;
+          attitudeDesired.yaw = state->attitude.yaw + yawMaxDelta;
         }
-        else if (delta < -YAW_MAX_DELTA)
+        else if (delta < -yawMaxDelta)
         {
-          attitudeDesired.yaw = state->attitude.yaw - YAW_MAX_DELTA;
+          attitudeDesired.yaw = state->attitude.yaw - yawMaxDelta;
         }
-      #endif
+      }
     } else if (setpoint->mode.yaw == modeAbs) {
       attitudeDesired.yaw = setpoint->attitude.yaw;
     } else if (setpoint->mode.quat == modeAbs) {
@@ -224,4 +226,3 @@ LOG_ADD(LOG_FLOAT, pitchRate, &rateDesired.pitch)
  */
 LOG_ADD(LOG_FLOAT, yawRate,   &rateDesired.yaw)
 LOG_GROUP_STOP(controller)
-

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -347,6 +347,23 @@ LOG_ADD(LOG_FLOAT, bodyX, &state_body_x)
 LOG_ADD(LOG_FLOAT, bodyY, &state_body_y)
 
 /**
+ * @brief PID proportional output position x
+ */
+LOG_ADD(LOG_FLOAT, Xp, &this.pidX.pid.outP)
+/**
+ * @brief PID integral output position x
+ */
+LOG_ADD(LOG_FLOAT, Xi, &this.pidX.pid.outI)
+/**
+ * @brief PID derivative output position x
+ */
+LOG_ADD(LOG_FLOAT, Xd, &this.pidX.pid.outD)
+/**
+ * @brief PID feedforward output position x
+ */
+LOG_ADD(LOG_FLOAT, Xff, &this.pidX.pid.outFF)
+
+/**
  * @brief PID proportional output position y
  */
 LOG_ADD(LOG_FLOAT, Yp, &this.pidY.pid.outP)
@@ -358,6 +375,10 @@ LOG_ADD(LOG_FLOAT, Yi, &this.pidY.pid.outI)
  * @brief PID derivative output position y
  */
 LOG_ADD(LOG_FLOAT, Yd, &this.pidY.pid.outD)
+/**
+ * @brief PID feedforward output position y
+ */
+LOG_ADD(LOG_FLOAT, Yff, &this.pidY.pid.outFF)
 
 /**
  * @brief PID proportional output position z
@@ -371,6 +392,10 @@ LOG_ADD(LOG_FLOAT, Zi, &this.pidZ.pid.outI)
  * @brief PID derivative output position z
  */
 LOG_ADD(LOG_FLOAT, Zd, &this.pidZ.pid.outD)
+/**
+ * @brief PID feedforward output position z
+ */
+LOG_ADD(LOG_FLOAT, Zff, &this.pidZ.pid.outFF)
 
 /**
  * @brief PID proportional output velocity x
@@ -384,6 +409,27 @@ LOG_ADD(LOG_FLOAT, VXi, &this.pidVX.pid.outI)
  * @brief PID derivative output velocity x
  */
 LOG_ADD(LOG_FLOAT, VXd, &this.pidVX.pid.outD)
+/**
+ * @brief PID feedforward output velocity x
+ */
+LOG_ADD(LOG_FLOAT, VXff, &this.pidVX.pid.outFF)
+
+/**
+ * @brief PID proportional output velocity y
+ */
+LOG_ADD(LOG_FLOAT, VYp, &this.pidVY.pid.outP)
+/**
+ * @brief PID integral output velocity y
+ */
+LOG_ADD(LOG_FLOAT, VYi, &this.pidVY.pid.outI)
+/**
+ * @brief PID derivative output velocity y
+ */
+LOG_ADD(LOG_FLOAT, VYd, &this.pidVY.pid.outD)
+/**
+ * @brief PID feedforward output velocity y
+ */
+LOG_ADD(LOG_FLOAT, VYff, &this.pidVY.pid.outFF)
 
 /**
  * @brief PID proportional output velocity z
@@ -397,6 +443,10 @@ LOG_ADD(LOG_FLOAT, VZi, &this.pidVZ.pid.outI)
  * @brief PID integral output velocity z
  */
 LOG_ADD(LOG_FLOAT, VZd, &this.pidVZ.pid.outD)
+/**
+ * @brief PID feedforward output velocity z
+ */
+LOG_ADD(LOG_FLOAT, VZff, &this.pidVZ.pid.outFF)
 
 LOG_GROUP_STOP(posCtl)
 

--- a/src/modules/src/position_controller_pid.c
+++ b/src/modules/src/position_controller_pid.c
@@ -70,17 +70,17 @@ static float velMaxOverhead = 1.10f;
 static const float thrustScale = 1000.0f;
 
 #define DT (float)(1.0f/POSITION_RATE)
-bool posFiltEnable = PID_POS_XY_FILT_ENABLE;
-bool velFiltEnable = PID_VEL_XY_FILT_ENABLE;
-float posFiltCutoff = PID_POS_XY_FILT_CUTOFF;
-float velFiltCutoff = PID_VEL_XY_FILT_CUTOFF;
-bool posZFiltEnable = PID_POS_Z_FILT_ENABLE;
-bool velZFiltEnable = PID_VEL_Z_FILT_ENABLE;
-float posZFiltCutoff = PID_POS_Z_FILT_CUTOFF;
+static bool posFiltEnable = PID_POS_XY_FILT_ENABLE;
+static bool velFiltEnable = PID_VEL_XY_FILT_ENABLE;
+static float posFiltCutoff = PID_POS_XY_FILT_CUTOFF;
+static float velFiltCutoff = PID_VEL_XY_FILT_CUTOFF;
+static bool posZFiltEnable = PID_POS_Z_FILT_ENABLE;
+static bool velZFiltEnable = PID_VEL_Z_FILT_ENABLE;
+static float posZFiltCutoff = PID_POS_Z_FILT_CUTOFF;
 #if CONFIG_CONTROLLER_PID_IMPROVED_BARO_Z_HOLD
-float velZFiltCutoff = PID_VEL_Z_FILT_CUTOFF_BARO_Z_HOLD;
+static float velZFiltCutoff = PID_VEL_Z_FILT_CUTOFF_BARO_Z_HOLD;
 #else
-float velZFiltCutoff = PID_VEL_Z_FILT_CUTOFF;
+static float velZFiltCutoff = PID_VEL_Z_FILT_CUTOFF;
 #endif
 
 #ifndef UNIT_TEST

--- a/src/modules/src/position_estimator_altitude.c
+++ b/src/modules/src/position_estimator_altitude.c
@@ -100,7 +100,7 @@ static void positionEstimateInternal(state_t* estimate, const baro_t* baro, cons
       filteredZ = (state->estAlphaAsl       ) * state->estimatedZ +
                   (1.0f - state->estAlphaAsl) * baro->asl;
     }
-    #ifdef IMPROVED_BARO_Z_HOLD
+    #if CONFIG_CONTROLLER_PID_IMPROVED_BARO_Z_HOLD
       state->estimatedZ = filteredZ;
     #else
       // Use asl as base and add velocity changes.

--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -40,3 +40,68 @@
 #ifdef CONFIG_PLATFORM_TAG
     #include "platform_defaults_tag.h"
 #endif
+
+// IMU alignment on the airframe 
+#ifndef IMU_PHI
+    #define IMU_PHI     0.0f
+#endif
+#ifndef IMU_THETA
+    #define IMU_THETA   0.0f
+#endif
+#ifndef IMU_PSI
+    #define IMU_PSI     0.0f
+#endif
+
+// Attitude PID control filter settings
+#ifndef ATTITUDE_LPF_CUTOFF_FREQ 
+    #define ATTITUDE_LPF_CUTOFF_FREQ      15.0f
+#endif
+#ifndef ATTITUDE_LPF_ENABLE
+    #define ATTITUDE_LPF_ENABLE false
+#endif
+#ifndef ATTITUDE_ROLL_RATE_LPF_CUTOFF_FREQ
+    #define ATTITUDE_ROLL_RATE_LPF_CUTOFF_FREQ 30.0f
+#endif
+#ifndef ATTITUDE_PITCH_RATE_LPF_CUTOFF_FREQ
+    #define ATTITUDE_PITCH_RATE_LPF_CUTOFF_FREQ 30.0f
+#endif
+#ifndef ATTITUDE_YAW_RATE_LPF_CUTOFF_FREQ
+    #define ATTITUDE_YAW_RATE_LPF_CUTOFF_FREQ 30.0f
+#endif
+#ifndef ATTITUDE_RATE_LPF_ENABLE
+    #define ATTITUDE_RATE_LPF_ENABLE false
+#endif
+#ifndef ATTITUDE_RATE_FF_YAW
+    #define ATTITUDE_RATE_FF_YAW 0.0f
+#endif
+#ifndef YAW_MAX_DELTA
+    #define YAW_MAX_DELTA     0.0f
+#endif
+
+#ifndef PID_POS_XY_FILT_ENABLE
+    #define PID_POS_XY_FILT_ENABLE true
+#endif
+#ifndef PID_POS_XY_FILT_CUTOFF
+    #define PID_POS_XY_FILT_CUTOFF 20.0f
+#endif
+#ifndef PID_POS_Z_FILT_ENABLE
+    #define PID_POS_Z_FILT_ENABLE true
+#endif
+#ifndef PID_POS_Z_FILT_CUTOFF
+    #define PID_POS_Z_FILT_CUTOFF 20.0f
+#endif
+#ifndef PID_VEL_XY_FILT_ENABLE
+    #define PID_VEL_XY_FILT_ENABLE true
+#endif
+#ifndef PID_VEL_XY_FILT_CUTOFF
+    #define PID_VEL_XY_FILT_CUTOFF 20.0f
+#endif
+#ifndef PID_VEL_Z_FILT_ENABLE
+    #define PID_VEL_Z_FILT_ENABLE true
+#endif
+#ifndef PID_VEL_Z_FILT_CUTOFF
+    #define PID_VEL_Z_FILT_CUTOFF 20.0f
+#endif
+#ifndef PID_VEL_Z_FILT_CUTOFF_BARO_Z_HOLD
+    #define PID_VEL_Z_FILT_CUTOFF_BARO_Z_HOLD 0.7 f
+#endif

--- a/src/platform/interface/platform_defaults_bolt.h
+++ b/src/platform/interface/platform_defaults_bolt.h
@@ -46,31 +46,37 @@
 #define PID_ROLL_RATE_KP  250.0
 #define PID_ROLL_RATE_KI  500.0
 #define PID_ROLL_RATE_KD  2.5
+#define PID_ROLL_RATE_KFF 0.0
 #define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
 
 #define PID_PITCH_RATE_KP  250.0
 #define PID_PITCH_RATE_KI  500.0
 #define PID_PITCH_RATE_KD  2.5
+#define PID_PITCH_RATE_KFF 0.0
 #define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
 
 #define PID_YAW_RATE_KP  120.0
 #define PID_YAW_RATE_KI  16.7
 #define PID_YAW_RATE_KD  0.0
+#define PID_YAW_RATE_KFF 0.0
 #define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
 
 #define PID_ROLL_KP  6.0
 #define PID_ROLL_KI  3.0
 #define PID_ROLL_KD  0.0
+#define PID_ROLL_KFF 0.0
 #define PID_ROLL_INTEGRATION_LIMIT    20.0
 
 #define PID_PITCH_KP  6.0
 #define PID_PITCH_KI  3.0
 #define PID_PITCH_KD  0.0
+#define PID_PITCH_KFF 0.0
 #define PID_PITCH_INTEGRATION_LIMIT   20.0
 
 #define PID_YAW_KP  6.0
 #define PID_YAW_KI  1.0
 #define PID_YAW_KD  0.35
+#define PID_YAW_KFF 0.0
 #define PID_YAW_INTEGRATION_LIMIT     360.0
 
 #define PID_VEL_X_KP 25.0f
@@ -86,10 +92,12 @@
 #define PID_VEL_Z_KP 25.0f
 #define PID_VEL_Z_KI 15.0f
 #define PID_VEL_Z_KD 0.0f
+#define PID_VEL_Z_KFF 0.0f
 
 #define PID_VEL_Z_KP_BARO_Z_HOLD 3.0f
 #define PID_VEL_Z_KI_BARO_Z_HOLD 1.0f
 #define PID_VEL_Z_KD_BARO_Z_HOLD 1.5f
+#define PID_VEL_Z_KFF_BARO_Z_HOLD 0.0f
 
 #define PID_VEL_ROLL_MAX 20.0f
 #define PID_VEL_PITCH_MAX 20.0f
@@ -100,14 +108,17 @@
 #define PID_POS_X_KP 2.0f
 #define PID_POS_X_KI 0.0f
 #define PID_POS_X_KD 0.0f
+#define PID_POS_X_KFF 0.0f
 
 #define PID_POS_Y_KP 2.0f
 #define PID_POS_Y_KI 0.0f
 #define PID_POS_Y_KD 0.0f
+#define PID_POS_Y_KFF 0.0f
 
 #define PID_POS_Z_KP 2.0f
 #define PID_POS_Z_KI 0.5f
 #define PID_POS_Z_KD 0.0f
+#define PID_POS_Z_KFF 0.0f
 
 #define PID_POS_VEL_X_MAX 1.0f
 #define PID_POS_VEL_Y_MAX 0.0f

--- a/src/platform/interface/platform_defaults_bolt.h
+++ b/src/platform/interface/platform_defaults_bolt.h
@@ -41,3 +41,74 @@
 // Default value for system shutdown in minutes after radio silence.
 // Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
+
+// Default PID gains
+#define PID_ROLL_RATE_KP  250.0
+#define PID_ROLL_RATE_KI  500.0
+#define PID_ROLL_RATE_KD  2.5
+#define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
+
+#define PID_PITCH_RATE_KP  250.0
+#define PID_PITCH_RATE_KI  500.0
+#define PID_PITCH_RATE_KD  2.5
+#define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
+
+#define PID_YAW_RATE_KP  120.0
+#define PID_YAW_RATE_KI  16.7
+#define PID_YAW_RATE_KD  0.0
+#define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
+
+#define PID_ROLL_KP  6.0
+#define PID_ROLL_KI  3.0
+#define PID_ROLL_KD  0.0
+#define PID_ROLL_INTEGRATION_LIMIT    20.0
+
+#define PID_PITCH_KP  6.0
+#define PID_PITCH_KI  3.0
+#define PID_PITCH_KD  0.0
+#define PID_PITCH_INTEGRATION_LIMIT   20.0
+
+#define PID_YAW_KP  6.0
+#define PID_YAW_KI  1.0
+#define PID_YAW_KD  0.35
+#define PID_YAW_INTEGRATION_LIMIT     360.0
+
+#define PID_VEL_X_KP 25.0f
+#define PID_VEL_X_KI 1.0f
+#define PID_VEL_X_KD 0.0f
+#define PID_VEL_X_KFF 0.0f
+
+#define PID_VEL_Y_KP 25.0f
+#define PID_VEL_Y_KI 1.0f
+#define PID_VEL_Y_KD 0.0f
+#define PID_VEL_Y_KFF 0.0f
+
+#define PID_VEL_Z_KP 25.0f
+#define PID_VEL_Z_KI 15.0f
+#define PID_VEL_Z_KD 0.0f
+
+#define PID_VEL_Z_KP_BARO_Z_HOLD 3.0f
+#define PID_VEL_Z_KI_BARO_Z_HOLD 1.0f
+#define PID_VEL_Z_KD_BARO_Z_HOLD 1.5f
+
+#define PID_VEL_ROLL_MAX 20.0f
+#define PID_VEL_PITCH_MAX 20.0f
+#define PID_VEL_THRUST_BASE 36000.0f
+#define PID_VEL_THRUST_BASE_BARO_Z_HOLD 38000.0f
+#define PID_VEL_THRUST_MIN 20000.0f
+
+#define PID_POS_X_KP 2.0f
+#define PID_POS_X_KI 0.0f
+#define PID_POS_X_KD 0.0f
+
+#define PID_POS_Y_KP 2.0f
+#define PID_POS_Y_KI 0.0f
+#define PID_POS_Y_KD 0.0f
+
+#define PID_POS_Z_KP 2.0f
+#define PID_POS_Z_KI 0.5f
+#define PID_POS_Z_KD 0.0f
+
+#define PID_POS_VEL_X_MAX 1.0f
+#define PID_POS_VEL_Y_MAX 0.0f
+#define PID_POS_VEL_Z_MAX 0.0f

--- a/src/platform/interface/platform_defaults_cf2.h
+++ b/src/platform/interface/platform_defaults_cf2.h
@@ -46,31 +46,37 @@
 #define PID_ROLL_RATE_KP  250.0
 #define PID_ROLL_RATE_KI  500.0
 #define PID_ROLL_RATE_KD  2.5
+#define PID_ROLL_RATE_KFF 0.0
 #define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
 
 #define PID_PITCH_RATE_KP  250.0
 #define PID_PITCH_RATE_KI  500.0
 #define PID_PITCH_RATE_KD  2.5
+#define PID_PITCH_RATE_KFF 0.0
 #define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
 
 #define PID_YAW_RATE_KP  120.0
 #define PID_YAW_RATE_KI  16.7
 #define PID_YAW_RATE_KD  0.0
+#define PID_YAW_RATE_KFF 0.0
 #define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
 
 #define PID_ROLL_KP  6.0
 #define PID_ROLL_KI  3.0
 #define PID_ROLL_KD  0.0
+#define PID_ROLL_KFF 0.0
 #define PID_ROLL_INTEGRATION_LIMIT    20.0
 
 #define PID_PITCH_KP  6.0
 #define PID_PITCH_KI  3.0
 #define PID_PITCH_KD  0.0
+#define PID_PITCH_KFF 0.0
 #define PID_PITCH_INTEGRATION_LIMIT   20.0
 
 #define PID_YAW_KP  6.0
 #define PID_YAW_KI  1.0
 #define PID_YAW_KD  0.35
+#define PID_YAW_KFF 0.0
 #define PID_YAW_INTEGRATION_LIMIT     360.0
 
 #define PID_VEL_X_KP 25.0f
@@ -86,10 +92,12 @@
 #define PID_VEL_Z_KP 25.0f
 #define PID_VEL_Z_KI 15.0f
 #define PID_VEL_Z_KD 0.0f
+#define PID_VEL_Z_KFF 0.0f
 
 #define PID_VEL_Z_KP_BARO_Z_HOLD 3.0f
 #define PID_VEL_Z_KI_BARO_Z_HOLD 1.0f
 #define PID_VEL_Z_KD_BARO_Z_HOLD 1.5f
+#define PID_VEL_Z_KFF_BARO_Z_HOLD 0.0f
 
 #define PID_VEL_ROLL_MAX 20.0f
 #define PID_VEL_PITCH_MAX 20.0f
@@ -100,14 +108,17 @@
 #define PID_POS_X_KP 2.0f
 #define PID_POS_X_KI 0.0f
 #define PID_POS_X_KD 0.0f
+#define PID_POS_X_KFF 0.0f
 
 #define PID_POS_Y_KP 2.0f
 #define PID_POS_Y_KI 0.0f
 #define PID_POS_Y_KD 0.0f
+#define PID_POS_Y_KFF 0.0f
 
 #define PID_POS_Z_KP 2.0f
 #define PID_POS_Z_KI 0.5f
 #define PID_POS_Z_KD 0.0f
+#define PID_POS_Z_KFF 0.0f
 
 #define PID_POS_VEL_X_MAX 1.0f
 #define PID_POS_VEL_Y_MAX 0.0f

--- a/src/platform/interface/platform_defaults_cf2.h
+++ b/src/platform/interface/platform_defaults_cf2.h
@@ -42,3 +42,73 @@
 // Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
 
+// Default PID gains
+#define PID_ROLL_RATE_KP  250.0
+#define PID_ROLL_RATE_KI  500.0
+#define PID_ROLL_RATE_KD  2.5
+#define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
+
+#define PID_PITCH_RATE_KP  250.0
+#define PID_PITCH_RATE_KI  500.0
+#define PID_PITCH_RATE_KD  2.5
+#define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
+
+#define PID_YAW_RATE_KP  120.0
+#define PID_YAW_RATE_KI  16.7
+#define PID_YAW_RATE_KD  0.0
+#define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
+
+#define PID_ROLL_KP  6.0
+#define PID_ROLL_KI  3.0
+#define PID_ROLL_KD  0.0
+#define PID_ROLL_INTEGRATION_LIMIT    20.0
+
+#define PID_PITCH_KP  6.0
+#define PID_PITCH_KI  3.0
+#define PID_PITCH_KD  0.0
+#define PID_PITCH_INTEGRATION_LIMIT   20.0
+
+#define PID_YAW_KP  6.0
+#define PID_YAW_KI  1.0
+#define PID_YAW_KD  0.35
+#define PID_YAW_INTEGRATION_LIMIT     360.0
+
+#define PID_VEL_X_KP 25.0f
+#define PID_VEL_X_KI 1.0f
+#define PID_VEL_X_KD 0.0f
+#define PID_VEL_X_KFF 0.0f
+
+#define PID_VEL_Y_KP 25.0f
+#define PID_VEL_Y_KI 1.0f
+#define PID_VEL_Y_KD 0.0f
+#define PID_VEL_Y_KFF 0.0f
+
+#define PID_VEL_Z_KP 25.0f
+#define PID_VEL_Z_KI 15.0f
+#define PID_VEL_Z_KD 0.0f
+
+#define PID_VEL_Z_KP_BARO_Z_HOLD 3.0f
+#define PID_VEL_Z_KI_BARO_Z_HOLD 1.0f
+#define PID_VEL_Z_KD_BARO_Z_HOLD 1.5f
+
+#define PID_VEL_ROLL_MAX 20.0f
+#define PID_VEL_PITCH_MAX 20.0f
+#define PID_VEL_THRUST_BASE 36000.0f
+#define PID_VEL_THRUST_BASE_BARO_Z_HOLD 38000.0f
+#define PID_VEL_THRUST_MIN 20000.0f
+
+#define PID_POS_X_KP 2.0f
+#define PID_POS_X_KI 0.0f
+#define PID_POS_X_KD 0.0f
+
+#define PID_POS_Y_KP 2.0f
+#define PID_POS_Y_KI 0.0f
+#define PID_POS_Y_KD 0.0f
+
+#define PID_POS_Z_KP 2.0f
+#define PID_POS_Z_KI 0.5f
+#define PID_POS_Z_KD 0.0f
+
+#define PID_POS_VEL_X_MAX 1.0f
+#define PID_POS_VEL_Y_MAX 0.0f
+#define PID_POS_VEL_Z_MAX 0.0f

--- a/src/platform/interface/platform_defaults_tag.h
+++ b/src/platform/interface/platform_defaults_tag.h
@@ -46,31 +46,37 @@
 #define PID_ROLL_RATE_KP  250.0
 #define PID_ROLL_RATE_KI  500.0
 #define PID_ROLL_RATE_KD  2.5
+#define PID_ROLL_RATE_KFF 0.0
 #define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
 
 #define PID_PITCH_RATE_KP  250.0
 #define PID_PITCH_RATE_KI  500.0
 #define PID_PITCH_RATE_KD  2.5
+#define PID_PITCH_RATE_KFF 0.0
 #define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
 
 #define PID_YAW_RATE_KP  120.0
 #define PID_YAW_RATE_KI  16.7
 #define PID_YAW_RATE_KD  0.0
+#define PID_YAW_RATE_KFF 0.0
 #define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
 
 #define PID_ROLL_KP  6.0
 #define PID_ROLL_KI  3.0
 #define PID_ROLL_KD  0.0
+#define PID_ROLL_KFF 0.0
 #define PID_ROLL_INTEGRATION_LIMIT    20.0
 
 #define PID_PITCH_KP  6.0
 #define PID_PITCH_KI  3.0
 #define PID_PITCH_KD  0.0
+#define PID_PITCH_KFF 0.0
 #define PID_PITCH_INTEGRATION_LIMIT   20.0
 
 #define PID_YAW_KP  6.0
 #define PID_YAW_KI  1.0
 #define PID_YAW_KD  0.35
+#define PID_YAW_KFF 0.0
 #define PID_YAW_INTEGRATION_LIMIT     360.0
 
 #define PID_VEL_X_KP 25.0f
@@ -86,10 +92,12 @@
 #define PID_VEL_Z_KP 25.0f
 #define PID_VEL_Z_KI 15.0f
 #define PID_VEL_Z_KD 0.0f
+#define PID_VEL_Z_KFF 0.0f
 
 #define PID_VEL_Z_KP_BARO_Z_HOLD 3.0f
 #define PID_VEL_Z_KI_BARO_Z_HOLD 1.0f
 #define PID_VEL_Z_KD_BARO_Z_HOLD 1.5f
+#define PID_VEL_Z_KFF_BARO_Z_HOLD 0.0f
 
 #define PID_VEL_ROLL_MAX 20.0f
 #define PID_VEL_PITCH_MAX 20.0f
@@ -100,14 +108,17 @@
 #define PID_POS_X_KP 2.0f
 #define PID_POS_X_KI 0.0f
 #define PID_POS_X_KD 0.0f
+#define PID_POS_X_KFF 0.0f
 
 #define PID_POS_Y_KP 2.0f
 #define PID_POS_Y_KI 0.0f
 #define PID_POS_Y_KD 0.0f
+#define PID_POS_Y_KFF 0.0f
 
 #define PID_POS_Z_KP 2.0f
 #define PID_POS_Z_KI 0.5f
 #define PID_POS_Z_KD 0.0f
+#define PID_POS_Z_KFF 0.0f
 
 #define PID_POS_VEL_X_MAX 1.0f
 #define PID_POS_VEL_Y_MAX 0.0f

--- a/src/platform/interface/platform_defaults_tag.h
+++ b/src/platform/interface/platform_defaults_tag.h
@@ -41,3 +41,74 @@
 // Default value for system shutdown in minutes after radio silence.
 // Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
+
+// Default PID gains
+#define PID_ROLL_RATE_KP  250.0
+#define PID_ROLL_RATE_KI  500.0
+#define PID_ROLL_RATE_KD  2.5
+#define PID_ROLL_RATE_INTEGRATION_LIMIT    33.3
+
+#define PID_PITCH_RATE_KP  250.0
+#define PID_PITCH_RATE_KI  500.0
+#define PID_PITCH_RATE_KD  2.5
+#define PID_PITCH_RATE_INTEGRATION_LIMIT   33.3
+
+#define PID_YAW_RATE_KP  120.0
+#define PID_YAW_RATE_KI  16.7
+#define PID_YAW_RATE_KD  0.0
+#define PID_YAW_RATE_INTEGRATION_LIMIT     166.7
+
+#define PID_ROLL_KP  6.0
+#define PID_ROLL_KI  3.0
+#define PID_ROLL_KD  0.0
+#define PID_ROLL_INTEGRATION_LIMIT    20.0
+
+#define PID_PITCH_KP  6.0
+#define PID_PITCH_KI  3.0
+#define PID_PITCH_KD  0.0
+#define PID_PITCH_INTEGRATION_LIMIT   20.0
+
+#define PID_YAW_KP  6.0
+#define PID_YAW_KI  1.0
+#define PID_YAW_KD  0.35
+#define PID_YAW_INTEGRATION_LIMIT     360.0
+
+#define PID_VEL_X_KP 25.0f
+#define PID_VEL_X_KI 1.0f
+#define PID_VEL_X_KD 0.0f
+#define PID_VEL_X_KFF 0.0f
+
+#define PID_VEL_Y_KP 25.0f
+#define PID_VEL_Y_KI 1.0f
+#define PID_VEL_Y_KD 0.0f
+#define PID_VEL_Y_KFF 0.0f
+
+#define PID_VEL_Z_KP 25.0f
+#define PID_VEL_Z_KI 15.0f
+#define PID_VEL_Z_KD 0.0f
+
+#define PID_VEL_Z_KP_BARO_Z_HOLD 3.0f
+#define PID_VEL_Z_KI_BARO_Z_HOLD 1.0f
+#define PID_VEL_Z_KD_BARO_Z_HOLD 1.5f
+
+#define PID_VEL_ROLL_MAX 20.0f
+#define PID_VEL_PITCH_MAX 20.0f
+#define PID_VEL_THRUST_BASE 36000.0f
+#define PID_VEL_THRUST_BASE_BARO_Z_HOLD 38000.0f
+#define PID_VEL_THRUST_MIN 20000.0f
+
+#define PID_POS_X_KP 2.0f
+#define PID_POS_X_KI 0.0f
+#define PID_POS_X_KD 0.0f
+
+#define PID_POS_Y_KP 2.0f
+#define PID_POS_Y_KI 0.0f
+#define PID_POS_Y_KD 0.0f
+
+#define PID_POS_Z_KP 2.0f
+#define PID_POS_Z_KI 0.5f
+#define PID_POS_Z_KD 0.0f
+
+#define PID_POS_VEL_X_MAX 1.0f
+#define PID_POS_VEL_Y_MAX 0.0f
+#define PID_POS_VEL_Z_MAX 0.0f


### PR DESCRIPTION
Until now, PID values have been hardcoded, and could only be changed via permanent_parameters, or in a custom fork. 
This PR enables using platform-specific PID gain values and filter settings.

- PID gains are now defined for each platform individually in the [specific_patform]_defaults.h
- defaults for low pass filter settings are in platform_defaults.h, and can be overridden inside [specific_patform]_defaults.h for each platform if needed
- defines PID_FILTER_ALL and IMPROVED_BARO_Z_HOLD moved to Kconfig