### PR TITLE
Improvements for the Upgrade Kit

### DIFF
--- a/src/drivers/interface/motors.h
+++ b/src/drivers/interface/motors.h
@@ -58,10 +58,6 @@
 #define MOTORS_TIM_DBG_CFG        DBGMCU_APB2PeriphConfig
 #define MOTORS_GPIO_AF_CFG(a,b,c) GPIO_PinAFConfig(a,b,c)
 
-// Compensate thrust depending on battery voltage so it will produce about the same
-// amount of thrust independent of the battery voltage. Based on thrust measurement.
-// Not applied for brushless motor setup.
-#define ENABLE_THRUST_BAT_COMPENSATED
 
 #ifdef CONFIG_MOTORS_ESC_PROTOCOL_ONESHOT125
 /**

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -170,7 +170,7 @@ GPIO_InitTypeDef GPIO_PassthroughOutput =
 // Voltage needed with the Supply voltage.
 float motorsCompensateBatteryVoltage(uint32_t id, float iThrust, float supplyVoltage)
 {
-  #ifdef ENABLE_THRUST_BAT_COMPENSATED
+  #ifdef CONFIG_ENABLE_THRUST_BAT_COMPENSATED
   ASSERT(id < NBR_OF_MOTORS);
 
   if (motorMap[id]->drvType == BRUSHED)

--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -162,6 +162,15 @@ config POWER_DISTRIBUTION_FLAPPER_REVB
     help
         Power distribution function for Flapper Nimble+ with revB PCB
 
+config ENABLE_THRUST_BAT_COMPENSATED
+    bool "Enable battery thrust compensation"
+    default y
+    help
+        Compensate thrust depending on battery voltage so it will produce about the same
+        amount of thrust independent of the battery voltage.
+        The compensation is based on thrust measurements, which are only valid for CF2.X stock configuration.
+        Not applied for brushless motor setup.
+
 endmenu
 
 menu "Parameter subsystem"

--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -334,7 +334,7 @@ PARAM_ADD_CORE(PARAM_UINT8, startBatTest, &startBatTest)
 /**
  * @brief PWM ratio to use when testing propellers. Required for brushless motors. [0 - UINT16_MAX]
  */
-PARAM_ADD_CORE(PARAM_UINT16, propTestPWMRatio, &propTestPWMRatio)
+PARAM_ADD_CORE(PARAM_UINT16 | PARAM_PERSISTENT, propTestPWMRatio, &propTestPWMRatio)
 
 PARAM_GROUP_STOP(health)
 


### PR DESCRIPTION
This PR makes the parameter `propTestPWMRatio` persistent, which is useful for the upgrade kit, when performing the propeller test. For this test to work properly on the stronger motors and different propellers, this parameter should be set to a different value, eg 30000.

This PR also moves the flag to enable/disable battery thrust compensation from `motor.h` to Kbuild