### PR TITLE
Unify controller and estimator function names

### DIFF
--- a/src/modules/interface/controller.h
+++ b/src/modules/interface/controller.h
@@ -43,7 +43,7 @@ void controller(control_t *control, setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);
-ControllerType getControllerType(void);
+ControllerType controllerGetType(void);
 const char* controllerGetName();
 
 #endif //__CONTROLLER_H__

--- a/src/modules/interface/estimator.h
+++ b/src/modules/interface/estimator.h
@@ -79,7 +79,7 @@ void stateEstimatorInit(StateEstimatorType estimator);
 bool stateEstimatorTest(void);
 void stateEstimatorSwitchTo(StateEstimatorType estimator);
 void stateEstimator(state_t *state, const uint32_t tick);
-StateEstimatorType getStateEstimator(void);
+StateEstimatorType stateEstimatorGetType(void);
 const char* stateEstimatorGetName();
 
 // Support to incorporate additional sensors into the state estimate via the following functions

--- a/src/modules/src/controller.c
+++ b/src/modules/src/controller.c
@@ -65,7 +65,7 @@ void controllerInit(ControllerType controller) {
   DEBUG_PRINT("Using %s (%d) controller\n", controllerGetName(), currentController);
 }
 
-ControllerType getControllerType(void) {
+ControllerType controllerGetType(void) {
   return currentController;
 }
 

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -127,7 +127,7 @@ void stateEstimatorSwitchTo(StateEstimatorType estimator) {
   DEBUG_PRINT("Using %s (%d) estimator\n", stateEstimatorGetName(), currentEstimator);
 }
 
-StateEstimatorType getStateEstimator(void) {
+StateEstimatorType stateEstimatorGetType(void) {
   return currentEstimator;
 }
 

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -182,8 +182,8 @@ void stabilizerInit(StateEstimatorType estimator)
   powerDistributionInit();
   motorsInit(platformConfigGetMotorMapping());
   collisionAvoidanceInit();
-  estimatorType = getStateEstimator();
-  controllerType = getControllerType();
+  estimatorType = stateEstimatorGetType();
+  controllerType = controllerGetType();
 
   STATIC_MEM_TASK_CREATE(stabilizerTask, stabilizerTask, STABILIZER_TASK_NAME, NULL, STABILIZER_TASK_PRI);
 
@@ -271,14 +271,14 @@ static void stabilizerTask(void* param)
       healthRunTests(&sensorData);
     } else {
       // allow to update estimator dynamically
-      if (getStateEstimator() != estimatorType) {
+      if (stateEstimatorGetType() != estimatorType) {
         stateEstimatorSwitchTo(estimatorType);
-        estimatorType = getStateEstimator();
+        estimatorType = stateEstimatorGetType();
       }
       // allow to update controller dynamically
-      if (getControllerType() != controllerType) {
+      if (controllerGetType() != controllerType) {
         controllerInit(controllerType);
-        controllerType = getControllerType();
+        controllerType = controllerGetType();
       }
 
       stateEstimator(&state, tick);


### PR DESCRIPTION
getControllerType -> controllerGetType
getStateEstimator -> stateEstimatorGetType

so that global/public functions start with a common prefix