### PR TITLE
Refactor kalman estimator

### DIFF
--- a/src/modules/interface/axis3fSubSampler.h
+++ b/src/modules/interface/axis3fSubSampler.h
@@ -1,0 +1,62 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2023 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "imu_types.h"
+
+typedef struct {
+  Axis3f sum;
+  uint32_t count;
+  float conversionFactor;
+
+  Axis3f subSample;
+} Axis3fSubSampler_t;
+
+/**
+ * @brief Initialize sub sampler
+ *
+ * @param this  Pointer to sub sampler
+ * @param conversionFactor  Conversion factor used for unit conversion.
+ */
+void axis3fSubSamplerInit(Axis3fSubSampler_t* this, const float conversionFactor);
+
+/**
+ * @brief Accumulate a sample
+ *
+ * @param this  Pointer to sub sampler
+ * @param sample  The sample to accumulate
+ */
+void axis3fSubSamplerAccumulate(Axis3fSubSampler_t* this, const Axis3f* sample);
+
+/**
+ * @brief Compute the sub sample, uses simple averaging of samples. The sub sample is multiplied with the conversion
+ * factor and the result is stored in the subSample member of the Axis3fSubSampler_t.
+ *
+ * @param this  Pointer to sub sampler
+ * @return Axis3f*  Pointer to the resulting sub sample
+ */
+Axis3f* axis3fSubSamplerFinalize(Axis3fSubSampler_t* this);

--- a/src/modules/interface/kalman_core/kalman_core.h
+++ b/src/modules/interface/kalman_core/kalman_core.h
@@ -93,6 +93,12 @@ typedef struct {
 
   // Quaternion used for initial orientation [w,x,y,z]
   float initialQuaternion[4];
+
+  // Tracks whether an update to the state has been made, and the state therefore requires finalization
+  bool isUpdated;
+
+  uint32_t lastPredictionMs;
+  uint32_t lastProcessNoiseUpdateMs;
 } kalmanCoreData_t;
 
 // The parameters used by the filter
@@ -129,7 +135,7 @@ typedef struct {
 void kalmanCoreDefaultParams(kalmanCoreParams_t *params);
 
 /*  - Initialize Kalman State */
-void kalmanCoreInit(kalmanCoreData_t *this, const kalmanCoreParams_t *params);
+void kalmanCoreInit(kalmanCoreData_t *this, const kalmanCoreParams_t *params, const uint32_t nowMs);
 
 /*  - Measurement updates based on sensors */
 
@@ -141,15 +147,21 @@ void kalmanCoreUpdateWithBaro(kalmanCoreData_t *this, const kalmanCoreParams_t *
  *
  * The filter progresses as:
  *  - Predicting the current state forward */
-void kalmanCorePredict(kalmanCoreData_t *this, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying);
+void kalmanCorePredict(kalmanCoreData_t *this, Axis3f *acc, Axis3f *gyro, const uint32_t nowMs, bool quadIsFlying);
 
-void kalmanCoreAddProcessNoise(kalmanCoreData_t *this, const kalmanCoreParams_t *params, float dt);
+void kalmanCoreAddProcessNoise(kalmanCoreData_t *this, const kalmanCoreParams_t *params, const uint32_t nowMs);
 
-/*  - Finalization to incorporate attitude error into body attitude */
-void kalmanCoreFinalize(kalmanCoreData_t* this, uint32_t tick);
+/**
+ * @brief Finalization to incorporate attitude error into body attitude
+ *
+ * @param this Core data
+ * @return true The state was finalized
+ * @return false The state was not changed and did not require finalization
+ */
+bool kalmanCoreFinalize(kalmanCoreData_t* this);
 
 /*  - Externalization to move the filter's internal state into the external state expected by other modules */
-void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, const Axis3f *acc, uint32_t tick);
+void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, const Axis3f *acc);
 
 void kalmanCoreDecoupleXY(kalmanCoreData_t* this);
 

--- a/src/modules/interface/kalman_core/mm_sweep_angles.h
+++ b/src/modules/interface/kalman_core/mm_sweep_angles.h
@@ -29,4 +29,4 @@
 #include "outlierFilter.h"
 
 // Measurement of sweep angles from a Lighthouse base station
-void kalmanCoreUpdateWithSweepAngles(kalmanCoreData_t *this, sweepAngleMeasurement_t *angles, const uint32_t tick, OutlierFilterLhState_t* sweepOutlierFilterState);
+void kalmanCoreUpdateWithSweepAngles(kalmanCoreData_t *this, sweepAngleMeasurement_t *angles, const uint32_t nowMs, OutlierFilterLhState_t* sweepOutlierFilterState);

--- a/src/modules/interface/outlierFilter.h
+++ b/src/modules/interface/outlierFilter.h
@@ -31,11 +31,11 @@ bool outlierFilterValidateTdoaSimple(const tdoaMeasurement_t* tdoa);
 bool outlierFilterValidateTdoaSteps(const tdoaMeasurement_t* tdoa, const float error, const vector_t* jacobian, const point_t* estPos);
 
 typedef struct {
-    uint32_t openingTime;
-    int32_t openingWindow;
+    uint32_t openingTimeMs;
+    int32_t openingWindowMs;
 } OutlierFilterLhState_t;
-bool outlierFilterValidateLighthouseSweep(OutlierFilterLhState_t* this, const float distanceToBs, const float angleError, const uint32_t now);
-void outlierFilterReset(OutlierFilterLhState_t* this, const uint32_t now);
+bool outlierFilterValidateLighthouseSweep(OutlierFilterLhState_t* this, const float distanceToBs, const float angleError, const uint32_t nowMs);
+void outlierFilterReset(OutlierFilterLhState_t* this, const uint32_t nowMs);
 
 
 #endif // __OUTLIER_FILTER_H__

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -65,8 +65,6 @@ typedef struct vec3_s acc_t;
 
 /* Orientation as a quaternion */
 typedef struct quaternion_s {
-  uint32_t timestamp;
-
   union {
     struct {
       float q0;

--- a/src/modules/src/Kbuild
+++ b/src/modules/src/Kbuild
@@ -27,6 +27,7 @@ obj-y += eventtrigger.o
 obj-y += extrx.o
 obj-y += health.o
 obj-$(CONFIG_ESTIMATOR_KALMAN_ENABLE) += kalman_supervisor.o
+obj-y += axis3fSubSampler.o
 obj-y += log.o
 obj-y += mem.o
 obj-y += msp.o

--- a/src/modules/src/axis3fSubSampler.c
+++ b/src/modules/src/axis3fSubSampler.c
@@ -1,0 +1,54 @@
+/**
+ * ,---------,       ____  _ __
+ * |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+ * | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * | / ,--´  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2023 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string.h>
+#include "axis3fSubSampler.h"
+
+void axis3fSubSamplerInit(Axis3fSubSampler_t* this, const float conversionFactor) {
+  memset(this, 0, sizeof(Axis3fSubSampler_t));
+  this->conversionFactor = conversionFactor;
+}
+
+void axis3fSubSamplerAccumulate(Axis3fSubSampler_t* this, const Axis3f* sample) {
+  this->sum.x += sample->x;
+  this->sum.y += sample->y;
+  this->sum.z += sample->z;
+
+  this->count++;
+}
+
+Axis3f* axis3fSubSamplerFinalize(Axis3fSubSampler_t* this) {
+  if (this->count > 0) {
+    this->subSample.x = this->sum.x * this->conversionFactor / this->count;
+    this->subSample.y = this->sum.y * this->conversionFactor / this->count;
+    this->subSample.z = this->sum.z * this->conversionFactor / this->count;
+
+    // Reset
+    this->count = 0;
+    this->sum = (Axis3f){.axis={0}};
+  }
+
+  return &this->subSample;
+}

--- a/src/modules/src/kalman_core/kalman_core.c
+++ b/src/modules/src/kalman_core/kalman_core.c
@@ -152,7 +152,7 @@ void kalmanCoreDefaultParams(kalmanCoreParams_t* params)
   params->initialYaw = 0.0;
 }
 
-void kalmanCoreInit(kalmanCoreData_t *this, const kalmanCoreParams_t *params)
+void kalmanCoreInit(kalmanCoreData_t *this, const kalmanCoreParams_t *params, const uint32_t nowMs)
 {
   // Reset all data to 0 (like upon system reset)
   memset(this, 0, sizeof(kalmanCoreData_t));
@@ -203,6 +203,10 @@ void kalmanCoreInit(kalmanCoreData_t *this, const kalmanCoreParams_t *params)
   this->Pm.pData = (float*)this->P;
 
   this->baroReferenceHeight = 0.0;
+
+  this->isUpdated = false;
+  this->lastPredictionMs = nowMs;
+  this->lastProcessNoiseUpdateMs = nowMs;
 }
 
 void kalmanCoreScalarUpdate(kalmanCoreData_t* this, arm_matrix_instance_f32 *Hm, float error, float stdMeasNoise)
@@ -273,6 +277,8 @@ void kalmanCoreScalarUpdate(kalmanCoreData_t* this, arm_matrix_instance_f32 *Hm,
   }
 
   assertStateNotNaN(this);
+
+  this->isUpdated = true;
 }
 
 void kalmanCoreUpdateWithPKE(kalmanCoreData_t* this, arm_matrix_instance_f32 *Hm, arm_matrix_instance_f32 *Km, arm_matrix_instance_f32 *P_w_m, float error)
@@ -309,6 +315,7 @@ void kalmanCoreUpdateWithPKE(kalmanCoreData_t* this, arm_matrix_instance_f32 *Hm
     }
     assertStateNotNaN(this);
 
+    this->isUpdated = true;
 }
 
 void kalmanCoreUpdateWithBaro(kalmanCoreData_t *this, const kalmanCoreParams_t *params, float baroAsl, bool quadIsFlying)
@@ -327,7 +334,7 @@ void kalmanCoreUpdateWithBaro(kalmanCoreData_t *this, const kalmanCoreParams_t *
   kalmanCoreScalarUpdate(this, &H, meas - this->S[KC_STATE_Z], params->measNoiseBaro);
 }
 
-void kalmanCorePredict(kalmanCoreData_t* this, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying)
+static void predictDt(kalmanCoreData_t* this, Axis3f *acc, Axis3f *gyro, float dt, bool quadIsFlying)
 {
   /* Here we discretize (euler forward) and linearise the quadrocopter dynamics in order
    * to push the covariance forward.
@@ -560,24 +567,30 @@ void kalmanCorePredict(kalmanCoreData_t* this, Axis3f *acc, Axis3f *gyro, float 
   float norm = arm_sqrt(tmpq0*tmpq0 + tmpq1*tmpq1 + tmpq2*tmpq2 + tmpq3*tmpq3) + EPS;
   this->q[0] = tmpq0/norm; this->q[1] = tmpq1/norm; this->q[2] = tmpq2/norm; this->q[3] = tmpq3/norm;
   assertStateNotNaN(this);
+
+  this->isUpdated = true;
 }
 
-void kalmanCoreAddProcessNoise(kalmanCoreData_t *this, const kalmanCoreParams_t *params, float dt)
+void kalmanCorePredict(kalmanCoreData_t* this, Axis3f *acc, Axis3f *gyro, const uint32_t nowMs, bool quadIsFlying) {
+  float dt = (nowMs - this->lastPredictionMs) / 1000.0f;
+  predictDt(this, acc, gyro, dt, quadIsFlying);
+  this->lastPredictionMs = nowMs;
+}
+
+
+static void addProcessNoiseDt(kalmanCoreData_t *this, const kalmanCoreParams_t *params, float dt)
 {
-  if (dt>0)
-  {
-    this->P[KC_STATE_X][KC_STATE_X] += powf(params->procNoiseAcc_xy*dt*dt + params->procNoiseVel*dt + params->procNoisePos, 2);  // add process noise on position
-    this->P[KC_STATE_Y][KC_STATE_Y] += powf(params->procNoiseAcc_xy*dt*dt + params->procNoiseVel*dt + params->procNoisePos, 2);  // add process noise on position
-    this->P[KC_STATE_Z][KC_STATE_Z] += powf(params->procNoiseAcc_z*dt*dt + params->procNoiseVel*dt + params->procNoisePos, 2);  // add process noise on position
+  this->P[KC_STATE_X][KC_STATE_X] += powf(params->procNoiseAcc_xy*dt*dt + params->procNoiseVel*dt + params->procNoisePos, 2);  // add process noise on position
+  this->P[KC_STATE_Y][KC_STATE_Y] += powf(params->procNoiseAcc_xy*dt*dt + params->procNoiseVel*dt + params->procNoisePos, 2);  // add process noise on position
+  this->P[KC_STATE_Z][KC_STATE_Z] += powf(params->procNoiseAcc_z*dt*dt + params->procNoiseVel*dt + params->procNoisePos, 2);  // add process noise on position
 
-    this->P[KC_STATE_PX][KC_STATE_PX] += powf(params->procNoiseAcc_xy*dt + params->procNoiseVel, 2); // add process noise on velocity
-    this->P[KC_STATE_PY][KC_STATE_PY] += powf(params->procNoiseAcc_xy*dt + params->procNoiseVel, 2); // add process noise on velocity
-    this->P[KC_STATE_PZ][KC_STATE_PZ] += powf(params->procNoiseAcc_z*dt + params->procNoiseVel, 2); // add process noise on velocity
+  this->P[KC_STATE_PX][KC_STATE_PX] += powf(params->procNoiseAcc_xy*dt + params->procNoiseVel, 2); // add process noise on velocity
+  this->P[KC_STATE_PY][KC_STATE_PY] += powf(params->procNoiseAcc_xy*dt + params->procNoiseVel, 2); // add process noise on velocity
+  this->P[KC_STATE_PZ][KC_STATE_PZ] += powf(params->procNoiseAcc_z*dt + params->procNoiseVel, 2); // add process noise on velocity
 
-    this->P[KC_STATE_D0][KC_STATE_D0] += powf(params->measNoiseGyro_rollpitch * dt + params->procNoiseAtt, 2);
-    this->P[KC_STATE_D1][KC_STATE_D1] += powf(params->measNoiseGyro_rollpitch * dt + params->procNoiseAtt, 2);
-    this->P[KC_STATE_D2][KC_STATE_D2] += powf(params->measNoiseGyro_yaw * dt + params->procNoiseAtt, 2);
-  }
+  this->P[KC_STATE_D0][KC_STATE_D0] += powf(params->measNoiseGyro_rollpitch * dt + params->procNoiseAtt, 2);
+  this->P[KC_STATE_D1][KC_STATE_D1] += powf(params->measNoiseGyro_rollpitch * dt + params->procNoiseAtt, 2);
+  this->P[KC_STATE_D2][KC_STATE_D2] += powf(params->measNoiseGyro_yaw * dt + params->procNoiseAtt, 2);
 
   for (int i=0; i<KC_STATE_DIM; i++) {
     for (int j=i; j<KC_STATE_DIM; j++) {
@@ -595,10 +608,22 @@ void kalmanCoreAddProcessNoise(kalmanCoreData_t *this, const kalmanCoreParams_t 
   assertStateNotNaN(this);
 }
 
+void kalmanCoreAddProcessNoise(kalmanCoreData_t *this, const kalmanCoreParams_t *params, const uint32_t nowMs) {
+  float dt = (nowMs - this->lastProcessNoiseUpdateMs) / 1000.0f;
+  if (dt > 0.0f) {
+    addProcessNoiseDt(this, params, dt);
+    this->lastProcessNoiseUpdateMs = nowMs;
+  }
+}
 
-
-void kalmanCoreFinalize(kalmanCoreData_t* this, uint32_t tick)
+bool kalmanCoreFinalize(kalmanCoreData_t* this)
 {
+  // Only finalize if data is updated
+  if (! this->isUpdated) {
+    return false;
+  }
+
+
   // Matrix to rotate the attitude covariances once updated
   NO_DMA_CCM_SAFE_ZERO_INIT static float A[KC_STATE_DIM][KC_STATE_DIM];
   static arm_matrix_instance_f32 Am = {KC_STATE_DIM, KC_STATE_DIM, (float *)A};
@@ -709,13 +734,15 @@ void kalmanCoreFinalize(kalmanCoreData_t* this, uint32_t tick)
   }
 
   assertStateNotNaN(this);
+
+  this->isUpdated = false;
+  return true;
 }
 
-void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, const Axis3f *acc, uint32_t tick)
+void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, const Axis3f *acc)
 {
   // position state is already in world frame
   state->position = (point_t){
-      .timestamp = tick,
       .x = this->S[KC_STATE_X],
       .y = this->S[KC_STATE_Y],
       .z = this->S[KC_STATE_Z]
@@ -723,7 +750,6 @@ void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, co
 
   // velocity is in body frame and needs to be rotated to world frame
   state->velocity = (velocity_t){
-      .timestamp = tick,
       .x = this->R[0][0]*this->S[KC_STATE_PX] + this->R[0][1]*this->S[KC_STATE_PY] + this->R[0][2]*this->S[KC_STATE_PZ],
       .y = this->R[1][0]*this->S[KC_STATE_PX] + this->R[1][1]*this->S[KC_STATE_PY] + this->R[1][2]*this->S[KC_STATE_PZ],
       .z = this->R[2][0]*this->S[KC_STATE_PX] + this->R[2][1]*this->S[KC_STATE_PY] + this->R[2][2]*this->S[KC_STATE_PZ]
@@ -733,7 +759,6 @@ void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, co
   // Furthermore, the legacy code requires acc.z to be acceleration without gravity.
   // Finally, note that these accelerations are in Gs, and not in m/s^2, hence - 1 for removing gravity
   state->acc = (acc_t){
-      .timestamp = tick,
       .x = this->R[0][0]*acc->x + this->R[0][1]*acc->y + this->R[0][2]*acc->z,
       .y = this->R[1][0]*acc->x + this->R[1][1]*acc->y + this->R[1][2]*acc->z,
       .z = this->R[2][0]*acc->x + this->R[2][1]*acc->y + this->R[2][2]*acc->z - 1
@@ -746,7 +771,6 @@ void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, co
 
   // Save attitude, adjusted for the legacy CF2 body coordinate system
   state->attitude = (attitude_t){
-      .timestamp = tick,
       .roll = roll*RAD_TO_DEG,
       .pitch = -pitch*RAD_TO_DEG,
       .yaw = yaw*RAD_TO_DEG
@@ -755,7 +779,6 @@ void kalmanCoreExternalizeState(const kalmanCoreData_t* this, state_t *state, co
   // Save quaternion, hopefully one day this could be used in a better controller.
   // Note that this is not adjusted for the legacy coordinate system
   state->attitudeQuaternion = (quaternion_t){
-      .timestamp = tick,
       .w = this->q[0],
       .x = this->q[1],
       .y = this->q[2],

--- a/src/modules/src/kalman_core/mm_sweep_angles.c
+++ b/src/modules/src/kalman_core/mm_sweep_angles.c
@@ -27,7 +27,7 @@
 #include "outlierFilter.h"
 
 
-void kalmanCoreUpdateWithSweepAngles(kalmanCoreData_t *this, sweepAngleMeasurement_t *sweepInfo, const uint32_t tick, OutlierFilterLhState_t* sweepOutlierFilterState) {
+void kalmanCoreUpdateWithSweepAngles(kalmanCoreData_t *this, sweepAngleMeasurement_t *sweepInfo, const uint32_t nowMs, OutlierFilterLhState_t* sweepOutlierFilterState) {
   // Rotate the sensor position from CF reference frame to global reference frame,
   // using the CF roatation matrix
   vec3d s;
@@ -65,7 +65,7 @@ void kalmanCoreUpdateWithSweepAngles(kalmanCoreData_t *this, sweepAngleMeasureme
   const float measuredSweepAngle = sweepInfo->measuredSweepAngle;
   const float error = measuredSweepAngle - predictedSweepAngle;
 
-  if (outlierFilterValidateLighthouseSweep(sweepOutlierFilterState, r, error, tick)) {
+  if (outlierFilterValidateLighthouseSweep(sweepOutlierFilterState, r, error, nowMs)) {
     // Calculate H vector (in the rotor reference frame)
     const float z_tan_t = z * tan_t;
     const float qNum = r2 - z_tan_t * z_tan_t;

--- a/src/modules/src/outlierFilter.c
+++ b/src/modules/src/outlierFilter.c
@@ -103,44 +103,44 @@ bool outlierFilterValidateTdoaSteps(const tdoaMeasurement_t* tdoa, const float e
 }
 
 
-#define LH_TICKS_PER_FRAME (1000 / 120)
-static const int32_t lhMinWindowTime = -2 * LH_TICKS_PER_FRAME;
-static const int32_t lhMaxWindowTime = 5 * LH_TICKS_PER_FRAME;
-static const int32_t lhBadSampleWindowChange = -LH_TICKS_PER_FRAME;
-static const int32_t lhGoodSampleWindowChange = LH_TICKS_PER_FRAME / 2;
+#define LH_MS_PER_FRAME (1000 / 120)
+static const int32_t lhMinWindowTimeMs = -2 * LH_MS_PER_FRAME;
+static const int32_t lhMaxWindowTimeMs = 5 * LH_MS_PER_FRAME;
+static const int32_t lhBadSampleWindowChangeMs = -LH_MS_PER_FRAME;
+static const int32_t lhGoodSampleWindowChangeMs = LH_MS_PER_FRAME / 2;
 static const float lhMaxError = 0.05f;
 
-void outlierFilterReset(OutlierFilterLhState_t* this, const uint32_t now) {
-  this->openingTime = now;
-  this->openingWindow = lhMinWindowTime;
+void outlierFilterReset(OutlierFilterLhState_t* this, const uint32_t nowMs) {
+  this->openingTimeMs = nowMs;
+  this->openingWindowMs = lhMinWindowTimeMs;
 }
 
 
-bool outlierFilterValidateLighthouseSweep(OutlierFilterLhState_t* this, const float distanceToBs, const float angleError, const uint32_t now) {
+bool outlierFilterValidateLighthouseSweep(OutlierFilterLhState_t* this, const float distanceToBs, const float angleError, const uint32_t nowMs) {
   // float error = distanceToBs * tan(angleError);
   // We use an approximattion
   float error = distanceToBs * angleError;
 
   bool isGoodSample = (fabsf(error) < lhMaxError);
   if (isGoodSample) {
-    this->openingWindow += lhGoodSampleWindowChange;
-    if (this->openingWindow > lhMaxWindowTime) {
-      this->openingWindow = lhMaxWindowTime;
+    this->openingWindowMs += lhGoodSampleWindowChangeMs;
+    if (this->openingWindowMs > lhMaxWindowTimeMs) {
+      this->openingWindowMs = lhMaxWindowTimeMs;
     }
   } else {
-    this->openingWindow += lhBadSampleWindowChange;
-    if (this->openingWindow < lhMinWindowTime) {
-      this->openingWindow = lhMinWindowTime;
+    this->openingWindowMs += lhBadSampleWindowChangeMs;
+    if (this->openingWindowMs < lhMinWindowTimeMs) {
+      this->openingWindowMs = lhMinWindowTimeMs;
     }
   }
 
   bool result = true;
-  bool isFilterClosed = (now < this->openingTime);
+  bool isFilterClosed = (nowMs < this->openingTimeMs);
   if (isFilterClosed) {
     result = isGoodSample;
   }
 
-  this->openingTime = now + this->openingWindow;
+  this->openingTimeMs = nowMs + this->openingWindowMs;
 
   return result;
 }

--- a/test/modules/src/test_axis3fSubSampler.c
+++ b/test/modules/src/test_axis3fSubSampler.c
@@ -1,0 +1,100 @@
+// File under test axis3fSubSampler.c
+#include "axis3fSubSampler.h"
+
+#include "unity.h"
+
+Axis3fSubSampler_t subSampler;
+
+const Axis3f sample1 = {.x=1.0, .y=2.0, .z=3.0};
+const Axis3f sample2 = {.x=4.0, .y=5.0, .z=6.0};
+const Axis3f sample3 = {.x=7.0, .y=8.0, .z=9.0};
+
+void setUp(void) {
+}
+
+void tearDown(void) {
+  // Empty
+}
+
+
+void testThatOneSampleIsUnchanged() {
+  // Fixture
+  axis3fSubSamplerInit(&subSampler, 1.0);
+
+  axis3fSubSamplerAccumulate(&subSampler, &sample1);
+
+  // Test
+  Axis3f* actual = axis3fSubSamplerFinalize(&subSampler);
+
+  // Assert
+  TEST_ASSERT_EQUAL_FLOAT(sample1.x, actual->x);
+  TEST_ASSERT_EQUAL_FLOAT(sample1.y, actual->y);
+  TEST_ASSERT_EQUAL_FLOAT(sample1.z, actual->z);
+}
+
+
+void testThatSamplesAreAveraged() {
+  // Fixture
+  axis3fSubSamplerInit(&subSampler, 1.0);
+
+  axis3fSubSamplerAccumulate(&subSampler, &sample1);
+  axis3fSubSamplerAccumulate(&subSampler, &sample2);
+  axis3fSubSamplerAccumulate(&subSampler, &sample3);
+
+  // Test
+  Axis3f* actual = axis3fSubSamplerFinalize(&subSampler);
+
+  // Assert
+  TEST_ASSERT_EQUAL_FLOAT(4.0, actual->x);
+  TEST_ASSERT_EQUAL_FLOAT(5.0, actual->y);
+  TEST_ASSERT_EQUAL_FLOAT(6.0, actual->z);
+}
+
+
+void testThatResultIsUnchangedWhenNoNewSamplesAreAccumulated() {
+  // Fixture
+  axis3fSubSamplerInit(&subSampler, 1.0);
+  axis3fSubSamplerAccumulate(&subSampler, &sample1);
+  axis3fSubSamplerFinalize(&subSampler);
+  // The sub sampler has now been finalized
+
+  // Test
+  Axis3f* actual = axis3fSubSamplerFinalize(&subSampler);
+
+  // Assert
+  TEST_ASSERT_EQUAL_FLOAT(sample1.x, actual->x);
+  TEST_ASSERT_EQUAL_FLOAT(sample1.y, actual->y);
+  TEST_ASSERT_EQUAL_FLOAT(sample1.z, actual->z);
+}
+
+void testThatResultIsUpdatedWhenNewSamplesAreAccumulated() {
+  // Fixture
+  axis3fSubSamplerInit(&subSampler, 1.0);
+  axis3fSubSamplerAccumulate(&subSampler, &sample1);
+  axis3fSubSamplerFinalize(&subSampler);
+  // The sub sampler has now been finalized
+
+  // Test
+  axis3fSubSamplerAccumulate(&subSampler, &sample2);
+  Axis3f* actual = axis3fSubSamplerFinalize(&subSampler);
+
+  // Assert
+  TEST_ASSERT_EQUAL_FLOAT(sample2.x, actual->x);
+  TEST_ASSERT_EQUAL_FLOAT(sample2.y, actual->y);
+  TEST_ASSERT_EQUAL_FLOAT(sample2.z, actual->z);
+}
+
+void testThatResultIsMultipliedWithConversionFactor() {
+  // Fixture
+  axis3fSubSamplerInit(&subSampler, 3.0);
+
+  axis3fSubSamplerAccumulate(&subSampler, &sample1);
+
+  // Test
+  Axis3f* actual = axis3fSubSamplerFinalize(&subSampler);
+
+  // Assert
+  TEST_ASSERT_EQUAL_FLOAT(sample1.x * 3.0f, actual->x);
+  TEST_ASSERT_EQUAL_FLOAT(sample1.y * 3.0f, actual->y);
+  TEST_ASSERT_EQUAL_FLOAT(sample1.z * 3.0f, actual->z);
+}

--- a/test/modules/src/test_outlier_filter.c
+++ b/test/modules/src/test_outlier_filter.c
@@ -74,18 +74,6 @@ void testThatSamplesAreRejectedWhenTdoaIsGreaterButNegativeThanDistanceBetweenAn
 #define LH_GOOD_ANGLE 0.0001
 #define LH_TIME_STEP (1000 / 120)
 
-// TOOD krri remove
-static void print(OutlierFilterLhState_t* this, uint32_t time) {
-  printf("win:%i openingTime:%i time:%i ", this->openingWindow, this->openingTime, time);
-  bool isFilterClosed = (time < this->openingTime);
-  if (isFilterClosed) {
-    printf("Is closed\n");
-  } else {
-    printf("Is open\n");
-  }
-}
-
-
 void testThatLhFilterLetsGoodSampleThroughWhenOpen() {
   // Fixture
   OutlierFilterLhState_t this;


### PR DESCRIPTION
This PR contains refactoring of the kalman estimator to make it easier to run it from python bindings.

The code in estimator_kalman.c must be re-implemented (with modifications) in python when running thrugh the bindings as this code has lots of dependencies to FreeRTOS. The chaninges in this PR aims at moving as much as possible to the kalman core and other portable core to minimize and simplify the code that must be re-implemented.

Main changes:
* Add sub sampler for gyro and accelerometer
* Change all times in kalman core and related files from ticks to ms
* Make sure kalman core knows whether it has been updated and should be finalized (used to be handled outside)
* Make the kalman core aware of when it was previously updated to enable it to compute delta time 