### PR TITLE
Support to configure ESCs with BLHeli Configurator

### DIFF
--- a/src/modules/interface/msp.h
+++ b/src/modules/interface/msp.h
@@ -93,4 +93,8 @@ void mspInit(MspObject* pMspObject, const MspResponseCallback callback);
  */
 void mspProcessByte(MspObject* pMspObject, const uint8_t data);
 
+/*
+*/
+bool mspHasSet4WayIf();
+
 #endif /* MSP_H_ */

--- a/src/modules/interface/msp.h
+++ b/src/modules/interface/msp.h
@@ -99,4 +99,7 @@ void mspProcessByte(MspObject* pMspObject, const uint8_t data);
  */
 bool mspHasSet4WayIf();
 
+
+void mspResetSet4WayIf();
+
 #endif /* MSP_H_ */

--- a/src/modules/interface/msp.h
+++ b/src/modules/interface/msp.h
@@ -94,7 +94,9 @@ void mspInit(MspObject* pMspObject, const MspResponseCallback callback);
 void mspProcessByte(MspObject* pMspObject, const uint8_t data);
 
 /*
-*/
+ * Returns true if the MSP_SET_4WAY_IF request has been answered.
+ * This information can be useful to know whether the connection phase of BLHeli Configurator has been completed.
+ */
 bool mspHasSet4WayIf();
 
 #endif /* MSP_H_ */

--- a/src/modules/src/msp.c
+++ b/src/modules/src/msp.c
@@ -254,6 +254,11 @@ bool mspHasSet4WayIf()
   return hasSet4WayIf;
 }
 
+void mspResetSet4WayIf()
+{
+  hasSet4WayIf = false;
+}
+
 // Private
 static uint8_t mspComputeCrc(uint8_t* pBuffer, uint32_t bufferLen)
 {

--- a/src/modules/src/msp.c
+++ b/src/modules/src/msp.c
@@ -227,6 +227,7 @@ bool mspHasSet4WayIf()
 }
 
 // Private
+static uint8_t mspComputeCrc(uint8_t* pBuffer, uint32_t bufferLen)
 {
   uint8_t crc = 0;
 
@@ -254,7 +255,7 @@ bool mspHasSet4WayIf()
   return crc;
 }
 
-bool mspIsRequestValid(MspObject* pMspObject)
+static bool mspIsRequestValid(MspObject* pMspObject)
 {
   if(pMspObject->requestHeader.preamble[0] != MSP_PREAMBLE_0 ||
       pMspObject->requestHeader.preamble[1] != MSP_PREAMBLE_1)
@@ -289,7 +290,7 @@ bool mspIsRequestValid(MspObject* pMspObject)
   return true;
 }
 
-void mspProcessRequest(MspObject* pMspObject)
+static void mspProcessRequest(MspObject* pMspObject)
 {
   if(!mspIsRequestValid(pMspObject))
   {
@@ -349,7 +350,7 @@ void mspProcessRequest(MspObject* pMspObject)
 
 }
 
-void mspHandleRequestMspStatus(MspObject* pMspObject)
+static void mspHandleRequestMspStatus(MspObject* pMspObject)
 {
   MspHeader* pHeader = (MspHeader*)pMspObject->mspResponse;
   MspStatus* pData = (MspStatus*)(pMspObject->mspResponse + sizeof(MspHeader));
@@ -376,7 +377,7 @@ void mspHandleRequestMspStatus(MspObject* pMspObject)
   pMspObject->mspResponseSize = sizeof(MspHeader) + sizeof(*pData) + 1;
 }
 
-void mspHandleRequestMspRc(MspObject* pMspObject)
+static void mspHandleRequestMspRc(MspObject* pMspObject)
 {
   MspHeader* pHeader = (MspHeader*)pMspObject->mspResponse;
   MspRc* pData = (MspRc*)(pMspObject->mspResponse + sizeof(MspHeader));

--- a/src/modules/src/vcp_esc_passthrough.c
+++ b/src/modules/src/vcp_esc_passthrough.c
@@ -184,6 +184,7 @@ static void blHeliConfigHandshake()
   {
     uint8_t byte = readByteBlocking();
     mspProcessByte(&pMspObject, byte);
-    vTaskDelay(M2T(2));
   }
+
+  mspResetSet4WayIf();
 }


### PR DESCRIPTION
This PR adds the ability to configure ESCs through BLHeli Configurator, which has a nicer UI than BLHeliSuite. BLHeli Configurator also runs nicely on Linux, compared to BLHeliSuite which must be used with something like `wine` to work.

To make the BLHeli Configurator recognize the Crazyflie, a "handshake" must first be done upon serial connection. This handshake follows the MSP extension protocol. I have reveresed engineered the protocol using BLHeli Configurator, so I'm not exactly sure which version I have really implemented.

I have tested to configure and flash the ESCs with the BOLT platform and it works OK.

Future improvements:
1. Know what version of the MSP protocol I've implemented.
2. Ensure that the information sent during the handshake (build version, FC name etc) is correct.
3. Refactor some of the request-handlers in `msp.c` to use `mspMakeTxPacket()` that I have added.