### PR TITLE
Added limitation of log variable name length

### DIFF
--- a/docs/userguides/logparam.md
+++ b/docs/userguides/logparam.md
@@ -94,6 +94,9 @@ log the *roll* variable in the *stabilizer* group it's access by
 *stabilizer.roll*. And if you would like to set the *effect* variable in
 the ring group it's accessed using *ring.effect*.
 
+### Log Variable length
+Please use length upto 26 as total log variable length (group + name +1)
+
 ## Parameters
 
 Using the parameter framework it's possible to both read and write


### PR DESCRIPTION
Faced issue while creating custom log variables for crazyflie-firmware. 
There seems to be script already for run time checking (https://github.com/bitcraze/crazyflie-firmware/issues/588)
Adding this information in document for logging seems appropriate for users to create correct variables in start.