### PR TITLE
Add a param/log for testing

### DIFF
--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -92,6 +92,7 @@ static uint8_t dumpAssertInfo = 0;
 static bool isInit;
 
 static char nrf_version[16];
+static uint8_t testLogParam;
 
 STATIC_MEM_TASK_ALLOC(systemTask, SYSTEM_TASK_STACKSIZE);
 
@@ -474,6 +475,12 @@ PARAM_ADD(PARAM_INT8 | PARAM_PERSISTENT, forceArm, &forceArm)
  */
 PARAM_ADD(PARAM_UINT8, assertInfo, &dumpAssertInfo)
 
+/**
+ * @brief Test util for log and param. This param sets the value of the sys.testLogParam log variable.
+ *
+ */
+PARAM_ADD(PARAM_UINT8, testLogParam, &testLogParam)
+
 PARAM_GROUP_STOP(system)
 
 /**
@@ -484,4 +491,10 @@ LOG_GROUP_START(sys)
  * @brief If zero, arming system is preventing motors to start
  */
 LOG_ADD(LOG_INT8, armed, &armed)
+
+/**
+ * @brief Test util for log and param. The value is set through the system.testLogParam parameter
+ */
+LOG_ADD(LOG_INT8, testLogParam, &testLogParam)
+
 LOG_GROUP_STOP(sys)


### PR DESCRIPTION
This PR adds a log/param that is connected. When a value is written to the parameter, it will be logged through the log. Can be used for testing.

param: `system.testLogParam`
log:`sys.testLogParam`