### PR TITLE
Added paramNotifyChanged() to let apps notify the core when they modify the value of a parameter programmatically

### DIFF
--- a/src/modules/interface/param_logic.h
+++ b/src/modules/interface/param_logic.h
@@ -150,12 +150,6 @@ void paramLogicInit();
  */
 void paramLogicStorageInit();
 
-/**
- * @brief Notify the param subsystem that we changed the value of a param
- * programmatically.
- */
-void paramNotifyChanged(paramVarId_t varid);
-
 // The following functions SHALL NOT be called outside paramTask!
 void paramWriteProcess(CRTPPacket *p);
 void paramReadProcess(CRTPPacket *p);

--- a/src/modules/interface/param_logic.h
+++ b/src/modules/interface/param_logic.h
@@ -150,6 +150,12 @@ void paramLogicInit();
  */
 void paramLogicStorageInit();
 
+/**
+ * @brief Notify the param subsystem that we changed the value of a param
+ * programmatically.
+ */
+void paramNotifyChanged(paramVarId_t varid);
+
 // The following functions SHALL NOT be called outside paramTask!
 void paramWriteProcess(CRTPPacket *p);
 void paramReadProcess(CRTPPacket *p);

--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -65,6 +65,7 @@ static const uint8_t typeLength[] = {
 
 //Private functions
 static int variableGetIndex(int id);
+static void paramNotifyChanged(int index);
 static char paramWriteByNameProcess(char* group, char* name, int type, void *valptr);
 
 
@@ -368,14 +369,12 @@ void paramWriteProcess(CRTPPacket *p)
 
   crtpSendPacketBlock(p);
 
-  if (params[index].callback) {
-    params[index].callback();
-  }
+  paramNotifyChanged(index);
 }
 
-void paramNotifyChanged(paramVarId_t varid) {
-  if (params[varid.index].callback) {
-    params[varid.index].callback();
+static void paramNotifyChanged(int index) {
+  if (params[index].callback) {
+    params[index].callback();
   }
 }
 
@@ -413,9 +412,7 @@ static char paramWriteByNameProcess(char* group, char* name, int type, void *val
 
   paramSet(index, valptr);
 
-  if (params[index].callback) {
-    params[index].callback();
-  }
+  paramNotifyChanged(index);
 
   return 0;
 }
@@ -581,6 +578,8 @@ void paramSetInt(paramVarId_t varid, int valuei)
   pk.size = 3 + paramSize;
   crtpSendPacketBlock(&pk);
 #endif
+
+  paramNotifyChanged(varid.index);
 }
 
 void paramSetFloat(paramVarId_t varid, float valuef)
@@ -601,6 +600,8 @@ void paramSetFloat(paramVarId_t varid, float valuef)
   pk.size += 4;
   crtpSendPacketBlock(&pk);
 #endif
+
+  paramNotifyChanged(varid.index);
 }
 
 void paramSetByName(CRTPPacket *p)
@@ -625,7 +626,7 @@ void paramSetByName(CRTPPacket *p)
   type = p->data[1 + strlen(group) + 1 + strlen(name) + 1];
   valPtr = &p->data[1 + strlen(group) + 1 + strlen(name) + 2];
 
-  error = paramWriteByNameProcess(group, name, type, valPtr);
+  error = paramWriteByNameProcess(group, name, type, valPtr);  /* calls callback */
 
   p->data[1 + strlen(group) + 1 + strlen(name) + 1] = error;
   p->size = 1 + strlen(group) + 1 + strlen(name) + 1 + 1;

--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -373,6 +373,12 @@ void paramWriteProcess(CRTPPacket *p)
   }
 }
 
+void paramNotifyChanged(paramVarId_t varid) {
+  if (params[varid.index].callback) {
+    params[varid.index].callback();
+  }
+}
+
 static char paramWriteByNameProcess(char* group, char* name, int type, void *valptr) {
   int index;
   char *pgroup = "";


### PR DESCRIPTION
This function intends to cater for the use-case when an app modifies the value of a parameter using `paramSetInt()`, `paramSetFloat()` or some similar mechanism (i.e. not externally via a CRTP packet but internally). Currently these functions do not call the callbacks associated to the parameter if there is one; `paramNotifyChanged()` allows the app code to trigger the callback programmatically.

Another option would be to change `paramSetInt()`, `paramSetFloat()` and similar functions to call the callback, but I don't know what other implications this change may have so I went for the surgical option instead.