### PR TITLE
Bugfix flapper power distribution

### DIFF
--- a/src/modules/src/power_distribution_flapper.c
+++ b/src/modules/src/power_distribution_flapper.c
@@ -103,7 +103,7 @@ static int8_t limitRollBias(uint8_t value)
 int powerDistributionMotorType(uint32_t id)
 {
   int type = 0;
-  if (id == (idPitch || idYaw)) type = 1;
+  if (id != (idPitch || idYaw)) type = 1;
   return type;
 }
 

--- a/src/modules/src/power_distribution_flapper.c
+++ b/src/modules/src/power_distribution_flapper.c
@@ -66,10 +66,10 @@ static float pitch_ampl = 0.4f; // 1 = full servo stroke
 
 #if CONFIG_POWER_DISTRIBUTION_FLAPPER_REVB
   uint32_t idPitch = 1;
-  uint32_t idYaw = 4;
+  uint32_t idYaw = 2;
 #else
-  uint32_t idPitch = 2;
-  uint32_t idYaw = 4;
+  uint32_t idPitch = 0;
+  uint32_t idYaw = 2;
 #endif
 
 static uint8_t limitServoNeutral(uint8_t value)


### PR DESCRIPTION
This PR fixes a bug introduced in #1132 and affecting only the newly introduced flapper platform.

After the changes requested by the reviewers, the `motorsStop()` function was not working as intended with the flapper platform.
The motor mapping in the newly introduced `powerDistributionStopRatio(id)` and `powerDistributionMotorType(id)` functions was incorrect, and is fixed in this PR.
