### PR TITLE
Log instead of assert on CPX version mismatch

### DIFF
--- a/src/modules/src/cpx/cpx.c
+++ b/src/modules/src/cpx/cpx.c
@@ -68,9 +68,22 @@ void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const
     route->version = CPX_VERSION;
 }
 
-bool cpxCheckVersion(const uint8_t version)
-{
-  return (version == CPX_VERSION);
+bool cpxCheckVersion(const uint8_t version) {
+  static bool hasLoggedVersionMismatch = false;
+
+  // Version mismatch is generally handled by ignoring messages and logging the problem once.
+  // Asserting has turned out to be a bad idea as it prevents flashing new firmware in some cases.
+
+  const bool isVersionOk = (version == CPX_VERSION);
+
+  if (!isVersionOk) {
+    if (!hasLoggedVersionMismatch) {
+      DEBUG_PRINT("WARNING! CPX version mismatch. Got %i, require %i\n", version, CPX_VERSION);
+      hasLoggedVersionMismatch = true;
+    }
+  }
+
+  return isVersionOk;
 }
 
 static void cpx(void* _param) {

--- a/src/modules/src/cpx/cpx_external_router.c
+++ b/src/modules/src/cpx/cpx_external_router.c
@@ -91,26 +91,26 @@ static void route(Receiver_t receive, CPXRoutablePacket_t* rxp, RouteContext_t* 
     receive(rxp);
     // this should never fail, as it should be checked when the packet is received
     // however, double checking doesn't harm
-    ASSERT(cpxCheckVersion(rxp->route.version));
+    if (cpxCheckVersion(rxp->route.version)) {
+      const CPXTarget_t source = rxp->route.source;
+      const CPXTarget_t destination = rxp->route.destination;
+      const uint16_t cpxDataLength = rxp->dataLength;
 
-    const CPXTarget_t source = rxp->route.source;
-    const CPXTarget_t destination = rxp->route.destination;
-    const uint16_t cpxDataLength = rxp->dataLength;
-
-    switch (destination) {
-      case CPX_T_WIFI_HOST:
-      case CPX_T_ESP32:
-      case CPX_T_GAP8:
-        //DEBUG_PRINT("%s [0x%02X] -> UART2 [0x%02X] (%u)\n", routerName, source, destination, cpxDataLength);
-        splitAndSend(rxp, context, cpxUARTTransportSend, CPX_UART_TRANSPORT_MTU - CPX_ROUTING_PACKED_SIZE);
-        break;
-      case CPX_T_STM32:
-        //DEBUG_PRINT("%s [0x%02X] -> STM32 [0x%02X] (%u)\n", routerName, source, destination, cpxDataLength);
-        splitAndSend(rxp, context, cpxInternalRouterRouteIn, CPX_UART_TRANSPORT_MTU - CPX_ROUTING_PACKED_SIZE);
-        break;
-      default:
-        DEBUG_PRINT("Cannot route from %s [0x%02X] to [0x%02X](%u)\n", routerName, source, destination, cpxDataLength);
-        break;
+      switch (destination) {
+        case CPX_T_WIFI_HOST:
+        case CPX_T_ESP32:
+        case CPX_T_GAP8:
+          //DEBUG_PRINT("%s [0x%02X] -> UART2 [0x%02X] (%u)\n", routerName, source, destination, cpxDataLength);
+          splitAndSend(rxp, context, cpxUARTTransportSend, CPX_UART_TRANSPORT_MTU - CPX_ROUTING_PACKED_SIZE);
+          break;
+        case CPX_T_STM32:
+          //DEBUG_PRINT("%s [0x%02X] -> STM32 [0x%02X] (%u)\n", routerName, source, destination, cpxDataLength);
+          splitAndSend(rxp, context, cpxInternalRouterRouteIn, CPX_UART_TRANSPORT_MTU - CPX_ROUTING_PACKED_SIZE);
+          break;
+        default:
+          DEBUG_PRINT("Cannot route from %s [0x%02X] to [0x%02X](%u)\n", routerName, source, destination, cpxDataLength);
+          break;
+      }
     }
   }
 }

--- a/src/modules/src/cpx/cpx_uart_transport.c
+++ b/src/modules/src/cpx/cpx_uart_transport.c
@@ -162,8 +162,9 @@ static void CPX_UART_RX(void *param)
         uint8_t crc;
         uart2GetData(1, &crc);
         ASSERT(crc == calcCrc(&uartRxp));
-        ASSERT(cpxCheckVersion(uartRxp.routablePayload.route.version));
-        xQueueSend(uartRxQueue, &uartRxp, portMAX_DELAY);
+        if (cpxCheckVersion(uartRxp.routablePayload.route.version)) {
+          xQueueSend(uartRxQueue, &uartRxp, portMAX_DELAY);
+        }
         xEventGroupSetBits(evGroup, ESP_CTR_EVENT);
       }
     }


### PR DESCRIPTION
Related to #1253

It has turned out that asserting on CPX version mismatch is a bad idea, as it restarts the STM and prevents flashing of the ESP.
This PR chantes the behavior to logging the problem and ignoring packets with the wrong version. 