### PR TITLE
Added function to read multi-byte data over UART1

### DIFF
--- a/src/drivers/interface/uart1.h
+++ b/src/drivers/interface/uart1.h
@@ -90,16 +90,7 @@ bool uart1GetDataWithTimeout(uint8_t *c, const uint32_t timeoutTicks);
 bool uart1GetDataWithDefaultTimeout(uint8_t *c);
 
 /**
- * Sends raw data using a lock. Should be used from
- * exception functions and for debugging when a lot of data
- * should be transfered.
- * @param[in] size  Number of bytes to send
- * @param[in] data  Pointer to data
- */
-void uart1SendData(uint32_t size, uint8_t* data);
-
-/**
- * Get data from the UART. Blocking until the amount of
+ * Get data from the UART connection. Blocking until the amount of
  * data has been read
  *
  * @param[in] size  Number of bytes to read
@@ -107,7 +98,17 @@ void uart1SendData(uint32_t size, uint8_t* data);
  * 
  * @return number of bytes read
  */
-void uart1GetData(uint32_t size, uint8_t* data);
+void uart1GetBytesWithDefaultTimeout(uint32_t size, uint8_t* data);
+
+
+/**
+ * Sends raw data using a lock. Should be used from
+ * exception functions and for debugging when a lot of data
+ * should be transfered.
+ * @param[in] size  Number of bytes to send
+ * @param[in] data  Pointer to data
+ */
+void uart1SendData(uint32_t size, uint8_t* data);
 
 /**
  * Sends raw data using DMA transfer.

--- a/src/drivers/interface/uart1.h
+++ b/src/drivers/interface/uart1.h
@@ -99,6 +99,17 @@ bool uart1GetDataWithDefaultTimeout(uint8_t *c);
 void uart1SendData(uint32_t size, uint8_t* data);
 
 /**
+ * Get data from the UART. Blocking until the amount of
+ * data has been read
+ *
+ * @param[in] size  Number of bytes to read
+ * @param[out] data  Pointer to data
+ * 
+ * @return number of bytes read
+ */
+void uart1GetData(uint32_t size, uint8_t* data);
+
+/**
  * Sends raw data using DMA transfer.
  * @param[in] size  Number of bytes to send
  * @param[in] data  Pointer to data

--- a/src/drivers/src/uart1.c
+++ b/src/drivers/src/uart1.c
@@ -202,6 +202,13 @@ bool uart1GetDataWithDefaultTimeout(uint8_t *c)
   return uart1GetDataWithTimeout(c, UART1_DATA_TIMEOUT_TICKS);
 }
 
+void uart1GetBytesWithDefaultTimeout(uint32_t size, uint8_t* data)
+{
+  for (size_t i = 0; i < size; i++) {
+    xQueueReceive(uart1queue, &data[i], portMAX_DELAY);
+  }
+}
+
 void uart1SendData(uint32_t size, uint8_t* data)
 {
   uint32_t i;
@@ -254,13 +261,6 @@ int uart1Putchar(int ch)
 void uart1Getchar(char * ch)
 {
   xQueueReceive(uart1queue, ch, portMAX_DELAY);
-}
-
-void uart1GetData(uint32_t size, uint8_t* data)
-{
-  for (size_t i = 0; i < size; i++) {
-    xQueueReceive(uart1queue, &data[i], portMAX_DELAY);
-  }
 }
 
 bool uart1DidOverrun()

--- a/src/drivers/src/uart1.c
+++ b/src/drivers/src/uart1.c
@@ -256,6 +256,13 @@ void uart1Getchar(char * ch)
   xQueueReceive(uart1queue, ch, portMAX_DELAY);
 }
 
+void uart1GetData(uint32_t size, uint8_t* data)
+{
+  for (size_t i = 0; i < size; i++) {
+    xQueueReceive(uart1queue, &data[i], portMAX_DELAY);
+  }
+}
+
 bool uart1DidOverrun()
 {
   bool result = hasOverrun;


### PR DESCRIPTION
Currently, UART1 communication supports sending multi-byte data over a UART1 connection, but it can only receive single-byte characters. This function enhances the UART1 communication capability by enabling the reception of multi-byte data over the UART1 connection.

This feature is particularly useful for efficiently streaming low-volume data from the AI-Deck directly to the STM-32.