### PR TITLE
Remove space in log and param names

### DIFF
--- a/src/hal/src/sensors_bmi088_bmp388.c
+++ b/src/hal/src/sensors_bmi088_bmp388.c
@@ -327,7 +327,7 @@ static void sensorsTask(void *param)
       measurement.type = MeasurementTypeGyroscope;
       measurement.data.gyroscope.gyro = sensorData.gyro;
       estimatorEnqueue(&measurement);
-      
+
       /* Acelerometer */
       accScaledIMU.x = accelRaw.x * SENSORS_BMI088_G_PER_LSB_CFG / accScale;
       accScaledIMU.y = accelRaw.y * SENSORS_BMI088_G_PER_LSB_CFG / accScale;
@@ -1005,16 +1005,16 @@ PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, BMP388, &isBarometerPresent)
 /**
  * @brief Euler angle Phi defining IMU orientation on the airframe (in degrees)
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Phi, &imuPhi)
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, imuPhi, &imuPhi)
 
 /**
  * @brief Euler angle Theta defining IMU orientation on the airframe (in degrees)
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Theta, &imuTheta)
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, imuTheta, &imuTheta)
 
 /**
  * @brief Euler angle Psi defining IMU orientation on the airframe (in degrees)
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Psi, &imuPsi)
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, imuPsi, &imuPsi)
 
 PARAM_GROUP_STOP(imu_sensors)

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -715,7 +715,7 @@ static void sensorsCalculateVarianceAndMean(BiasObj* bias, Axis3f* varOut, Axis3
     sumSq[2] += bias->buffer[i].z * bias->buffer[i].z;
   }
 
-  
+
   meanOut->x = (float) sum[0] / SENSORS_NBR_OF_BIAS_SAMPLES;
   meanOut->y = (float) sum[1] / SENSORS_NBR_OF_BIAS_SAMPLES;
   meanOut->z = (float) sum[2] / SENSORS_NBR_OF_BIAS_SAMPLES;
@@ -870,7 +870,7 @@ static void sensorsAlignToAirframe(Axis3f* in, Axis3f* out)
 {
   // IMU alignment
   static float sphi, cphi, stheta, ctheta, spsi, cpsi;
-   
+
   sphi   = sinf(imuPhi * (float) M_PI / 180);
   cphi   = cosf(imuPhi * (float) M_PI / 180);
   stheta = sinf(imuTheta * (float) M_PI / 180);
@@ -998,16 +998,16 @@ PARAM_ADD(PARAM_UINT8 | PARAM_RONLY, LPS25H, &isLPS25HTestPassed)
 /**
  * @brief Euler angle Phi defining IMU orientation on the airframe (in degrees)
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Phi, &imuPhi)
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, imuPhi, &imuPhi)
 
 /**
  * @brief Euler angle Theta defining IMU orientation on the airframe (in degrees)
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Theta, &imuTheta)
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, imuTheta, &imuTheta)
 
 /**
  * @brief Euler angle Psi defining IMU orientation on the airframe (in degrees)
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, IMU Psi, &imuPsi)
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, imuPsi, &imuPsi)
 
 PARAM_GROUP_STOP(imu_tests)

--- a/tools/verify/elf_sanity.py
+++ b/tools/verify/elf_sanity.py
@@ -187,6 +187,12 @@ def check_structs(stream, what: str, core: bool) -> dict:
                       file=sys.stderr)
                 sys.exit(1)
 
+            # Parameter and log names must not contain space as they are mapped to topic in ROS that does not support
+            # space.
+            if ' ' in name:
+                print(f'{Colors.RED}Name contains space(s){Colors.END} ("{name}")', file=sys.stderr)
+                sys.exit(1)
+
         offset += struct_len
     return name_type_dict
 


### PR DESCRIPTION
This PR adds a test to make sure there are no spaces in log or param names. The reason that this is important is that the names are used as topics in ROS (when using Crazyswarm) and topics must not contain space.

The newly added parameters "IMU Phi", "IMU Theta" and "IMU PSI" have also been renamed.