### PR TITLE
Revert clearing of data in mem init

### DIFF
--- a/src/modules/src/mem.c
+++ b/src/modules/src/mem.c
@@ -63,10 +63,6 @@ void memInit(void)
     return;
   }
 
-  registrationEnabled = true;
-  nrOfHandlers = 0;
-  owMemHandler = 0;
-
   memoryRegisterHandler(&memTesterDef);
 
   isInit = true;
@@ -87,6 +83,10 @@ bool memTest(void) {
 #ifdef UNIT_TEST_MODE
 void memReset() {
   isInit = false;
+
+  registrationEnabled = true;
+  nrOfHandlers = 0;
+  owMemHandler = 0;
 }
 #endif
 


### PR DESCRIPTION
Fixes #1260

This PR removes the clearing of data in the init function. The main reason that I added clearing of data was for testing purposes. Clearing is now moved to the reset function that is called in the tests.