### PR TITLE
added actions to publish python bindings

### DIFF
--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -1,0 +1,164 @@
+name: build bindings
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      guard:
+        description: 'Do not run manually. Run "publish" to publish on Pypi'
+        required: true
+      repository_url:
+        description: 'URL of the pypi repository to upload to'     
+        required: true
+        default: 'https://test.pypi.org/legacy/'
+
+jobs:
+  Source:
+    runs-on: ubuntu-20.04
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install sdist dependencies
+      run: pip3 install setuptools
+
+    - name: Generate source distribution tarball
+      run: python3 bindings/setup.py sdist
+    
+    - name: Build source distribution
+      run: |
+        sudo apt-get install -y libusb-1.0-0-dev ninja-build
+        pip3 install wheel
+        pip3 wheel dist/*.tar.gz
+
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        name: source-build
+        path: "dist/*.tar.gz"
+
+  Linux:
+    runs-on: ubuntu-latest
+    needs: Source
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    
+    - name: Pull builder image
+      run: docker pull quay.io/pypa/manylinux2014_x86_64
+
+    - name: Build wheels
+      run: tools/build/build-wheels.sh
+
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        name: linux-build
+        path: "dist/*.whl"
+  
+  MacOS:
+    runs-on: macos-10.15
+    needs: Source
+
+    strategy:
+      matrix:
+        python: [3.8, 3.9, 3.10]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          brew install python@${{ matrix.python }} sdl2 libusb
+          brew link --overwrite python@${{ matrix.python }}
+          pip3 install cmake ninja wheel
+      
+      - name: Build
+        run: python3 bindings/setup.py bdist_wheel
+      
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2.1.4
+        with:
+          name: macos-build
+          path: "dist/*.whl"
+
+  Windows:
+    runs-on: windows-2019
+    needs: Source
+
+    strategy:
+      matrix:
+        python: [3.7, 3.8, 3.9, 3.10]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: |
+          pip install wheel
+
+      - name: Build
+        run: python bindings/setup.py bdist_wheel
+      
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2.1.4
+        with:
+          name: win-build
+          path: "dist/*.whl"
+  
+  Publish:
+    runs-on: ubuntu-20.04
+    needs: [Source, Linux, MacOS, Windows]
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.guard == 'do-release' }}
+
+    steps:    
+    - uses: actions/download-artifact@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Check match between the build version and the current git tag
+      run: |
+        sudo apt-get install -y jq
+        pip3 install wheel-inspect
+        
+        export TAG=$(echo ${{ github.ref }} | cut -d/ -f3)
+        python3 -m wheel_inspect *-build/*.whl | jq .version | grep ^\\\"$TAG\\\"$
+
+
+    - name: Publish on Pypi
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        pip3 install setuptools
+        pip3 install twine
+        
+        python3 -m twine check source-build/*
+        python3 -m twine check linux-build/*
+        python3 -m twine check macos-build/*
+        python3 -m twine check win-build/*
+        
+        python3 -m twine upload --skip-existing --repository-url ${{ github.event.inputs.repository_url }} source-build/*
+        python3 -m twine upload --skip-existing --repository-url ${{ github.event.inputs.repository_url }} linux-build/*
+        python3 -m twine upload --skip-existing --repository-url ${{ github.event.inputs.repository_url }} macos-build/*
+        python3 -m twine upload --skip-existing --repository-url ${{ github.event.inputs.repository_url }} win-build/*
+

--- a/.github/workflows/publish_bindings.yml
+++ b/.github/workflows/publish_bindings.yml
@@ -1,0 +1,37 @@
+name: publish bindings
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release. Must match the version in the version file!'
+        required: true
+      destination:
+        description: 'Release destination, "testing" for test.pypi.org, "release" for pypi.org.'     
+        required: true
+        default: 'testing'
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Start the build workflow for publishing to testing
+      if: ${{ github.event.inputs.destination == 'testing' }}
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: build bindings
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: ${{ github.event.inputs.tag }}
+        inputs: '{ "guard": "do-release", "repository_url": "https://test.pypi.org/legacy/" }'
+    
+    - name: Start the build bindings workflow for publishing to Pypi
+      if: ${{ github.event.inputs.destination == 'release' }}
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: build bindings
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: ${{ github.event.inputs.tag }}
+        inputs: '{ "guard": "do-release", "repository_url": "https://upload.pypi.org/legacy/" }'
+
+

--- a/tools/build/build-wheels.sh
+++ b/tools/build/build-wheels.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+
+DOCKER=docker
+
+# Prefer running with podman
+if which podman
+then
+    DOCKER=podman
+fi
+
+# Test if we are currently in the builder image
+if [ ! -d /opt/python ]
+then
+    # We are not in the image, start the image with the build script
+    $DOCKER run --rm -v $(realpath $(dirname $0)/../..):/io quay.io/pypa/manylinux2014_x86_64 /io/tools/build/build-wheels.sh
+else
+    # We are in the image, building!
+    yum install -y libusbx-devel
+
+    cd /io
+
+    PREV_PATH=$PATH
+
+    for PYBIN in /opt/python/cp{36,37,38,39}*/bin; do
+        PATH=${PYBIN}:$PREV_PATH
+        rm -rf build/
+        "${PYBIN}/pip" install -U "setuptools>=42" wheel ninja "cmake>=3.12"
+        "${PYBIN}/python" bindings/setup.py bdist_wheel
+    done
+
+    WHEELS=$(echo dist/*.whl)
+
+    for whl in $WHEELS; do
+        auditwheel repair "$whl" -w dist/
+    done
+
+    rm $WHEELS
+fi


### PR DESCRIPTION
These are proposed actions to publish the cffirmware as a pypi package, shamelessly copied from @ataffanel's implementation on [crazyflie-link-cpp](https://github.com/bitcraze/crazyflie-link-cpp). For simulation we would like to make it easier to install the bindings so that we can implement it better into webots/crazyswarm2

This probably needs some discussion... so let's see :)