### PR TITLE
Implement storage statistic printing on console

### DIFF
--- a/src/hal/interface/storage.h
+++ b/src/hal/interface/storage.h
@@ -97,3 +97,10 @@ typedef bool (*storageFunc_t)(const char *key, void *buffer, size_t length);
  * @return true in case of success.
  */
 bool storageForeach(const char* prefix, storageFunc_t func);
+
+/**
+ * Print storage information on the debug console
+ * 
+ * This function locks the storage while getting the stats.
+ */
+void storagePrintStats();

--- a/src/hal/src/storage.c
+++ b/src/hal/src/storage.c
@@ -27,6 +27,7 @@
  */
 
 #include "storage.h"
+#include "param.h"
 
 #include "kve/kve.h"
 
@@ -210,3 +211,40 @@ bool storageDelete(const char* key)
 
   return result;
 }
+
+void storagePrintStats()
+{
+  kveStats_t stats;
+
+  xSemaphoreTake(storageMutex, portMAX_DELAY);
+
+  kveGetStats(&kve, &stats);
+
+  xSemaphoreGive(storageMutex);
+
+
+  DEBUG_PRINT("Used storage: %d item stored, %d Bytes/%d Bytes (%d%%)\n", stats.totalItems, stats.itemSize, stats.totalSize, (stats.itemSize*100)/stats.totalSize);
+  DEBUG_PRINT("Fragmentation: %d%%\n", stats.fragmentation);
+  DEBUG_PRINT("Efficiency: Data: %d Bytes (%d%%), Keys: %d Bytes (%d%%), Metadata: %d Bytes (%d%%)\n", 
+    stats.dataSize, (stats.dataSize*100)/stats.totalSize,
+    stats.keySize, (stats.keySize*100)/stats.totalSize,
+    stats.metadataSize, (stats.metadataSize*100)/stats.totalSize);
+}
+
+static bool storageStats;
+
+static void printStats(void)
+{
+  storagePrintStats();
+
+  storageStats = false;
+}
+
+PARAM_GROUP_START(system)
+
+/**
+ * @brief Set to nonzero to dump CPU and stack usage to console
+ */
+PARAM_ADD_WITH_CALLBACK(PARAM_UINT8, storageStats, &storageStats, printStats)
+
+PARAM_GROUP_STOP(system)

--- a/src/hal/src/storage.c
+++ b/src/hal/src/storage.c
@@ -235,9 +235,11 @@ static bool storageStats;
 
 static void printStats(void)
 {
-  storagePrintStats();
+  if (storageStats) {
+    storagePrintStats();
 
-  storageStats = false;
+    storageStats = false;
+  }
 }
 
 PARAM_GROUP_START(system)

--- a/src/utils/interface/kve/kve.h
+++ b/src/utils/interface/kve/kve.h
@@ -48,3 +48,18 @@ void kveFormat(kveMemory_t *kve);
 bool kveCheck(kveMemory_t *kve);
 
 bool kveForeach(kveMemory_t *kve, const char *prefix, kveFunc_t func);
+
+typedef struct kveStats {
+    size_t totalSize;
+    size_t totalItems;
+    size_t itemSize;
+    size_t keySize;
+    size_t dataSize;
+    size_t metadataSize;
+    size_t holeSize;
+    size_t freeSpace;
+    size_t fragmentation;
+    size_t spaceLeftUntilForcedDefrag;
+} kveStats_t;
+
+void kveGetStats(kveMemory_t *kve, kveStats_t *stats);

--- a/src/utils/interface/kve/kve_storage.h
+++ b/src/utils/interface/kve/kve_storage.h
@@ -44,7 +44,9 @@
 
 #define KVE_STORAGE_INVALID_ADDRESS (SIZE_MAX)
 
-#define END_TAG_LENDTH 2
+#define KVE_END_TAG_LENDTH 2
+
+#define KVE_END_TAG (0xffffu)
 
 typedef struct itemHeader_s {
   uint16_t full_length;

--- a/src/utils/src/kve/kve_storage.c
+++ b/src/utils/src/kve/kve_storage.c
@@ -40,8 +40,6 @@ static size_t min(size_t a, size_t b)
     }
 }
 
-#define END_TAG (0xffffu)
-
 int kveStorageWriteItem(kveMemory_t *kve, size_t address, const char* key, const void* buffer, size_t length)
 {
   kveItemHeader_t header;
@@ -70,7 +68,7 @@ uint16_t kveStorageWriteHole(kveMemory_t *kve, size_t address, size_t full_lengt
 }
 
 uint16_t kveStorageWriteEnd(kveMemory_t *kve, size_t address) {
-    uint16_t endTag = END_TAG;
+    uint16_t endTag = KVE_END_TAG;
 
     kve->write(address, &endTag, 2);
 
@@ -110,7 +108,7 @@ size_t kveStorageFindItemByKey(kveMemory_t *kve, size_t address, const char * ke
         length = searchBuffer[0] + (searchBuffer[1]<<8);
         keyLength = searchBuffer[2];
 
-        if (length == END_TAG) {
+        if (length == KVE_END_TAG) {
             return SIZE_MAX;
         }
 
@@ -146,7 +144,7 @@ size_t kveStorageFindItemByPrefix(kveMemory_t *kve, size_t address,
         length = searchBuffer[0] + (searchBuffer[1]<<8);
         keyLength = searchBuffer[2];
 
-        if (length == END_TAG) {
+        if (length == KVE_END_TAG) {
             *itemAddress = SIZE_MAX;
             return SIZE_MAX;
         }
@@ -174,7 +172,7 @@ size_t kveStorageFindEnd(kveMemory_t *kve, size_t address) {
 
     while (currentAddress < (kve->memorySize - 2)) {
         kve->read(currentAddress, &header, sizeof(header));
-        if (header.full_length == END_TAG) {
+        if (header.full_length == KVE_END_TAG) {
             return currentAddress;
         }
 
@@ -213,7 +211,7 @@ size_t kveStorageFindNextItem(kveMemory_t *kve, size_t address)
 
     // Jump over the current item
     kve->read(currentAddress, &header, sizeof(header));
-    if (header.full_length == END_TAG) {
+    if (header.full_length == KVE_END_TAG) {
         return KVE_STORAGE_INVALID_ADDRESS;
     }
     currentAddress += header.full_length;
@@ -222,7 +220,7 @@ size_t kveStorageFindNextItem(kveMemory_t *kve, size_t address)
         kve->read(currentAddress, &header, sizeof(header));
 
 
-        if (header.full_length == END_TAG) {
+        if (header.full_length == KVE_END_TAG) {
             return KVE_STORAGE_INVALID_ADDRESS;
         }
 


### PR DESCRIPTION
Until now the storage subsystem was quite opaque in the sense that it is not possible to inspect its state and how much space is being used.

This PR implements a way to print storage statistics on the console. The printing is controled by setting 1 the parameter "system.storageStats". The printed values looks like:

```
STORAGE: Used storage: 46 item stored, 1394 Bytes/7168 Bytes (19%)
STORAGE: Fragmentation: 60%
STORAGE: Efficiency: Data: 387 Bytes (5%), Keys: 869 Bytes (12%), Metadata: 138 Bytes (1%)
```