### PR TITLE
fix typo in name of Kalman estimator

### DIFF
--- a/src/modules/src/estimator.c
+++ b/src/modules/src/estimator.c
@@ -117,7 +117,7 @@ void stateEstimatorSwitchTo(StateEstimatorType estimator) {
   }
 
   #if defined(CONFIG_ESTIMATOR_KALMAN)
-    #define ESTIMATOR KalmanEstimator
+    #define ESTIMATOR kalmanEstimator
   #elif defined(CONFIG_UKF_KALMAN)
     #define ESTIMATOR ukfEstimator
   #elif defined(CONFIG_ESTIMATOR_COMPLEMENTARY)


### PR DESCRIPTION
There was a typo in the name of the Kalman estimator that prevented compilation if the Kalman estimator was selected explicitly in the configuration.