### PR TITLE
Use a file to define build targets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,25 +15,7 @@ permissions:
 
 jobs:
   read_targets_from_file:
-    runs-on: ubuntu-latest
-    outputs:
-      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: false
-
-    - id: read-build-target-from-file
-      run: |
-        content=`cat ./build_targets.json`
-        # the following lines are required for multi line json
-        content="${content//'%'/'%25'}"
-        content="${content//$'\n'/'%0A'}"
-        content="${content//$'\r'/'%0D'}"
-        # end of handling for multi line json
-        echo "::set-output name=platforms::$content"
+    uses: ./.github/workflows/read_build_targets.yml
 
   basic_build:
     needs: read_targets_from_file

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,8 +14,19 @@ permissions:
   contents: read
 
 jobs:
-  cf2:
+
+
+  basic_build:
+    needs: read_targets_from_file
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - cf2
+        - bolt
+        - tag
 
     steps:
     - name: Checkout Repo
@@ -24,79 +35,19 @@ jobs:
         submodules: true
 
     - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v2.1.4
       with:
-        name: cf2-${{ github.sha }}
+        name: ${{ matrix.platform }}-${{ github.sha }}
         path: |
-          cf2.bin
-          cf2.elf
-
-  bolt:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make bolt_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
-
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2.1.4
-      with:
-        name: bolt-${{ github.sha }}
-        path: |
-          bolt.bin
-          bolt.elf
-
-  tag:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make tag_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
-
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2.1.4
-      with:
-        name: tag-${{ github.sha }}
-        path: |
-          tag.bin
-          tag.elf
-
-  cfbl:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - name: build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make cfbl_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
-
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v2.1.4
-      with:
-        name: cfbl-${{ github.sha }}
-        path: |
-          cfbl.bin
-          cfbl.elf
+          ${{ matrix.platform }}.bin
+          ${{ matrix.platform }}.elf
 
   features:
     runs-on: ubuntu-latest
-    needs: cf2
+    needs: basic_build
 
     strategy:
       fail-fast: false
@@ -132,7 +83,7 @@ jobs:
 
   apps:
     runs-on: ubuntu-latest
-    needs: cf2
+    needs: basic_build
 
     strategy:
       fail-fast: false
@@ -160,7 +111,7 @@ jobs:
 
   kbuild-targets:
     runs-on: ubuntu-latest
-    needs: cf2
+    needs: basic_build
 
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,26 @@ permissions:
   contents: read
 
 jobs:
+  read_targets_from_file:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
 
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+
+    - id: read-build-target-from-file
+      run: |
+        content=`cat ./build_targets.json`
+        # the following lines are required for multi line json
+        content="${content//'%'/'%25'}"
+        content="${content//$'\n'/'%0A'}"
+        content="${content//$'\r'/'%0D'}"
+        # end of handling for multi line json
+        echo "::set-output name=platforms::$content"
 
   basic_build:
     needs: read_targets_from_file
@@ -23,10 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-        - cf2
-        - bolt
-        - tag
+        ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
 
     steps:
     - name: Checkout Repo

--- a/.github/workflows/read_build_targets.yml
+++ b/.github/workflows/read_build_targets.yml
@@ -1,0 +1,39 @@
+# This work flow checks out the repo and reads the list of release targets from
+# the build_targetst.json file.
+
+# The list of targets is available in needs.read_targets_from_file.outputs.platforms as a json dictionary, use it
+# in matrix like this: ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
+
+name: Read build targets
+
+on:
+  workflow_call:
+    outputs:
+      platforms:
+        description: "'platform' is set to the list of targets"
+        value: ${{ jobs.read_targets_from_file.outputs.platforms }}
+
+permissions:
+  contents: read
+
+jobs:
+  read_targets_from_file:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+
+    - id: read-build-target-from-file
+      run: |
+        content=`cat ./build_targets.json`
+        # the following lines are required for multi line json
+        content="${content//'%'/'%25'}"
+        content="${content//$'\n'/'%0A'}"
+        content="${content//$'\r'/'%0D'}"
+        # end of handling for multi line json
+        echo "::set-output name=platforms::$content"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,7 @@ permissions:
 
 jobs:
   read_targets_from_file:
-    runs-on: ubuntu-latest
-    outputs:
-      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
-
-    steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        submodules: false
-
-    - id: read-build-target-from-file
-      run: |
-        content=`cat ./build_targets.json`
-        # the following lines are required for multi line json
-        content="${content//'%'/'%25'}"
-        content="${content//$'\n'/'%0A'}"
-        content="${content//$'\r'/'%0D'}"
-        # end of handling for multi line json
-        echo "::set-output name=platforms::$content"
+    uses: ./.github/workflows/read_build_targets.yml
 
   release:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,32 @@ permissions:
   contents: read
 
 jobs:
+  read_targets_from_file:
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.read-build-target-from-file.outputs.platforms }}
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+
+    - id: read-build-target-from-file
+      run: |
+        content=`cat ./build_targets.json`
+        # the following lines are required for multi line json
+        content="${content//'%'/'%25'}"
+        content="${content//$'\n'/'%0A'}"
+        content="${content//$'\r'/'%0D'}"
+        # end of handling for multi line json
+        echo "::set-output name=platforms::$content"
+
   release:
     permissions:
       contents: write  # for actions/create-release to create a release
     name: Create Release on Github
+    needs: read_targets_from_file
     runs-on: ubuntu-latest
     steps:
     - name: Create Release
@@ -31,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: release_url
-        path: release_url.txt       
+        path: release_url.txt
 
   upload:
     permissions:
@@ -42,8 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platforms: [cf2, tag, bolt]
-  
+        ${{fromJson(needs.read_targets_from_file.outputs.platforms)}}
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -51,7 +73,7 @@ jobs:
         submodules: true
 
     - name: Build
-      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platforms }}_defconfig && ./tools/build/build PLATFORM=${{ matrix.platforms }} UNIT_TEST_STYLE=min"
+      run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build PLATFORM=${{ matrix.platform }} UNIT_TEST_STYLE=min"
 
     - name: Load Release URL File from release job
       uses: actions/download-artifact@v1
@@ -63,19 +85,19 @@ jobs:
       run: |
         value=`cat release_url/release_url.txt`
         echo ::set-output name=upload_url::$value
-        
-    - name: Get the version 
-      id: get_release_version 
-      env: 
+
+    - name: Get the version
+      id: get_release_version
+      env:
         GITHUB_REF : ${{ github.ref }}
       run: echo ::set-output name=release_version::${GITHUB_REF/refs\/tags\//}
-      
-    - name: Upload ${{ matrix.platforms }} bin
+
+    - name: Upload ${{ matrix.platform }} bin
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ${{ matrix.platforms }}.bin
-        asset_name: ${{ matrix.platforms }}-${{ steps.get_release_version.outputs.release_version }}.bin
+        asset_path: ${{ matrix.platform }}.bin
+        asset_name: ${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
         asset_content_type: application/octet-stream

--- a/build_targets.json
+++ b/build_targets.json
@@ -1,0 +1,7 @@
+{
+    "platform" : [
+      "cf2",
+      "bolt",
+      "tag"
+    ]
+  }

--- a/module.json
+++ b/module.json
@@ -3,16 +3,5 @@
   "environmentReqs": {
     "build": ["arm-none-eabi"],
     "build-docs": ["doxygen"]
-  },
-  "actions": {
-    "artifacts": [
-      ".bin",
-      ".dfu"
-     ],
-    "targets" : [
-      "cf2",
-      "bolt",
-      "tag"
-    ]
   }
 }


### PR DESCRIPTION
This PR introduces a new file (build_targets.json) with a list of platforms to build. This file is used both in CI and release builds.