### PR TITLE
Added function to start battery autoupdate to avoid syslink queue overflow.

### DIFF
--- a/src/hal/src/pm_stm32f4.c
+++ b/src/hal/src/pm_stm32f4.c
@@ -256,6 +256,15 @@ static void pmGracefulShutdown()
   syslinkSendPacket(&slp);
 }
 
+static void pmEnableBatteryStatusAutoupdate()
+{
+  SyslinkPacket slp = {
+    .type = SYSLINK_PM_BATTERY_AUTOUPDATE,
+  };
+
+  syslinkSendPacket(&slp);
+}
+
 void pmSyslinkUpdate(SyslinkPacket *slp)
 {
   if (slp->type == SYSLINK_PM_BATTERY_STATE) {
@@ -398,6 +407,10 @@ void pmTask(void *param)
 
   pmSetChargeState(charge500mA);
   systemWaitStart();
+
+  // Continuous battery voltage and status messages must be enabled
+  // after system startup to avoid syslink queue overflow.
+  pmEnableBatteryStatusAutoupdate();
 
   while(1)
   {


### PR DESCRIPTION
Part of fixing https://github.com/bitcraze/crazyflie2-nrf-firmware/issues/78.

Before the nRF was sending battery status and RSSI messages to STM over syslink after a startup delay. Now a activation message must be sent to avoid a syslink queue overflow.