### PR TITLE
usddeck: fix incorrect use of MAX_USD_LOG_EVENTS

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -668,7 +668,7 @@ static void usdLogTask(void* prm)
               continue;
             }
           }
-          if (usdLogConfig.numEventConfigs < MAX_USD_LOG_EVENTS - 1) {
+          if (usdLogConfig.numEventConfigs < MAX_USD_LOG_EVENTS) {
             ++usdLogConfig.numEventConfigs;
             cfg = &usdLogConfig.eventConfigs[usdLogConfig.numEventConfigs];
           } else {


### PR DESCRIPTION
The previous code was incorrect and did not allow to record data if MAX_USD_LOG_EVENTS=1