### PR TITLE
Refactor controller update to take const setpoint

### DIFF
--- a/src/modules/interface/controller.h
+++ b/src/modules/interface/controller.h
@@ -39,7 +39,7 @@ typedef enum {
 
 void controllerInit(ControllerType controller);
 bool controllerTest(void);
-void controller(control_t *control, setpoint_t *setpoint,
+void controller(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);

--- a/src/modules/interface/controller_brescianini.h
+++ b/src/modules/interface/controller_brescianini.h
@@ -41,7 +41,7 @@
 void controllerBrescianiniInit(void);
 bool controllerBrescianiniTest(void);
 void controllerBrescianini(control_t *control,
-                        setpoint_t *setpoint,
+                        const setpoint_t *setpoint,
                         const sensorData_t *sensors,
                         const state_t *state,
                         const uint32_t tick);

--- a/src/modules/interface/controller_indi.h
+++ b/src/modules/interface/controller_indi.h
@@ -109,7 +109,7 @@ struct IndiVariables {
 
 void controllerINDIInit(void);
 bool controllerINDITest(void);
-void controllerINDI(control_t *control, setpoint_t *setpoint,
+void controllerINDI(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);

--- a/src/modules/interface/controller_mellinger.h
+++ b/src/modules/interface/controller_mellinger.h
@@ -30,7 +30,7 @@
 
 void controllerMellingerInit(void);
 bool controllerMellingerTest(void);
-void controllerMellinger(control_t *control, setpoint_t *setpoint,
+void controllerMellinger(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);

--- a/src/modules/interface/controller_pid.h
+++ b/src/modules/interface/controller_pid.h
@@ -30,7 +30,7 @@
 
 void controllerPidInit(void);
 bool controllerPidTest(void);
-void controllerPid(control_t *control, setpoint_t *setpoint,
+void controllerPid(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick);

--- a/src/modules/interface/position_controller.h
+++ b/src/modules/interface/position_controller.h
@@ -33,9 +33,9 @@
 void positionControllerInit();
 void positionControllerResetAllPID();
 void positionControllerResetAllfilters();
-void positionController(float* thrust, attitude_t *attitude, setpoint_t *setpoint,
+void positionController(float* thrust, attitude_t *attitude, const setpoint_t *setpoint,
                                                              const state_t *state);
-void velocityController(float* thrust, attitude_t *attitude, setpoint_t *setpoint,
+void velocityController(float* thrust, attitude_t *attitude, const Axis3f *setpoint_velocity,
                                                              const state_t *state);
 
 #endif /* POSITION_CONTROLLER_H_ */

--- a/src/modules/interface/position_controller_indi.h
+++ b/src/modules/interface/position_controller_indi.h
@@ -80,7 +80,7 @@ struct IndiOuterVariables {
 
 void positionControllerINDIInit(void);
 void positionControllerINDI(const sensorData_t *sensors,
-                            setpoint_t *setpoint,
+                            const setpoint_t *setpoint,
                             const state_t *state, 
                             vector_t *refOuterINDI);
 

--- a/src/modules/src/controller.c
+++ b/src/modules/src/controller.c
@@ -18,7 +18,7 @@ static void initController();
 typedef struct {
   void (*init)(void);
   bool (*test)(void);
-  void (*update)(control_t *control, setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick);
+  void (*update)(control_t *control, const setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick);
   const char* name;
 } ControllerFcns;
 
@@ -77,7 +77,7 @@ bool controllerTest(void) {
   return controllerFunctions[currentController].test();
 }
 
-void controller(control_t *control, setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick) {
+void controller(control_t *control, const setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick) {
   controllerFunctions[currentController].update(control, setpoint, sensors, state, tick);
 }
 

--- a/src/modules/src/controller_brescianini.c
+++ b/src/modules/src/controller_brescianini.c
@@ -94,7 +94,7 @@ void controllerBrescianiniInit(void) {
 
 
 void controllerBrescianini(control_t *control,
-                                 setpoint_t *setpoint,
+                                 const setpoint_t *setpoint,
                                  const sensorData_t *sensors,
                                  const state_t *state,
                                  const uint32_t tick) {

--- a/src/modules/src/controller_indi.c
+++ b/src/modules/src/controller_indi.c
@@ -142,7 +142,7 @@ bool controllerINDITest(void)
 	return pass;
 }
 
-void controllerINDI(control_t *control, setpoint_t *setpoint,
+void controllerINDI(control_t *control, const setpoint_t *setpoint,
 	const sensorData_t *sensors,
 	const state_t *state,
 	const uint32_t tick)

--- a/src/modules/src/controller_mellinger.c
+++ b/src/modules/src/controller_mellinger.c
@@ -121,7 +121,7 @@ bool controllerMellingerTest(void)
   return true;
 }
 
-void controllerMellinger(control_t *control, setpoint_t *setpoint,
+void controllerMellinger(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick)

--- a/src/modules/src/controller_pid.c
+++ b/src/modules/src/controller_pid.c
@@ -53,7 +53,7 @@ static float capAngle(float angle) {
   return result;
 }
 
-void controllerPid(control_t *control, setpoint_t *setpoint,
+void controllerPid(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const uint32_t tick)

--- a/src/modules/src/position_controller_indi.c
+++ b/src/modules/src/position_controller_indi.c
@@ -116,7 +116,7 @@ void positionControllerINDIInit(void)
 
 
 void positionControllerINDI(const sensorData_t *sensors,
-                            setpoint_t *setpoint,
+                            const setpoint_t *setpoint,
                             const state_t *state, 
                             vector_t *refOuterINDI){ 
 


### PR DESCRIPTION
The update function of controllers should not alter the setpoint itself.
This could lead to unexpected behavior and makes the Python interface for
software-in-the-loop simulation less clean.

The change itself is simple, apart from the PID velocity controller.
Here, there is a small behavior change: when logging, the user-specified setpoint will be shown, not
the intermedate value altered by the controller.
However, this seems to be the more logical behavior and is consistent
with the behavior of all other controllers that compute intermediate
setpoints (e.g., position controller of mellinger
 computes intermediate angles).