### PR TITLE
Add handling of rx fail for Loco

### DIFF
--- a/src/deck/drivers/src/locodeck.c
+++ b/src/deck/drivers/src/locodeck.c
@@ -176,6 +176,10 @@ static void rxTimeoutCallback(dwDevice_t * dev) {
   timeout = algorithm->onEvent(dev, eventReceiveTimeout);
 }
 
+static void rxFailedCallback(dwDevice_t * dev) {
+  timeout = algorithm->onEvent(dev, eventReceiveFailed);
+}
+
 static bool handleMemRead(const uint32_t memAddr, const uint8_t readLen, uint8_t* dest) {
   bool result = false;
 
@@ -511,6 +515,7 @@ static void dwm1000Init(DeckInfo *info)
   dwAttachSentHandler(dwm, txCallback);
   dwAttachReceivedHandler(dwm, rxCallback);
   dwAttachReceiveTimeoutHandler(dwm, rxTimeoutCallback);
+  dwAttachReceiveFailedHandler(dwm, rxFailedCallback);
 
   dwNewConfiguration(dwm);
   dwSetDefaults(dwm);

--- a/src/deck/drivers/src/lpsTdoa2Tag.c
+++ b/src/deck/drivers/src/lpsTdoa2Tag.c
@@ -252,8 +252,9 @@ static uint32_t onEvent(dwDevice_t *dev, uwbEvent_t event) {
       }
       break;
     case eventTimeout:
-      setRadioInReceiveMode(dev);
-      break;
+      // Fall through
+    case eventReceiveFailed:
+      // Fall through
     case eventReceiveTimeout:
       setRadioInReceiveMode(dev);
       break;

--- a/src/deck/drivers/src/lpsTdoa3Tag.c
+++ b/src/deck/drivers/src/lpsTdoa3Tag.c
@@ -244,6 +244,8 @@ static uint32_t onEvent(dwDevice_t *dev, uwbEvent_t event) {
       break;
     case eventReceiveTimeout:
       break;
+    case eventReceiveFailed:
+      break;
     case eventPacketSent:
       // Service packet sent, the radio is back to receive automatically
       break;


### PR DESCRIPTION
This PR adds handling of failed receives in the Loco system.
When a packed is not properly received, the underlying library calls the `receiveFailedHandler`. This handler has not been properly implemented with the result that the radio is not reset for a new receive. This in turn stops the loco deck from any further processing.

This PR fixes #1186 