### PR TITLE
Make paramSetXXX() functions non-blocking

### DIFF
--- a/src/modules/interface/param_logic.h
+++ b/src/modules/interface/param_logic.h
@@ -116,12 +116,8 @@ unsigned int paramGetUint(paramVarId_t varid);
 
 /** Set int value of an int parameter (1-4 bytes)
  *
- *  An update is also send to the client 
- *  NOTE: The update to the client will be added to the output queue. If 
- *  the Crazyflie is not connected to a client, the queue may fill up and
- *  this call will block until the queue is emptied.This could be avoided 
- *  by setting the CONFIG_PARAM_SILENT_UPDATES flag.
- * 
+ *  An update is also send to the client
+ *
  * @param varId variable ID, returned by paramGetVarId()
  * @param valuei Value to set in the variable
  */
@@ -129,12 +125,8 @@ void paramSetInt(paramVarId_t varid, int valuei);
 
 /** Set float value of a float parameter
  *
- *  An update is also send to the client 
- *  NOTE: The update to the client will be added to the output queue. If 
- *  the Crazyflie is not connected to a client, the queue may fill up and
- *  this call will block until the queue is emptied.This could be avoided 
- *  by setting the CONFIG_PARAM_SILENT_UPDATES flag.
- * 
+ *  An update is also send to the client
+ *
  * @param varId variable ID, returned by paramGetVarId()
  * @param valuef Value to set in the variable
  */

--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -576,7 +576,7 @@ void paramSetInt(paramVarId_t varid, int valuei)
   pk.data[1] = varid.id & 0xffu;
   pk.data[2] = (varid.id >> 8) & 0xffu;
   pk.size = 3 + paramSize;
-  crtpSendPacketBlock(&pk);
+  crtpSendPacket(&pk);
 #endif
 
   paramNotifyChanged(varid.index);
@@ -598,7 +598,7 @@ void paramSetFloat(paramVarId_t varid, float valuef)
   pk.size = 3;
   memcpy(&pk.data[2], &valuef, 4);
   pk.size += 4;
-  crtpSendPacketBlock(&pk);
+  crtpSendPacket(&pk);
 #endif
 
   paramNotifyChanged(varid.index);

--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -7,7 +7,7 @@
  *
  * Crazyflie control firmware
  *
- * Copyright (C) 2011-2021 Bitcraze AB
+ * Copyright (C) 2011-2023 Bitcraze AB
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@
 #include <errno.h>
 
 #include "config.h"
+#include "FreeRTOS.h"
 #include "param_logic.h"
 #include "storage.h"
 #include "crc32.h"
@@ -576,7 +577,10 @@ void paramSetInt(paramVarId_t varid, int valuei)
   pk.data[1] = varid.id & 0xffu;
   pk.data[2] = (varid.id >> 8) & 0xffu;
   pk.size = 3 + paramSize;
-  crtpSendPacket(&pk);
+  const int sendResult = crtpSendPacket(&pk);
+  if (sendResult == errQUEUE_FULL) {
+    DEBUG_PRINT("WARNING: Param update not sent\n");
+  }
 #endif
 
   paramNotifyChanged(varid.index);
@@ -598,7 +602,10 @@ void paramSetFloat(paramVarId_t varid, float valuef)
   pk.size = 3;
   memcpy(&pk.data[2], &valuef, 4);
   pk.size += 4;
-  crtpSendPacket(&pk);
+  const int sendResult = crtpSendPacket(&pk);
+  if (sendResult == errQUEUE_FULL) {
+    DEBUG_PRINT("WARNING: Param update not sent\n");
+  }
 #endif
 
   paramNotifyChanged(varid.index);

--- a/test/modules/src/test_param_logic.c
+++ b/test/modules/src/test_param_logic.c
@@ -83,7 +83,7 @@ void testSetUint8(void) {
   // Fixture
   uint8_t expected = UINT8_MAX - 1;
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
   paramVarId_t varid = paramGetVarId("myGroup", "myUint8");
 
   // Test
@@ -97,7 +97,7 @@ void testSetUint16(void) {
   // Fixture
   uint16_t expected = UINT16_MAX - 1;
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
   paramVarId_t varid = paramGetVarId("myGroup", "myUint16");
 
   // Test
@@ -111,7 +111,7 @@ void testSetUint32(void) {
   // Fixture
   uint32_t expected = UINT32_MAX - 1;
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
   paramVarId_t varid = paramGetVarId("myGroup", "myUint32");
 
   // Test
@@ -125,7 +125,7 @@ void testSetInt8(void) {
   // Fixture
   uint8_t expected = INT8_MAX - 1;
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
   paramVarId_t varid = paramGetVarId("myGroup", "myInt8");
 
   // Test
@@ -139,7 +139,7 @@ void testSetInt16(void) {
   // Fixture
   uint16_t expected =UINT16_MAX - 1;
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
   paramVarId_t varid = paramGetVarId("myGroup", "myInt16");
 
   // Test
@@ -153,7 +153,7 @@ void testSetInt32(void) {
   // Fixture
   uint32_t expected = INT32_MAX - 1;
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
   paramVarId_t varid = paramGetVarId("myGroup", "myInt32");
 
   // Test
@@ -268,7 +268,7 @@ void testPersistentSetGetFloat(void) {
 
   paramVarId_t varid = paramGetVarId("myGroup", "myPersistentFloat");
 
-  crtpSendPacketBlock_StubWithCallback(crtpReply);
+  crtpSendPacket_StubWithCallback(crtpReply);
 
   // Test
   paramSetFloat(varid, expected);


### PR DESCRIPTION
Fixes #1234

This PR changes the 'paramSetXXX()' functions to be non-blocking when pushing data to the TX queue. If the queue is full, a warning message will be logged. 

The behavior should be identical in most (all?) cases when a client is connected. The TX queue is 120 slots long and it should not be full as long as a client is connected.  

When no client is connected, an app can still call paramSetXXX() without surprises.