### PR TITLE
Improve build scripts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,15 +33,15 @@ jobs:
         submodules: true
 
     - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.features }}_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v2.1.4
       with:
-        name: ${{ matrix.features }}-${{ github.sha }}
+        name: ${{ matrix.platform }}-${{ github.sha }}
         path: |
-          ${{ matrix.features }}.bin
-          ${{ matrix.features }}.elf
+          ${{ matrix.platform }}.bin
+          ${{ matrix.platform }}.elf
 
   features:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,16 +14,25 @@ permissions:
   contents: read
 
 jobs:
+  read_targets_from_file:
+        - id: read_platforms
+        run: |
+          content=`cat ./build_targets.json`
+          # the following lines are required for multi line json
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          # end of handling for multi line json
+          echo "::set-output name=platforms::$content"
+
   basic_build:
+    needs: read_targets_from_file
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        platform:
-        - cf2
-        - bolt
-        - tag
+        ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,15 +15,18 @@ permissions:
 
 jobs:
   read_targets_from_file:
-        - id: read_platforms
-        run: |
-          content=`cat ./build_targets.json`
-          # the following lines are required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          # end of handling for multi line json
-          echo "::set-output name=platforms::$content"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Read build targets from file
+
+      run: |
+        content=`cat ./build_targets.json`
+        # the following lines are required for multi line json
+        content="${content//'%'/'%25'}"
+        content="${content//$'\n'/'%0A'}"
+        content="${content//$'\r'/'%0D'}"
+        # end of handling for multi line json
+        echo "::set-output name=platforms::$content"
 
   basic_build:
     needs: read_targets_from_file

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,8 +14,17 @@ permissions:
   contents: read
 
 jobs:
-  cf2:
+  basic_build:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - cf2
+        - bolt
+        - tag
+        - cfbl
 
     steps:
     - name: Checkout Repo
@@ -24,79 +33,19 @@ jobs:
         submodules: true
 
     - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.features }}_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v2.1.4
       with:
-        name: cf2-${{ github.sha }}
+        name: ${{ matrix.features }}-${{ github.sha }}
         path: |
-          cf2.bin
-          cf2.elf
-
-  bolt:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make bolt_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
-
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2.1.4
-      with:
-        name: bolt-${{ github.sha }}
-        path: |
-          bolt.bin
-          bolt.elf
-
-  tag:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make tag_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
-
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2.1.4
-      with:
-        name: tag-${{ github.sha }}
-        path: |
-          tag.bin
-          tag.elf
-
-  cfbl:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make cfbl_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
-
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2.1.4
-      with:
-        name: cfbl-${{ github.sha }}
-        path: |
-          cfbl.bin
-          cfbl.elf
+          ${{ matrix.features }}.bin
+          ${{ matrix.features }}.elf
 
   features:
     runs-on: ubuntu-latest
-    needs: cf2
+    needs: basic_build
 
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,13 +16,16 @@ permissions:
 jobs:
   read_targets_from_file:
     runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
       with:
         submodules: false
 
-    - name: Read build targets from file
+    - id: read-build-target-from-file
       run: |
         content=`cat ./build_targets.json`
         # the following lines are required for multi line json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,12 @@ jobs:
   read_targets_from_file:
     runs-on: ubuntu-latest
     steps:
-    - name: Read build targets from file
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
 
+    - name: Read build targets from file
       run: |
         content=`cat ./build_targets.json`
         # the following lines are required for multi line json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,6 @@ jobs:
         - cf2
         - bolt
         - tag
-        - cfbl
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,7 @@ jobs:
 
   apps:
     runs-on: ubuntu-latest
-    needs: cf2
+    needs: basic_build
 
     strategy:
       fail-fast: false
@@ -109,7 +109,7 @@ jobs:
 
   kbuild-targets:
     runs-on: ubuntu-latest
-    needs: cf2
+    needs: basic_build
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,32 @@ permissions:
   contents: read
 
 jobs:
+  read_targets_from_file:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+
+    - id: read-build-target-from-file
+      run: |
+        content=`cat ./build_targets.json`
+        # the following lines are required for multi line json
+        content="${content//'%'/'%25'}"
+        content="${content//$'\n'/'%0A'}"
+        content="${content//$'\r'/'%0D'}"
+        # end of handling for multi line json
+        echo "::set-output name=platforms::$content"
+
   release:
     permissions:
       contents: write  # for actions/create-release to create a release
     name: Create Release on Github
+    needs: read_targets_from_file
     runs-on: ubuntu-latest
     steps:
     - name: Create Release
@@ -31,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: release_url
-        path: release_url.txt       
+        path: release_url.txt
 
   upload:
     permissions:
@@ -42,8 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platforms: [cf2, tag, bolt]
-  
+        ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -51,7 +73,7 @@ jobs:
         submodules: true
 
     - name: Build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platforms }}_defconfig && ./tools/build/build PLATFORM=${{ matrix.platforms }} UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build PLATFORM=${{ matrix.platform }} UNIT_TEST_STYLE=min"
 
     - name: Load Release URL File from release job
       uses: actions/download-artifact@v1
@@ -63,19 +85,19 @@ jobs:
       run: |
         value=`cat release_url/release_url.txt`
         echo ::set-output name=upload_url::$value
-        
-    - name: Get the version 
-      id: get_release_version 
-      env: 
+
+    - name: Get the version
+      id: get_release_version
+      env:
         GITHUB_REF : ${{ github.ref }}
       run: echo ::set-output name=release_version::${GITHUB_REF/refs\/tags\//}
-      
-    - name: Upload ${{ matrix.platforms }} bin
+
+    - name: Upload ${{ matrix.platform }} bin
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ${{ matrix.platforms }}.bin
-        asset_name: ${{ matrix.platforms }}-${{ steps.get_release_version.outputs.release_version }}.bin
+        asset_path: ${{ matrix.platform }}.bin
+        asset_name: ${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
         asset_content_type: application/octet-stream

--- a/build_targets.json
+++ b/build_targets.json
@@ -1,0 +1,7 @@
+{
+  "platform" : [
+    "cf2",
+    "bolt",
+    "tag"
+  ]
+}

--- a/module.json
+++ b/module.json
@@ -3,16 +3,5 @@
   "environmentReqs": {
     "build": ["arm-none-eabi"],
     "build-docs": ["doxygen"]
-  },
-  "actions": {
-    "artifacts": [
-      ".bin",
-      ".dfu"
-     ],
-    "targets" : [
-      "cf2",
-      "bolt",
-      "tag"
-    ]
   }
 }


### PR DESCRIPTION
There is a lot of repetition for platforms in our build scripts. Ideally there should be one list of platforms (possibly in module.json) that is used by all scripts that requires the information