### PR TITLE
usddeck: improve error handling on write

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -809,9 +809,13 @@ static void usdWriteData(const void *data, size_t size)
 {
   UINT bytesWritten;
   FRESULT status = f_write(&logFile, data, size, &bytesWritten);
-  ASSERT(status == FR_OK);
-  crc32Update(&crcContext, data, size);
-  STATS_CNT_RATE_MULTI_EVENT(&fatWriteRate, bytesWritten);
+  if (status != FR_OK) {
+    DEBUG_PRINT("usd deck write failure %d\n", status);
+    enableLogging = false;
+  } else {
+    crc32Update(&crcContext, data, size);
+    STATS_CNT_RATE_MULTI_EVENT(&fatWriteRate, bytesWritten);
+  }
 }
 
 static void usdWriteTask(void* prm)


### PR DESCRIPTION
Instead of hitting an assert (and crash), we report an error and stop
writing to the card. This can happen if the card is loose, even during flight.