### PR TITLE
Deprecated enHighLevel

### DIFF
--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -166,7 +166,10 @@ int commanderGetActivePriority(void)
 PARAM_GROUP_START(commander)
 
 /**
- *  @brief Enable high level commander
+ * @brief Enable high level commander - deprecated (removed after August 2023)
+ *
+ * This parameter does not change anything and does not provide any functionality. There is no need
+ * to set it before using the high level commander. See https://github.com/bitcraze/crazyflie-firmware/pull/903
  */
 PARAM_ADD_CORE(PARAM_UINT8, enHighLevel, &enableHighLevel)
 


### PR DESCRIPTION
The parameter `commander.enHighLevel` is not used any more (#903). Added deprecation notice