### PR TITLE
Params: add missing callback for writeByName

### DIFF
--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -407,6 +407,10 @@ static char paramWriteByNameProcess(char* group, char* name, int type, void *val
 
   paramSet(index, valptr);
 
+  if (params[index].callback) {
+    params[index].callback();
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
The callback function is used, e.g., for led.bitmask and currently only
implemented for paramWriteProcess, not paramWriteByNameProcess