### PR TITLE
Fix GAP8 flashing problems

### DIFF
--- a/src/utils/interface/buf2buf.h
+++ b/src/utils/interface/buf2buf.h
@@ -1,0 +1,120 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * buf2buf.h - utility for copying buffers when transferring data from one buffer size to another.
+ * Incoming buffers have one size while outgoing buffers have a different size.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct {
+    const uint8_t* inBuf;
+    uint32_t inBufIndex;
+    uint32_t inBufSize;
+    uint32_t added;
+
+    uint8_t* outBuf;
+    uint32_t outBufIndex;
+    uint32_t outBufSize;
+    uint32_t consumed;
+} Buf2bufContext_t;
+
+/**
+ * @brief Initialize a context
+ *
+ * This function must be called first to initialize the context.
+ * A pointer to the out-buffer will be stored in the context and the out-buffer should not be modified until released.
+ *
+ * @param context A new context
+ * @param outBuf Pointer to the out buffer (reused over and over)
+ * @param outBufSize The size of the out buffer
+ */
+void buf2bufInit(Buf2bufContext_t* context, uint8_t* outBuf, const uint32_t outBufSize);
+
+/**
+ * @brief Add a new in-buffer
+ *
+ * Call this function when a new in-buffer is available. The pointer to the in-buffer will be stored in the context
+ * and the in-buffer should not be modified until released by a call to buf2bufReleaseInBuf().
+ *
+ * @param context The context
+ * @param inBuf Pointer to the in-buffer
+ * @param inBufSize The size of the in-buffer
+ */
+void buf2bufAddInBuf(Buf2bufContext_t* context, const uint8_t* inBuf, const uint32_t inBufSize);
+
+/**
+ * @brief Consume data from the in-buffer
+ *
+ * Copy data from the in-buffer to the out-buffer, may have to be called multiple times if the out-buffer can not
+ * hold all the data from the in-buffer. If this function returns true, the out-buffer is full and is ready to be
+ * emptied by the application code. This function should be called repeatedly until it returns false which indicates
+ * that the in-buffer is fully consumed.
+ *
+ * @param context The context
+ * @return true The out buffer is full and ready to be used
+ * @return false The in buffer is fully consumed
+ */
+bool buf2bufConsumeInBuf(Buf2bufContext_t* context);
+
+/**
+ * @brief Release the in-buffer
+ *
+ * Call when in-buffer has been fully consumed to release the in-buffer.
+ *
+ * @param context The context
+ */
+void buf2bufReleaseInBuf(Buf2bufContext_t* context);
+
+/**
+ * @brief Release the out-buffer
+ *
+ * Will release the out-buffer and return the number of bytes of data that remains to be emptied by the application
+ * code.
+ *
+ * @param context
+ * @return uint32_t
+ */
+uint32_t buf2bufReleaseOutBuf(Buf2bufContext_t* context);
+
+/**
+ * @brief The total number of bytes added by in-buffers
+ *
+ * @param context The context
+ * @return uint32_t The number of bytes
+ */
+static inline uint32_t buf2bufBytesAdded(const Buf2bufContext_t* context) {
+    return context->added;
+}
+
+/**
+ * @brief The total number of bytes consumed from in-buffers
+ *
+ * @param context The context
+ * @return uint32_t The number of bytes
+ */
+static inline uint32_t buf2bufBytesConsumed(const Buf2bufContext_t* context) {
+    return context->consumed;
+}

--- a/src/utils/src/Kbuild
+++ b/src/utils/src/Kbuild
@@ -5,7 +5,7 @@ obj-y += cpuid.o
 obj-y += crc32.o
 obj-y += debug.o
 obj-y += eprintf.o
-
+obj-y += buf2buf.o
 ### Implementations for abort(), malloc() and free(), needed to interact with apps written in C++
 obj-y += abort.o
 obj-y += malloc.o

--- a/src/utils/src/buf2buf.c
+++ b/src/utils/src/buf2buf.c
@@ -1,0 +1,110 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <string.h>
+#include "buf2buf.h"
+
+void buf2bufInit(Buf2bufContext_t* context, uint8_t* outBuf, const uint32_t outBufSize) {
+    context->outBuf = outBuf;
+    context->outBufSize = outBufSize;
+    context->outBufIndex = 0;
+
+    context->inBuf = 0;
+    context->inBufSize = 0;
+    context->inBufIndex = 0;
+
+    context->consumed = 0;
+    context->added = 0;
+}
+
+
+void buf2bufAddInBuf(Buf2bufContext_t* context, const uint8_t* inBuf, const uint32_t inBufSize) {
+    context->inBuf = inBuf;
+    context->inBufSize = inBufSize;
+    context->inBufIndex = 0;
+    context->added += inBufSize;
+}
+
+
+bool buf2bufConsumeInBuf(Buf2bufContext_t* context) {
+    const uint32_t dataLeftIn = context->inBufSize - context->inBufIndex;
+    const uint32_t spaceLeftOut = context->outBufSize - context->outBufIndex;
+
+    uint32_t copySize = dataLeftIn;
+    if (spaceLeftOut < dataLeftIn) {
+        copySize = spaceLeftOut;
+    }
+
+    memcpy(&context->outBuf[context->outBufIndex], &context->inBuf[context->inBufIndex], copySize);
+    context->inBufIndex += copySize;
+    context->outBufIndex += copySize;
+    context->consumed += copySize;
+
+    const bool isOutBufFull = (context->outBufIndex == context->outBufSize);
+    if (isOutBufFull) {
+        context->outBufIndex = 0;
+    }
+
+    return isOutBufFull;
+}
+
+
+void buf2bufReleaseInBuf(Buf2bufContext_t* context) {
+    context->inBuf = 0;
+    context->inBufSize = 0;
+    context->inBufIndex = 0;
+}
+
+
+uint32_t buf2bufReleaseOutBuf(Buf2bufContext_t* context) {
+    context->outBuf = 0;
+
+    return context->outBufIndex;
+}
+
+
+#define OUTBUFSIZE 1000
+static uint8_t outBuf[OUTBUFSIZE];
+static Buf2bufContext_t context;
+void handleInBuffer(const uint32_t memAddr, const uint8_t inBufDataLen, const uint8_t *inBuf, const uint32_t totSize) {
+    const bool isFirstBuf = (memAddr == 0);
+    if (isFirstBuf) {
+        buf2bufInit(&context, outBuf, OUTBUFSIZE);
+    }
+
+    buf2bufAddInBuf(&context, inBuf, inBufDataLen);
+    while(buf2bufConsumeInBuf(&context)) {
+        // send(outbuf, OUTBUFSIZE);
+    }
+    buf2bufReleaseInBuf(&context);
+
+    const bool isLastBuf = (memAddr + inBufDataLen >= totSize);
+    if (isLastBuf) {
+        uint32_t size = buf2bufReleaseOutBuf(&context);
+        if (size > 0) {
+            // send(outbuf, size);
+        }
+    }
+}

--- a/test/utils/src/test_buf2buf.c
+++ b/test/utils/src/test_buf2buf.c
@@ -1,0 +1,184 @@
+/**
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2022 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Unit tests for buf2buf
+ */
+
+// Module under test
+#include "buf2buf.h"
+
+#include "unity.h"
+#include <string.h>
+
+static Buf2bufContext_t context;
+
+#define IN_BUF_SIZE 100
+static uint8_t inBuf[IN_BUF_SIZE];
+
+#define OUT_BUF_SIZE 100
+static uint8_t outBuf[OUT_BUF_SIZE];
+
+// Helpers
+
+static void validateStdUseCase(uint32_t inBufSize, uint32_t nrOfInBufs, uint32_t outBufSize);
+
+void setUp(void) {
+  for (int i = 0; i < IN_BUF_SIZE; i++) {
+    inBuf[i] = i + 1;
+  }
+
+  memset(outBuf, 0, sizeof(outBuf));
+  memset(&context, 0, sizeof(context));
+}
+
+void tearDown(void) {}
+
+void testThatASmallInBufferIsNotFillingLargeOutBuffer() {
+  // Fixture
+  buf2bufInit(&context, outBuf, 10);
+
+  // Test
+  buf2bufAddInBuf(&context, inBuf, 4);
+  bool actual = buf2bufConsumeInBuf(&context);
+
+  // Assert
+  TEST_ASSERT_FALSE(actual);
+}
+
+void testThatEqualSizeInAndOutBufferFillsOutBuffer() {
+  // Fixture
+  buf2bufInit(&context, outBuf, 10);
+
+  // Test
+  buf2bufAddInBuf(&context, inBuf, 10);
+  bool actual = buf2bufConsumeInBuf(&context);
+
+  // Assert
+  TEST_ASSERT_TRUE(actual);
+}
+
+void testThatALargeInBufferFillsSmallerOutBuffer() {
+  // Fixture
+  buf2bufInit(&context, outBuf, 10);
+
+  // Test
+  buf2bufAddInBuf(&context, inBuf, 15);
+  bool actual = buf2bufConsumeInBuf(&context);
+
+  // Assert
+  TEST_ASSERT_TRUE(actual);
+}
+
+void testThatMultipleSmallInBufferFillsOutBuffer() {
+  // Fixture
+  buf2bufInit(&context, outBuf, 10);
+
+  // Test
+  buf2bufAddInBuf(&context, inBuf, 7);
+  bool actual1 = buf2bufConsumeInBuf(&context);
+
+  buf2bufAddInBuf(&context, inBuf, 7);
+  bool actual2 = buf2bufConsumeInBuf(&context);
+
+  // Assert
+  TEST_ASSERT_FALSE(actual1);
+  TEST_ASSERT_TRUE(actual2);
+}
+
+void testThatOutBufferWithDataReportsSizeWhenReleased() {
+  // Fixture
+  buf2bufInit(&context, outBuf, 10);
+
+  buf2bufAddInBuf(&context, inBuf, 4);
+  buf2bufConsumeInBuf(&context);
+
+  buf2bufAddInBuf(&context, inBuf, 4);
+  buf2bufConsumeInBuf(&context);
+
+  // Test
+  uint32_t actual = buf2bufReleaseOutBuf(&context);
+
+  // Assert
+  TEST_ASSERT_EQUAL_UINT32(8, actual);
+}
+
+void testStdUseCaseWithVariousConfigurations() {
+  // Same buffer size
+  validateStdUseCase(5, 5, 5);
+
+  // Smaller in buffer than out buffer
+  validateStdUseCase(5, 10, 7);
+
+  // Our buffer multiple size of in buffer
+  validateStdUseCase(4, 5, 8);
+
+  // In buffer multiple size of out buffer
+  validateStdUseCase(8, 5, 4);
+
+  // Larger in buffer than out buffer
+  validateStdUseCase(7, 10, 5);
+
+  // Last in buffer overflows into new out buffer
+  validateStdUseCase(5, 2, 7);
+
+  // Last in buffer fits in out buffer
+  validateStdUseCase(5, 3, 8);
+}
+
+// Helpers -------------------------------
+
+static void validateStdUseCase(uint32_t inBufSize, uint32_t nrOfInBufs, uint32_t outBufSize) {
+  TEST_ASSERT_LESS_OR_EQUAL(IN_BUF_SIZE, inBufSize);
+  TEST_ASSERT_LESS_OR_EQUAL(OUT_BUF_SIZE, outBufSize);
+
+  // Buffers for concatenating all in and out buffers, will be compared at the end
+  uint8_t concatInBufs[inBufSize * nrOfInBufs];
+  uint8_t concatOutBufs[inBufSize * nrOfInBufs];
+
+  uint32_t inIndex = 0;
+  uint32_t outIndex = 0;
+
+  buf2bufInit(&context, outBuf, outBufSize);
+
+  // Simulate a bunch of in buffers
+  for (uint32_t i = 0; i < nrOfInBufs; i++) {
+    memcpy(&concatInBufs[inIndex], inBuf, inBufSize);
+    inIndex += inBufSize;
+
+    buf2bufAddInBuf(&context, inBuf, inBufSize);
+    while(buf2bufConsumeInBuf(&context)) {
+      // Store out buffers
+      memcpy(&concatOutBufs[outIndex], outBuf, outBufSize);
+      outIndex += outBufSize;
+    }
+    buf2bufReleaseInBuf(&context);
+  }
+
+  // Store the last potential out buffer
+  uint32_t size = buf2bufReleaseOutBuf(&context);
+  memcpy(&concatOutBufs[outIndex], outBuf, size);
+  outIndex += size;
+
+  TEST_ASSERT_EQUAL_UINT32(inIndex, outIndex);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(concatInBufs, concatOutBufs, inIndex);
+}


### PR DESCRIPTION
This PR fixes bugs in the GAP8 flashing of the AI-deck. 

In teh current implementation some file sizes will fail to flash due to a buffer problem.

This PR also intriduces a generic utility that handles copying between buffers of different sizes in a structured way.

Fixes bitcraze/aideck-gap8-examples#104