### PR TITLE
Initialize mem sub system before decks

### DIFF
--- a/src/modules/src/crtp_mem.c
+++ b/src/modules/src/crtp_mem.c
@@ -111,6 +111,8 @@ static void memTask(void* param) {
   // there might be late arrivals for the registration that will
   // trigger assert.
 
+  systemWaitStart();
+
   // Do not allow registration of new handlers after this point as clients now can start
   // to query for available memories
   memBlockHandlerRegistration();

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -209,6 +209,7 @@ void systemTask(void *arg)
   // This should probably be done later, but deckInit() takes a long time if this is done later.
   uartslkEnableIncoming();
 
+  memInit();
   deckInit();
   estimator = deckGetRequiredEstimator();
   stabilizerInit(estimator);
@@ -217,7 +218,6 @@ void systemTask(void *arg)
     platformSetLowInterferenceRadioMode();
   }
   soundInit();
-  memInit();
   crtpMemInit();
 
 #ifdef PROXIMITY_ENABLED
@@ -278,6 +278,10 @@ void systemTask(void *arg)
   if (memTest() == false) {
     pass = false;
     DEBUG_PRINT("mem [FAIL]\n");
+  }
+  if (crtpMemTest() == false) {
+    pass = false;
+    DEBUG_PRINT("CRTP mem [FAIL]\n");
   }
   if (watchdogNormalStartTest() == false) {
     pass = false;


### PR DESCRIPTION
This PR changes the initialization order. 

The memory sub system should be initialized before decks, as the deck init registers the OW mem handler.
