### PR TITLE
Fix prediction rate in kalman filter

### DIFF
--- a/src/modules/src/estimator_kalman.c
+++ b/src/modules/src/estimator_kalman.c
@@ -237,7 +237,11 @@ static void kalmanTask(void* parameters) {
         STATS_CNT_RATE_EVENT(&predictionCounter);
       }
 
-      nextPrediction = osTick + S2T(1.0f / PREDICT_RATE);
+      nextPrediction = nextPrediction + S2T(1.0f / PREDICT_RATE);
+      if (osTick > nextPrediction) {
+        // Overrun
+        nextPrediction = osTick + S2T(1.0f / PREDICT_RATE);
+      }
 
       if (!rateSupervisorValidate(&rateSupervisorContext, T2M(osTick))) {
         DEBUG_PRINT("WARNING: Kalman prediction rate low (%lu)\n", rateSupervisorLatestCount(&rateSupervisorContext));


### PR DESCRIPTION
This PR enforces the prediction rate in the kalman stimator. The current implementation is sensitive to temporary loads in the system and will not recover in a nice way. 

Fixes #1115 and #1112