### PR TITLE
[CPX] custom data types from gap8 to stm32

### DIFF
--- a/src/deck/drivers/interface/aideck.h
+++ b/src/deck/drivers/interface/aideck.h
@@ -43,3 +43,5 @@
  * @param packet packet that was received
  */
 void cpxBootloaderMessage(const CPXPacket_t * packet);
+
+void messageReceive(const CPXPacket_t packet);

--- a/src/deck/drivers/interface/msg.h
+++ b/src/deck/drivers/interface/msg.h
@@ -1,0 +1,130 @@
+#ifndef MSG_H
+#define MSG_H
+
+#define MSG_SIZE 53
+#define GAP8_ENABLED false
+
+#include "stdio.h"
+
+#if GAP8_ENABLED
+  #include "pmsis.h"
+#endif
+
+typedef struct _Pixel
+{
+  uint16_t x; // uint16 (2 bytes)
+  uint16_t y; // uint16 (2 bytes)
+} __attribute__((packed)) Pixel;
+
+typedef struct _TagPacket
+{
+  uint8_t id; // uint8 (1 byte) = 1
+  Pixel corners[4]; // Pixel (4 bytes) * 4 = 16
+  float homography[3][3]; // float (4 bytes) * 3 * 3 = 36
+} __attribute__((packed)) TagPacket;
+
+#if GAP8_ENABLED
+  // https://stackoverflow.com/a/6002598
+  static void reserve_space(uint8_t *data, size_t bytes,
+    uint8_t *size, uint8_t *next) 
+  {
+    if((*next + bytes) > *size) {
+      // double size to enforce O(lg N) reallocs
+      // data = realloc(data, *size * 2);
+      // *size *= 2;
+    }
+  }
+  
+  static void serialize_uint8(uint8_t x, uint8_t *data, 
+    uint8_t *size, uint8_t *next) 
+  {
+    reserve_space(data, sizeof(uint8_t), size, next);
+
+    memcpy(data + *next, &x, sizeof(uint8_t));
+    *next += sizeof(uint8_t);
+  }
+
+  static void serialize_uint16(uint16_t x, uint8_t *data, 
+    uint8_t *size, uint8_t *next) 
+  {
+    reserve_space(data, sizeof(uint16_t), size, next);
+
+    memcpy(data + *next, &x, sizeof(uint16_t));
+    *next += sizeof(uint16_t);
+  }
+
+  static void serialize_float(float x, uint8_t *data, 
+    uint8_t *size, uint8_t *next) 
+  {
+    reserve_space(data, sizeof(float), size, next);
+
+    memcpy(data + *next, &x, sizeof(float));
+    *next += sizeof(float);
+  }
+
+  static void serialization(TagPacket tp, CPXPacket_t *pkt) 
+  { 
+    uint8_t size = MSG_SIZE;
+    uint8_t next = 0;
+
+    pkt->dataLength = (uint16_t)size;
+
+    serialize_uint8(tp.id, pkt->data, &size, &next);
+    for (size_t i = 0; i < sizeof(tp.corners)/sizeof(Pixel); ++i)
+    {
+      serialize_uint16(tp.corners[i].x, pkt->data, &size, &next);
+      serialize_uint16(tp.corners[i].y, pkt->data, &size, &next);
+    }
+    for (int i = 0; i < 3; ++i)
+      for (int j = 0; j < 3; ++j)
+          serialize_float(tp.homography[i][j], pkt->data, &size, &next);
+  }
+#endif
+
+static void deserialize_uint8(uint8_t *x, uint8_t *data, 
+  uint8_t *next) 
+{
+  memcpy(x, data + *next, sizeof(uint8_t));
+  *next += sizeof(uint8_t);
+}
+
+static void deserialize_uint16(uint16_t *x, uint8_t *data, 
+  uint8_t *next) 
+{
+  memcpy(x, data + *next, sizeof(uint16_t));
+  *next += sizeof(uint16_t);
+}
+
+static void deserialize_float(float *x, uint8_t *data, 
+  uint8_t *next) 
+{
+
+  memcpy(x, data + *next, sizeof(float));
+  *next += sizeof(float);
+}
+
+static void deserialization(TagPacket *tp, CPXPacket_t pkt) 
+{
+  uint8_t next = 0;
+
+  deserialize_uint8(&(tp->id), pkt.data, &next);
+  for (size_t i = 0; i < sizeof(tp->corners)/sizeof(Pixel); ++i)
+  {
+    uint16_t x = 0, y = 0;
+    deserialize_uint16(&x, pkt.data, &next);
+    deserialize_uint16(&y, pkt.data, &next);
+    tp->corners[i].x = x;
+    tp->corners[i].y = y;
+  }
+  for (int i = 0; i < 3; ++i)
+  {
+    for (int j = 0; j < 3; ++j)
+    {
+      float x = 0.0f;
+      deserialize_float(&x, pkt.data, &next);
+      tp->homography[i][j] = x;
+    }
+  }
+}
+
+#endif

--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -62,6 +62,7 @@
 #include "cpx.h"
 
 #include "aideck.h"
+#include "msg.h"
 
 static bool isInit = false;
 
@@ -111,6 +112,21 @@ const uint32_t espUartReadMaxWait = M2T(100);
 void cpxBootloaderMessage(const CPXPacket_t * packet) {
   xEventGroupSetBits(bootloaderSync, CPX_WAIT_FOR_BOOTLOADER_REPLY);
 }
+
+void messageReceive(const CPXPacket_t packet) {
+
+  TagPacket tp = {};
+  deserialization(&tp, packet);
+
+  // DEBUG_PRINT("(receive) id(uint8_t) %d c[0](uint16_t) %d, %d\n", 
+  //   tp.id, tp.corners[0].x, tp.corners[0].y);
+
+  DEBUG_PRINT("(receive)\n[%.2f, %.2f, %.2f\n%.2f, %.2f, %.2f\n%.2f, %.2f, %.2f]\n",
+    (double)tp.homography[0][0], (double)tp.homography[1][0], (double)tp.homography[2][0], 
+    (double)tp.homography[0][1], (double)tp.homography[1][1], (double)tp.homography[2][1],
+    (double)tp.homography[0][2], (double)tp.homography[1][2], (double)tp.homography[2][2]);
+}
+
 
 static CPXPacket_t txPacket;
 

--- a/src/modules/src/cpx/cpx.c
+++ b/src/modules/src/cpx/cpx.c
@@ -126,8 +126,14 @@ static void cpx(void* _param) {
           }
         }
         break;
+      case CPX_F_APP:
+      {
+        messageReceive(cpxRx);
+        break;
+      }
       default:
         DEBUG_PRINT("Not handling function [0x%02X] from [0x%02X]\n", cpxRx.route.function, cpxRx.route.source);
+        break;
     }
   }
 }

--- a/src/modules/src/cpx/cpx_internal_router.c
+++ b/src/modules/src/cpx/cpx_internal_router.c
@@ -70,6 +70,7 @@ void cpxInternalRouterRouteIn(const CPXRoutablePacket_t* packet) {
     case CPX_F_WIFI_CTRL:
     case CPX_F_BOOTLOADER:
     case CPX_F_TEST:
+    case CPX_F_APP:
       xQueueSend(mixedQueue, packet, portMAX_DELAY);
       break;
     case CPX_F_CRTP:


### PR DESCRIPTION
This PR addresses https://github.com/bitcraze/aideck-gap8-examples/issues/116. A look at it is as shown below, using an example of `sending apriltag detection of corners` and `pose estimation` related data
![cpx](https://user-images.githubusercontent.com/64059887/222921517-c4084a62-8ddf-4e6e-801e-8a50de904ad1.png)