### PR TITLE
Implement escaped percentage support in eprintf

### DIFF
--- a/src/utils/src/eprintf.c
+++ b/src/utils/src/eprintf.c
@@ -219,6 +219,12 @@ int evprintf(putc_t putcf, const char * fmt, va_list ap)
       width = 0;
 
       fmt++;
+      if (*fmt == '%') {
+        putcf(*fmt++);
+        len++;
+        continue;
+      }
+
       while ('0' == *fmt)
       {
         padChar = '0';

--- a/test/utils/src/test_eprintf.c
+++ b/test/utils/src/test_eprintf.c
@@ -258,6 +258,13 @@ void testThatAllIntTypesArePrinted() {
   verify("FFFFFFFFFFFFFFFF", "%llX", (uint64_t)0xFFFFFFFFFFFFFFFF);
 }
 
+void testThatPercentIsPrinted() {
+  // Fixture
+  // Test
+  // Assert
+  verify("This is 100% correct", "This is %d%% correct", 100);
+}
+
 //////////////////////////////
 
 static int putcMock(int c) {


### PR DESCRIPTION
The current implementation of eprintf, used among other things to print in the Crazyflie console, does not support printing the percen (%) symbol.

Traditionally, with printf, the percent symbol can be printed by doubling it "%%". This currently makes the Crazyflie crash and the unit-test framework freeze.

This PR fixes the issue by implementing the handling of "%%".