### PR TITLE
Add reformat of storage

### DIFF
--- a/src/hal/interface/storage.h
+++ b/src/hal/interface/storage.h
@@ -100,7 +100,17 @@ bool storageForeach(const char* prefix, storageFunc_t func);
 
 /**
  * Print storage information on the debug console
- * 
+ *
  * This function locks the storage while getting the stats.
  */
 void storagePrintStats();
+
+/**
+ * @brief Reformat the storage.
+ *
+ * Warning! All stored data will be lost!
+ *
+ * @return true   Format was successful
+ * @return false  Format failed
+ */
+bool storageReformat();


### PR DESCRIPTION
This PR adds a parameter that can be used to trigger a re-format of the storage. This will erase all stored data (persistent parameters and lighthouse geometry/calib) and can be useful if data in the storage is corrupt. 

Fixes #1207