### PR TITLE
Test framework improvements

### DIFF
--- a/bindings/cffirmware.i
+++ b/bindings/cffirmware.i
@@ -89,6 +89,12 @@ void collisionAvoidanceUpdateSetpointWrap(
     free(workspace);
 }
 
+void assertFail(char *exp, char *file, int line) {
+    char buf[150];
+    sprintf(buf, "%s in File: \"%s\", line %d\n", exp, file, line);
+
+    PyErr_SetString(PyExc_AssertionError, buf);
+}
 %}
 
 %pythoncode %{

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -54,6 +54,7 @@ cffirmware = Extension(
         # The following flags are also used for compiling the actual firmware
         "-fno-strict-aliasing",
         "-Wno-address-of-packed-member",
+        "-DUNIT_TEST_MODE",
     ],
 )
 

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -13,9 +13,22 @@ include = [
     "src/config",
     "src/drivers/interface",
     "src/platform/interface",
+    "vendor/CMSIS/CMSIS/DSP/Include",
+    "vendor/CMSIS/CMSIS/Core/Include",
 ]
 
 fw_sources = [
+    'vendor/CMSIS/CMSIS/DSP/Source/BasicMathFunctions/arm_add_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/BasicMathFunctions/arm_scale_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/BasicMathFunctions/arm_sub_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/CommonTables/arm_common_tables.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/FastMathFunctions/arm_cos_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/FastMathFunctions/arm_sin_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/StatisticsFunctions/arm_power_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/MatrixFunctions/arm_mat_mult_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/MatrixFunctions/arm_mat_scale_f32.c',
+    'vendor/CMSIS/CMSIS/DSP/Source/MatrixFunctions/arm_mat_trans_f32.c',
     "src/modules/src/pptraj.c",
     "src/modules/src/pptraj_compressed.c",
     "src/modules/src/planner.c",

--- a/examples/app_hello_world-cpp/src/hello_world.cpp
+++ b/examples/app_hello_world-cpp/src/hello_world.cpp
@@ -23,7 +23,7 @@
  *
  *
  * hello_world.c - App layer application of a simple hello world debug print every
- *   2 seconds.  
+ *   2 seconds.
  */
 
 
@@ -37,12 +37,12 @@
 extern "C"
 {
   #include "app.h"
+
+  #include "FreeRTOS.h"
+  #include "task.h"
+
+  #include "debug.h"
 }
-
-#include "FreeRTOS.h"
-#include "task.h"
-
-#include "debug.h"
 
 #define DEBUG_MODULE "HELLOWORLD"
 

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -89,8 +89,21 @@ typedef enum {
 } measurementSource_t;
 
 typedef struct tdoaMeasurement_s {
-  point_t anchorPositions[2];
-  uint8_t anchorIds[2];
+  union {
+    point_t anchorPositions[2];
+    struct {
+      point_t anchorPositionA;
+      point_t anchorPositionB;
+    };
+  };
+  union {
+    uint8_t anchorIds[2];
+    struct {
+      uint8_t anchorIdA;
+      uint8_t anchorIdB;
+    };
+  };
+
   float distanceDiff;
   float stdDev;
 } tdoaMeasurement_t;

--- a/src/modules/src/console.c
+++ b/src/modules/src/console.c
@@ -24,12 +24,12 @@
  * console.c - Used to send console data to client
  */
 
-#include <stdbool.h>
 #include <string.h>
 
 /*FreeRtos includes*/
 #include "FreeRTOS.h"
 #include "semphr.h"
+#include "console.h"
 
 #include "crtp.h"
 
@@ -104,12 +104,12 @@ int consolePutchar(int ch)
   if (xSemaphoreTake(synch, portMAX_DELAY) == pdTRUE)
   {
     // Try to send if we already have a pending message
-    if (messageSendingIsPending) 
+    if (messageSendingIsPending)
     {
       consoleSendMessage();
     }
 
-    if (! messageSendingIsPending) 
+    if (! messageSendingIsPending)
     {
       if (messageToPrint.size < CRTP_MAX_DATA_SIZE)
       {
@@ -171,7 +171,7 @@ void consoleFlush(void)
 static int findMarkerStart()
 {
   int start = messageToPrint.size;
-  
+
   // If last char is new line, rewind one char since the marker contains a new line.
   if (start > 0 && messageToPrint.data[start - 1] == '\n')
   {
@@ -183,9 +183,9 @@ static int findMarkerStart()
 
 static void addBufferFullMarker()
 {
-  // Try to add the marker after the message if it fits in the buffer, otherwise overwrite the end of the message 
+  // Try to add the marker after the message if it fits in the buffer, otherwise overwrite the end of the message
   int endMarker = findMarkerStart() + sizeof(bufferFullMsg);
-  if (endMarker >= (CRTP_MAX_DATA_SIZE)) 
+  if (endMarker >= (CRTP_MAX_DATA_SIZE))
   {
     endMarker = CRTP_MAX_DATA_SIZE;
   }

--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -1,3 +1,4 @@
+#include "stm32fxxx.h"
 #include "FreeRTOS.h"
 #include "queue.h"
 #include "static_mem.h"

--- a/src/modules/src/kalman_core/kalman_core.c
+++ b/src/modules/src/kalman_core/kalman_core.c
@@ -64,7 +64,6 @@
 #include "math3d.h"
 #include "static_mem.h"
 
-#include "lighthouse_calibration.h"
 // #define DEBUG_STATE_CHECK
 
 // the reversion of pitch and roll to zero

--- a/src/utils/interface/cfassert.h
+++ b/src/utils/interface/cfassert.h
@@ -24,8 +24,7 @@
  * cfassert.h - Assert macro
  */
 
-#include "stm32fxxx.h"
-#include "console.h"
+#include <stdbool.h>
 
 #ifndef __CFASSERT_H__
 #define __CFASSERT_H__

--- a/src/utils/interface/debug.h
+++ b/src/utils/interface/debug.h
@@ -47,9 +47,9 @@
 void debugInit(void);
 
 #if defined(UNIT_TEST_MODE)
-  // Empty defines when running unit tests
-  #define DEBUG_PRINT(fmt, ...)
-  #define DEBUG_PRINT_OS(fmt, ...)
+  #include <stdio.h>
+  #define DEBUG_PRINT(fmt, ...) printf(DEBUG_FMT(fmt), ##__VA_ARGS__)
+  #define DEBUG_PRINT_OS(fmt, ...) printf(DEBUG_FMT(fmt), ##__VA_ARGS__)
 #elif defined(CONFIG_DEBUG_PRINT_ON_UART1)
   #define DEBUG_PRINT(fmt, ...) uartPrintf(DEBUG_FMT(fmt), ##__VA_ARGS__)
   #define DEBUG_PRINT_OS(fmt, ...) uartPrintf(DEBUG_FMT(fmt), ##__VA_ARGS__)

--- a/src/utils/interface/lighthouse/lighthouse_geometry.h
+++ b/src/utils/interface/lighthouse/lighthouse_geometry.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
-#include "arm_math.h"
+#include "cf_math.h"
 #include "stabilizer_types.h"
 
 typedef struct {

--- a/src/utils/src/lighthouse/pulse_processor_v1.c
+++ b/src/utils/src/lighthouse/pulse_processor_v1.c
@@ -268,13 +268,6 @@ TESTABLE_STATIC bool isNewSync(uint32_t timestamp, uint32_t lastSync) {
   return (diff > max) && (diff < min);
 }
 
-#ifndef UNIT_TEST_MODE
-#include "debug.h"
-#else
-#include <stdio.h>
-#define DEBUG_PRINT printf
-#endif
-
 static bool decodeAndApplyBaseStationCalibrationData(pulseProcessor_t *state) {
   bool isDecoded = false;
 

--- a/test/deck/drivers/src/test_lps_twr_tag.c
+++ b/test/deck/drivers/src/test_lps_twr_tag.c
@@ -4,7 +4,6 @@
 #include <string.h>
 #include "unity.h"
 #include "mock_libdw1000.h"
-#include "mock_cfassert.h"
 #include "mock_locodeck.h"
 #include "mock_configblock.h"
 
@@ -137,22 +136,6 @@ void testNormalMessageSequenceShouldGenerateDistance() {
 
   float actualDistance = lpsTwrTagGetDistance(expectedAnchor);
   TEST_ASSERT_FLOAT_WITHIN(0.01, expectedDistance, actualDistance);
-}
-
-void testEventReceiveUnhandledEventShouldAssertFailure() {
-  // Fixture
-  assertFail_Expect("", "", 0);
-  assertFail_IgnoreArg_exp();
-  assertFail_IgnoreArg_file();
-  assertFail_IgnoreArg_line();
-
-  uwbEvent_t unknownEvent = 100;
-
-  // Test
-  uwbTwrTagAlgorithm.onEvent(&dev, unknownEvent);
-
-  // Assert
-  // Mock automatically validated after test
 }
 
 void testEventReceiveFailedShouldBeIgnored() {

--- a/test/modules/src/lighthouse/test_lighthouse_core.c
+++ b/test/modules/src/lighthouse/test_lighthouse_core.c
@@ -16,6 +16,7 @@
 #include "mock_statsCnt.h"
 #include "mock_crtp_localization_service.h"
 #include "mock_lighthouse_storage.h"
+#include "mock_lighthouse_throttle.h"
 
 #include <stdbool.h>
 

--- a/test/modules/src/lighthouse/test_lighthouse_core.c
+++ b/test/modules/src/lighthouse/test_lighthouse_core.c
@@ -14,7 +14,6 @@
 #include "mock_lighthouse_calibration.h"
 #include "mock_uart1.h"
 #include "mock_statsCnt.h"
-#include "mock_cfassert.h"
 #include "mock_crtp_localization_service.h"
 #include "mock_lighthouse_storage.h"
 

--- a/test/modules/src/lighthouse/test_lighthouse_storage.c
+++ b/test/modules/src/lighthouse/test_lighthouse_storage.c
@@ -6,7 +6,6 @@
 #include "unity.h"
 #include "mock_system.h"
 #include "mock_storage.h"
-#include "mock_cfassert.h"
 #include "mock_lighthouse_position_est.h"
 #include "mock_lighthouse_calibration.h"
 #include "mock_lighthouse_core.h"

--- a/test/modules/src/test_outlier_filter.c
+++ b/test/modules/src/test_outlier_filter.c
@@ -3,8 +3,6 @@
 
 #include "unity.h"
 
-#include "mock_cfassert.h"
-
 static tdoaMeasurement_t tdoa;
 
 // Helpers

--- a/test/modules/src/test_param_logic.c
+++ b/test/modules/src/test_param_logic.c
@@ -9,7 +9,6 @@
 #include "unity.h"
 
 #include "mock_crtp.h"
-#include "mock_cfassert.h"
 #include "mock_storage.h"
 #include "crc32.h"
 

--- a/test/testSupport/cfassert_in_test.c
+++ b/test/testSupport/cfassert_in_test.c
@@ -1,0 +1,9 @@
+#include "cfassert.h"
+#include "unity.h"
+
+// Implementation of assert used in unit tests, it triggers an assert in unity that will fail the test.
+void assertFail(char *exp, char *file, int line) {
+  char buf[150];
+  sprintf(buf, "%s in File: \"%s\", line %d\n", exp, file, line);
+  TEST_ASSERT_MESSAGE(false, buf);
+}

--- a/test/utils/src/lighthouse/test_lighthouse_geometry.c
+++ b/test/utils/src/lighthouse/test_lighthouse_geometry.c
@@ -7,9 +7,6 @@
 #include <string.h>
 #include "unity.h"
 
-#include "mock_cfassert.h"
-
-
 // Build the arm dsp math lib and use the "real thing" instead of mocking calls to it
 // @BUILD_LIB ARM_DSP_MATH
 

--- a/test/utils/src/lighthouse/test_pulse_processor.c
+++ b/test/utils/src/lighthouse/test_pulse_processor.c
@@ -15,15 +15,15 @@ void setUp(void) {
 void testThatResultStructIsCleared() {
   // Fixture
   pulseProcessorResult_t angles;
-  angles.sensorMeasurementsLh1[2].baseStationMeasurements[1].validCount = 2;
-  angles.sensorMeasurementsLh2[2].baseStationMeasurements[1].validCount = 2;
+  angles.baseStationMeasurementsLh1[1].sensorMeasurements[2].validCount = 2;
+  angles.baseStationMeasurementsLh2[1].sensorMeasurements[2].validCount = 2;
 
   // Test
   pulseProcessorClear(&angles, 1);
 
   // Assert
-  TEST_ASSERT_EQUAL_INT(0, angles.sensorMeasurementsLh1[2].baseStationMeasurements[1].validCount);
-  TEST_ASSERT_EQUAL_INT(0, angles.sensorMeasurementsLh2[2].baseStationMeasurements[1].validCount);
+  TEST_ASSERT_EQUAL_INT(0, angles.baseStationMeasurementsLh1[1].sensorMeasurements[2].validCount);
+  TEST_ASSERT_EQUAL_INT(0, angles.baseStationMeasurementsLh2[1].sensorMeasurements[2].validCount);
 }
 
 void testThatTsDiffReturnsDifference() {

--- a/test_python/test_cf_assert.py
+++ b/test_python/test_cf_assert.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import cffirmware
+import pytest
+
+def test_that_assert_in_the_firmware_is_mapped_to_pytest_assert():
+    # Fixture
+    assert_message = 'Assert in firmware (triggered from python)'
+
+    # Test
+    # Assert
+    with pytest.raises(SystemError):
+        cffirmware.assertFail(assert_message, "Some file", 4711)

--- a/tools/make/targets.mk
+++ b/tools/make/targets.mk
@@ -66,4 +66,4 @@ clean_cf:
 	@rm -f $(srctree)/$(PROG).*
 	@rm -f $(srctree)/cffirmware.py
 	@rm -f $(srctree)/_cffirmware*.so
-	
+	@rm -f $(srctree)/build/cffirmware_wrap.c

--- a/tools/test/gcc.yml
+++ b/tools/test/gcc.yml
@@ -84,6 +84,9 @@ compiler:
     extension: '.o'
     destination: *build_path
   libs:
+    TEST_SUPPORT:
+      files:
+        - 'test/testSupport/cfassert_in_test.c'
     ARM_DSP_MATH:
       files:
         - 'vendor/CMSIS/CMSIS/DSP/Source/BasicMathFunctions/arm_add_f32.c'

--- a/tools/test/rakefile_helper.rb
+++ b/tools/test/rakefile_helper.rb
@@ -247,6 +247,7 @@ module RakefileHelpers
       end
 
       # build libs
+      obj_list += add_lib_source_files(['TEST_SUPPORT'], test_defines)
       lib_annotations = read_lib_annotations(test)
       obj_list += add_lib_source_files(lib_annotations, test_defines)
 
@@ -414,8 +415,9 @@ module RakefileHelpers
     libs.each do |lib|
       puts 'Adding lib ' + lib
 
-      files = $cfg['compiler']['libs'][lib]['files']
-      extra_options = $cfg['compiler']['libs'][lib]['extra_options']
+      files = $cfg['compiler']['libs'][lib]['files'] || []
+      extra_options = $cfg['compiler']['libs'][lib]['extra_options'] || []
+
       files.each do |src_file|
         obj_list << compile(src_file, test_defines, extra_options=extra_options)
       end

--- a/tools/test/rakefile_helper.rb
+++ b/tools/test/rakefile_helper.rb
@@ -354,8 +354,11 @@ module RakefileHelpers
   end
 
   def exclude_test_files(files, defines)
+    # Extract the names of the defines and remove the values
+    trimmed_defines = defines.map {|define| define.split('=')[0]}
+
     files.select do |file|
-      !annotation_ignore_file?(file, defines)
+      !annotation_ignore_file?(file, trimmed_defines)
     end
   end
 
@@ -364,10 +367,10 @@ module RakefileHelpers
   # // @IGNORE_IF_NOT PLATFORM_CF2
   # or
   # // @IGNORE_IF_NOT CONFIG_DECK_LIGHTHOUSE
-  # Ignores values of defines, so this would fail and keep the file
+  # Ignores values of defines, so this would remove the file
   # param to gradle: -DMYDEFINE=0
   # // @IGNORE_IF_NOT MYDEFINE
-  def annotation_ignore_file?(file, defines)
+  def annotation_ignore_file?(file, trimmed_defines)
     ignore_str = '@IGNORE_IF_NOT'
 
     File.foreach( file ) do |line|
@@ -377,7 +380,7 @@ module RakefileHelpers
 
         if tokens.length >= (index + 2)
           condition = tokens[index + 1]
-          conditionIsMet = defines.detect {|define| define == condition}
+          conditionIsMet = trimmed_defines.include? condition
           if !conditionIsMet
             return true
           end


### PR DESCRIPTION
This PR aims at improving testability, both in unit tests and the python tests (using python bindings). A secondary goal is also to make it possible to add the kalman estimator to the python bindings which would make it possible to use it in simulations and test.

The main changes include:
* `ASSERT()` in the firmware is propagated to the test frameworks and fails the test if an assert is false 
* `DEBUG_PRINT()` in the firmware is now printed in the test console output
* CMSIS matrix math functions are supported from tests, that is the matrix operations in `cf_math.h` works when called from a test
* Fixes a bug related to the `@IGNORE_IF_NOT` annotation that prevented some tests from running
