### PR TITLE
Rename stabilizer loop tick to stabilizerStep

### DIFF
--- a/src/hal/interface/sensors.h
+++ b/src/hal/interface/sensors.h
@@ -40,7 +40,7 @@ bool sensorsAreCalibrated(void);
 bool sensorsManufacturingTest(void);
 
 // For legacy control
-void sensorsAcquire(sensorData_t *sensors, const uint32_t tick);
+void sensorsAcquire(sensorData_t *sensors);
 
 /**
  * This function should block and unlock at 1KhZ

--- a/src/hal/interface/sensors_bmi088_bmp388.h
+++ b/src/hal/interface/sensors_bmi088_bmp388.h
@@ -33,7 +33,7 @@ void sensorsBmi088Bmp388Init_SPI(void);
 bool sensorsBmi088Bmp388Test(void);
 bool sensorsBmi088Bmp388AreCalibrated(void);
 bool sensorsBmi088Bmp388ManufacturingTest(void);
-void sensorsBmi088Bmp388Acquire(sensorData_t *sensors, const uint32_t tick);
+void sensorsBmi088Bmp388Acquire(sensorData_t *sensors);
 void sensorsBmi088Bmp388WaitDataReady(void);
 bool sensorsBmi088Bmp388ReadGyro(Axis3f *gyro);
 bool sensorsBmi088Bmp388ReadAcc(Axis3f *acc);

--- a/src/hal/interface/sensors_bosch.h
+++ b/src/hal/interface/sensors_bosch.h
@@ -32,7 +32,7 @@ void sensorsBoschInit(void);
 bool sensorsBoschTest(void);
 bool sensorsBoschAreCalibrated(void);
 bool sensorsBoschManufacturingTest(void);
-void sensorsBoschAcquire(sensorData_t *sensors, const uint32_t tick);
+void sensorsBoschAcquire(sensorData_t *sensors);
 void sensorsBoschWaitDataReady(void);
 bool sensorsBoschReadGyro(Axis3f *gyro);
 bool sensorsBoschReadAcc(Axis3f *acc);

--- a/src/hal/interface/sensors_mpu9250_lps25h.h
+++ b/src/hal/interface/sensors_mpu9250_lps25h.h
@@ -31,7 +31,7 @@ void sensorsMpu9250Lps25hInit(void);
 bool sensorsMpu9250Lps25hTest(void);
 bool sensorsMpu9250Lps25hAreCalibrated(void);
 bool sensorsMpu9250Lps25hManufacturingTest(void);
-void sensorsMpu9250Lps25hAcquire(sensorData_t *sensors, const uint32_t tick);
+void sensorsMpu9250Lps25hAcquire(sensorData_t *sensors);
 void sensorsMpu9250Lps25hWaitDataReady(void);
 bool sensorsMpu9250Lps25hReadGyro(Axis3f *gyro);
 bool sensorsMpu9250Lps25hReadAcc(Axis3f *acc);

--- a/src/hal/src/sensors.c
+++ b/src/hal/src/sensors.c
@@ -56,7 +56,7 @@ typedef struct {
   bool (*test)(void);
   bool (*areCalibrated)(void);
   bool (*manufacturingTest)(void);
-  void (*acquire)(sensorData_t *sensors, const uint32_t tick);
+  void (*acquire)(sensorData_t *sensors);
   void (*waitDataReady)(void);
   bool (*readGyro)(Axis3f *gyro);
   bool (*readAcc)(Axis3f *acc);
@@ -177,8 +177,8 @@ bool sensorsManufacturingTest(void){
   return activeImplementation->manufacturingTest;
 }
 
-void sensorsAcquire(sensorData_t *sensors, const uint32_t tick) {
-  activeImplementation->acquire(sensors, tick);
+void sensorsAcquire(sensorData_t *sensors) {
+  activeImplementation->acquire(sensors);
 }
 
 void sensorsWaitDataReady(void) {

--- a/src/hal/src/sensors_bmi088_bmp388.c
+++ b/src/hal/src/sensors_bmi088_bmp388.c
@@ -270,7 +270,7 @@ bool sensorsBmi088Bmp388ReadBaro(baro_t *baro)
   return (pdTRUE == xQueueReceive(barometerDataQueue, baro, 0));
 }
 
-void sensorsBmi088Bmp388Acquire(sensorData_t *sensors, const uint32_t tick)
+void sensorsBmi088Bmp388Acquire(sensorData_t *sensors)
 {
   sensorsReadGyro(&sensors->gyro);
   sensorsReadAcc(&sensors->acc);

--- a/src/hal/src/sensors_bosch.c
+++ b/src/hal/src/sensors_bosch.c
@@ -867,7 +867,7 @@ bool sensorsBoschReadBaro(baro_t *baro)
   return (pdTRUE == xQueueReceive(baroPrimDataQueue, baro, 0));
 }
 
-void sensorsBoschAcquire(sensorData_t *sensors, const uint32_t tick)
+void sensorsBoschAcquire(sensorData_t *sensors)
 {
   sensorsReadGyro(&sensors->gyro);
   sensorsReadAcc(&sensors->acc);

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -200,7 +200,7 @@ bool sensorsMpu9250Lps25hReadBaro(baro_t *baro)
   return (pdTRUE == xQueueReceive(barometerDataQueue, baro, 0));
 }
 
-void sensorsMpu9250Lps25hAcquire(sensorData_t *sensors, const uint32_t tick)
+void sensorsMpu9250Lps25hAcquire(sensorData_t *sensors)
 {
   sensorsReadGyro(&sensors->gyro);
   sensorsReadAcc(&sensors->acc);

--- a/src/modules/interface/collision_avoidance.h
+++ b/src/modules/interface/collision_avoidance.h
@@ -149,7 +149,7 @@ bool collisionAvoidanceTest(void);
 // Wrapper that uses the peer localization system to construct the input arrays
 // for collisionAvoidanceUpdateSetpointCore.
 void collisionAvoidanceUpdateSetpoint(
-  setpoint_t *setpoint, sensorData_t const *sensorData, state_t const *state, uint32_t tick);
+  setpoint_t *setpoint, sensorData_t const *sensorData, state_t const *state, stabilizerStep_t stabilizerStep);
 
 #endif // CRAZYFLIE_FW defined
 

--- a/src/modules/interface/controller/controller.h
+++ b/src/modules/interface/controller/controller.h
@@ -45,7 +45,7 @@ bool controllerTest(void);
 void controller(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick);
+                                         const stabilizerStep_t stabilizerStep);
 ControllerType controllerGetType(void);
 const char* controllerGetName();
 
@@ -53,7 +53,7 @@ const char* controllerGetName();
 #ifdef CONFIG_CONTROLLER_OOT
 void controllerOutOfTreeInit(void);
 bool controllerOutOfTreeTest(void);
-void controllerOutOfTree(control_t *control, const setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick);
+void controllerOutOfTree(control_t *control, const setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const stabilizerStep_t stabilizerStep);
 #endif
 
 #endif //__CONTROLLER_H__

--- a/src/modules/interface/controller/controller_brescianini.h
+++ b/src/modules/interface/controller/controller_brescianini.h
@@ -44,4 +44,4 @@ void controllerBrescianini(control_t *control,
                         const setpoint_t *setpoint,
                         const sensorData_t *sensors,
                         const state_t *state,
-                        const uint32_t tick);
+                        const stabilizerStep_t stabilizerStep);

--- a/src/modules/interface/controller/controller_indi.h
+++ b/src/modules/interface/controller/controller_indi.h
@@ -44,7 +44,7 @@
 #define STABILIZATION_INDI_FILT_CUTOFF_R STABILIZATION_INDI_FILT_CUTOFF
 
 // Control effectiveness coefficients values Volodscoi
-#define STABILIZATION_INDI_G1_P 0.0066146f 
+#define STABILIZATION_INDI_G1_P 0.0066146f
 #define STABILIZATION_INDI_G1_Q 0.0052125f
 #define STABILIZATION_INDI_G1_R 0.001497f
 #define STABILIZATION_INDI_G2_R 0.000043475f
@@ -56,12 +56,12 @@
 // #define STABILIZATION_INDI_G2_R 0.00001725f
 
 //Proportional gains inner INDI, attitude error
-#define STABILIZATION_INDI_REF_ERR_P 5.0f 
+#define STABILIZATION_INDI_REF_ERR_P 5.0f
 #define STABILIZATION_INDI_REF_ERR_Q 5.0f
 #define STABILIZATION_INDI_REF_ERR_R 5.0f
 
 //Derivative gains inner INDI, attitude rate error
-#define STABILIZATION_INDI_REF_RATE_P 24.0f 
+#define STABILIZATION_INDI_REF_RATE_P 24.0f
 #define STABILIZATION_INDI_REF_RATE_Q 24.0f
 #define STABILIZATION_INDI_REF_RATE_R 24.0f
 
@@ -112,6 +112,6 @@ bool controllerINDITest(void);
 void controllerINDI(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick);
+                                         const stabilizerStep_t stabilizerStep);
 
 #endif //__CONTROLLER_INDI_H__

--- a/src/modules/interface/controller/controller_mellinger.h
+++ b/src/modules/interface/controller/controller_mellinger.h
@@ -92,7 +92,7 @@ bool controllerMellingerTest(controllerMellinger_t* self);
 void controllerMellinger(controllerMellinger_t* self, control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick);
+                                         const stabilizerStep_t stabilizerStep);
 
 #ifdef CRAZYFLIE_FW
 
@@ -101,7 +101,7 @@ bool controllerMellingerFirmwareTest(void);
 void controllerMellingerFirmware(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick);
+                                         const stabilizerStep_t stabilizerStep);
 
 #endif // CRAZYFLIE_FW
 

--- a/src/modules/interface/controller/controller_pid.h
+++ b/src/modules/interface/controller/controller_pid.h
@@ -33,6 +33,6 @@ bool controllerPidTest(void);
 void controllerPid(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick);
+                                         const stabilizerStep_t stabilizerStep);
 
 #endif //__CONTROLLER_PID_H__

--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -59,7 +59,7 @@ void crtpCommanderHighLevelInit(void);
 
 // Retrieves the current setpoint. Returns false if the high-level commander is
 // disabled, i.e. it does not have an "opinion" on what the setpoint should be.
-bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state, uint32_t tick);
+bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state, stabilizerStep_t stabilizerStep);
 
 // When flying sequences of high-level commands, the high-level commander uses
 // its own history of commands to determine the initial conditions of the next

--- a/src/modules/interface/estimator/estimator.h
+++ b/src/modules/interface/estimator/estimator.h
@@ -81,7 +81,7 @@ typedef struct
 void stateEstimatorInit(StateEstimatorType estimator);
 bool stateEstimatorTest(void);
 void stateEstimatorSwitchTo(StateEstimatorType estimator);
-void stateEstimator(state_t *state, const uint32_t tick);
+void stateEstimator(state_t *state, const stabilizerStep_t stabilizerStep);
 StateEstimatorType stateEstimatorGetType(void);
 const char* stateEstimatorGetName();
 
@@ -167,5 +167,5 @@ bool estimatorDequeue(measurement_t *measurement);
 #ifdef CONFIG_ESTIMATOR_OOT
 void estimatorOutOfTreeInit(void);
 bool estimatorOutOfTreeTest(void);
-void estimatorOutOfTree(state_t *state, const uint32_t tick);
+void estimatorOutOfTree(state_t *state, const stabilizerStep_t stabilizerStep);
 #endif

--- a/src/modules/interface/estimator/estimator_complementary.h
+++ b/src/modules/interface/estimator/estimator_complementary.h
@@ -29,6 +29,6 @@
 
 void estimatorComplementaryInit(void);
 bool estimatorComplementaryTest(void);
-void estimatorComplementary(state_t *state, const uint32_t tick);
+void estimatorComplementary(state_t *state, const stabilizerStep_t stabilizerStep);
 
 bool estimatorComplementaryEnqueueTOF(const tofMeasurement_t *tof);

--- a/src/modules/interface/estimator/estimator_kalman.h
+++ b/src/modules/interface/estimator/estimator_kalman.h
@@ -58,7 +58,7 @@
 
 void estimatorKalmanInit(void);
 bool estimatorKalmanTest(void);
-void estimatorKalman(state_t *state, const uint32_t tick);
+void estimatorKalman(state_t *state, const stabilizerStep_t stabilizerStep);
 
 void estimatorKalmanTaskInit();
 bool estimatorKalmanTaskTest();

--- a/src/modules/interface/estimator/position_estimator.h
+++ b/src/modules/interface/estimator/position_estimator.h
@@ -27,5 +27,5 @@
 
 #include "stabilizer_types.h"
 
-void positionEstimate(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick);
+void positionEstimate(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, stabilizerStep_t stabilizerStep);
 void positionUpdateVelocity(float accWZ, float dt);

--- a/src/modules/interface/stabilizer.h
+++ b/src/modules/interface/stabilizer.h
@@ -32,7 +32,6 @@
 #include "estimator.h"
 
 #define EMERGENCY_STOP_TIMEOUT_DISABLED (-1)
-
 /**
  * Initialize the stabilizer subsystem and launch the stabilizer loop task.
  * The stabilizer loop task will wait on systemWaitStart() before running.

--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -35,6 +35,9 @@
  * All have a timestamp to be set when the data is calculated.
  */
 
+// stabilizerStep_t represents the number of times the stabilizer loop has run (at 1000 Hz)
+typedef uint32_t stabilizerStep_t;
+
 /** Attitude in euler angle form */
 typedef struct attitude_s {
   uint32_t timestamp;  // Timestamp when the data was computed

--- a/src/modules/src/collision_avoidance.c
+++ b/src/modules/src/collision_avoidance.c
@@ -305,7 +305,7 @@ static float workspace[7 * MAX_CELL_ROWS];
 static uint32_t latency = 0;
 
 void collisionAvoidanceUpdateSetpoint(
-  setpoint_t *setpoint, sensorData_t const *sensorData, state_t const *state, uint32_t tick)
+  setpoint_t *setpoint, sensorData_t const *sensorData, state_t const *state, stabilizerStep_t stabilizerStep)
 {
   if (!collisionAvoidanceEnable) {
     return;
@@ -364,7 +364,7 @@ LOG_GROUP_STOP(colAv)
  * while respecting the buffered Voronoi cell constraint. Our motion within the
  * cell also depends on a planning horizon (longer horizon will lead to more
  * conservative behavior) and a maximum speed. The commander and controller do
- * not need to know if BVCA is enabled. 
+ * not need to know if BVCA is enabled.
  *
  * BVCA does not attempt to smooth the modified setpoints, so the output may be
  * discontinuous or far from the current robot state. The controller must be

--- a/src/modules/src/controller/controller.c
+++ b/src/modules/src/controller/controller.c
@@ -80,8 +80,8 @@ bool controllerTest(void) {
   return controllerFunctions[currentController].test();
 }
 
-void controller(control_t *control, const setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const uint32_t tick) {
-  controllerFunctions[currentController].update(control, setpoint, sensors, state, tick);
+void controller(control_t *control, const setpoint_t *setpoint, const sensorData_t *sensors, const state_t *state, const stabilizerStep_t stabilizerStep) {
+  controllerFunctions[currentController].update(control, setpoint, sensors, state, stabilizerStep);
 }
 
 const char* controllerGetName() {

--- a/src/modules/src/controller/controller_brescianini.c
+++ b/src/modules/src/controller/controller_brescianini.c
@@ -97,7 +97,7 @@ void controllerBrescianini(control_t *control,
                                  const setpoint_t *setpoint,
                                  const sensorData_t *sensors,
                                  const state_t *state,
-                                 const uint32_t tick) {
+                                 const stabilizerStep_t stabilizerStep) {
 
   static float control_omega[3];
   static struct vec control_torque;
@@ -109,7 +109,7 @@ void controllerBrescianini(control_t *control,
   omega[1] = radians(sensors->gyro.y);
   omega[2] = radians(sensors->gyro.z);
 
-  if (RATE_DO_EXECUTE(UPDATE_RATE, tick)) {
+  if (RATE_DO_EXECUTE(UPDATE_RATE, stabilizerStep)) {
     // desired accelerations
     struct vec accDes = vzero();
     // desired thrust

--- a/src/modules/src/controller/controller_indi.c
+++ b/src/modules/src/controller/controller_indi.c
@@ -145,12 +145,12 @@ bool controllerINDITest(void)
 void controllerINDI(control_t *control, const setpoint_t *setpoint,
 	const sensorData_t *sensors,
 	const state_t *state,
-	const uint32_t tick)
+	const stabilizerStep_t stabilizerStep)
 {
 	control->controlMode = controlModeLegacy;
 
 	//The z_distance decoder adds a negative sign to the yaw command, the position decoder doesn't
-	if (RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
+	if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
 		// Rate-controled YAW is moving YAW angle setpoint
 		if (setpoint->mode.yaw == modeVelocity) {
 			attitudeDesired.yaw += setpoint->attitudeRate.yaw * ATTITUDE_UPDATE_DT; //if line 140 (or the other setpoints) in crtp_commander_generic.c has the - sign remove add a -sign here to convert the crazyfly coords (ENU) to INDI  body coords (NED)
@@ -167,14 +167,14 @@ void controllerINDI(control_t *control, const setpoint_t *setpoint,
 		}
 	}
 
-	if (RATE_DO_EXECUTE(POSITION_RATE, tick) && !outerLoopActive) {
+	if (RATE_DO_EXECUTE(POSITION_RATE, stabilizerStep) && !outerLoopActive) {
 		positionController(&actuatorThrust, &attitudeDesired, setpoint, state);
 	}
 
 	/*
 	 * Skipping calls faster than ATTITUDE_RATE
 	 */
-	if (RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
+	if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
 
 		// Call outer loop INDI (position controller)
 		if (outerLoopActive) {

--- a/src/modules/src/controller/controller_mellinger.c
+++ b/src/modules/src/controller/controller_mellinger.c
@@ -115,7 +115,7 @@ bool controllerMellingerTest(controllerMellinger_t* self)
 void controllerMellinger(controllerMellinger_t* self, control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick)
+                                         const stabilizerStep_t stabilizerStep)
 {
   struct vec r_error;
   struct vec v_error;
@@ -131,7 +131,7 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
 
   control->controlMode = controlModeLegacy;
 
-  if (!RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
+  if (!RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
     return;
   }
 
@@ -328,9 +328,9 @@ bool controllerMellingerFirmwareTest(void)
 void controllerMellingerFirmware(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick)
+                                         const stabilizerStep_t stabilizerStep)
 {
-  controllerMellinger(&g_self, control, setpoint, sensors, state, tick);
+  controllerMellinger(&g_self, control, setpoint, sensors, state, stabilizerStep);
 }
 
 

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -56,11 +56,11 @@ static float capAngle(float angle) {
 void controllerPid(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
-                                         const uint32_t tick)
+                                         const stabilizerStep_t stabilizerStep)
 {
   control->controlMode = controlModeLegacy;
 
-  if (RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
+  if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
     // Rate-controled YAW is moving YAW angle setpoint
     if (setpoint->mode.yaw == modeVelocity) {
       attitudeDesired.yaw = capAngle(attitudeDesired.yaw + setpoint->attitudeRate.yaw * ATTITUDE_UPDATE_DT);
@@ -90,11 +90,11 @@ void controllerPid(control_t *control, const setpoint_t *setpoint,
     attitudeDesired.yaw = capAngle(attitudeDesired.yaw);
   }
 
-  if (RATE_DO_EXECUTE(POSITION_RATE, tick)) {
+  if (RATE_DO_EXECUTE(POSITION_RATE, stabilizerStep)) {
     positionController(&actuatorThrust, &attitudeDesired, setpoint, state);
   }
 
-  if (RATE_DO_EXECUTE(ATTITUDE_RATE, tick)) {
+  if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
     // Switch between manual and automatic position control
     if (setpoint->mode.z == modeDisable) {
       actuatorThrust = setpoint->thrust;

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -298,9 +298,9 @@ int crtpCommanderHighLevelDisable()
   return 0;
 }
 
-bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state, uint32_t tick)
+bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *state, stabilizerStep_t stabilizerStep)
 {
-  if (!RATE_DO_EXECUTE(RATE_HL_COMMANDER, tick)) {
+  if (!RATE_DO_EXECUTE(RATE_HL_COMMANDER, stabilizerStep)) {
     return false;
   }
 

--- a/src/modules/src/estimator/estimator.c
+++ b/src/modules/src/estimator/estimator.c
@@ -50,7 +50,7 @@ typedef struct {
   void (*init)(void);
   void (*deinit)(void);
   bool (*test)(void);
-  void (*update)(state_t *state, const uint32_t tick);
+  void (*update)(state_t *state, const stabilizerStep_t stabilizerStep);
   const char* name;
 } EstimatorFcns;
 
@@ -160,7 +160,7 @@ bool stateEstimatorTest(void) {
   return estimatorFunctions[currentEstimator].test();
 }
 
-void stateEstimator(state_t *state, const uint32_t tick) {
+void stateEstimator(state_t *state, const stabilizerStep_t tick) {
   estimatorFunctions[currentEstimator].update(state, tick);
 }
 

--- a/src/modules/src/estimator/estimator_complementary.c
+++ b/src/modules/src/estimator/estimator_complementary.c
@@ -63,7 +63,7 @@ bool estimatorComplementaryTest(void)
   return pass;
 }
 
-void estimatorComplementary(state_t *state, const uint32_t tick)
+void estimatorComplementary(state_t *state, const stabilizerStep_t stabilizerStep)
 {
   // Pull the latest sensors values of interest; discard the rest
   measurement_t m;
@@ -88,7 +88,7 @@ void estimatorComplementary(state_t *state, const uint32_t tick)
   }
 
   // Update filter
-  if (RATE_DO_EXECUTE(ATTITUDE_UPDATE_RATE, tick)) {
+  if (RATE_DO_EXECUTE(ATTITUDE_UPDATE_RATE, stabilizerStep)) {
     sensfusion6UpdateQ(gyro.x, gyro.y, gyro.z,
                         acc.x, acc.y, acc.z,
                         ATTITUDE_UPDATE_DT);
@@ -111,7 +111,7 @@ void estimatorComplementary(state_t *state, const uint32_t tick)
     positionUpdateVelocity(state->acc.z, ATTITUDE_UPDATE_DT);
   }
 
-  if (RATE_DO_EXECUTE(POS_UPDATE_RATE, tick)) {
-    positionEstimate(state, &baro, &tof, POS_UPDATE_DT, tick);
+  if (RATE_DO_EXECUTE(POS_UPDATE_RATE, stabilizerStep)) {
+    positionEstimate(state, &baro, &tof, POS_UPDATE_DT, stabilizerStep);
   }
 }

--- a/src/modules/src/estimator/estimator_kalman.c
+++ b/src/modules/src/estimator/estimator_kalman.c
@@ -273,7 +273,7 @@ static void kalmanTask(void* parameters) {
   }
 }
 
-void estimatorKalman(state_t *state, const uint32_t tick) {
+void estimatorKalman(state_t *state, const stabilizerStep_t stabilizerStep) {
   // This function is called from the stabilizer loop. It is important that this call returns
   // as quickly as possible. The dataMutex must only be locked short periods by the task.
   xSemaphoreTake(dataMutex, portMAX_DELAY);

--- a/src/modules/src/estimator/position_estimator_altitude.c
+++ b/src/modules/src/estimator/position_estimator_altitude.c
@@ -58,18 +58,18 @@ static struct selfState_s state = {
   .estimatedVZ = 0.0f,
 };
 
-static void positionEstimateInternal(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick, struct selfState_s* state);
+static void positionEstimateInternal(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, stabilizerStep_t stabilizerStep, struct selfState_s* state);
 static void positionUpdateVelocityInternal(float accWZ, float dt, struct selfState_s* state);
 
-void positionEstimate(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick) {
-  positionEstimateInternal(estimate, baro, tofMeasurement, dt, tick, &state);
+void positionEstimate(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, stabilizerStep_t stabilizerStep) {
+  positionEstimateInternal(estimate, baro, tofMeasurement, dt, stabilizerStep, &state);
 }
 
 void positionUpdateVelocity(float accWZ, float dt) {
   positionUpdateVelocityInternal(accWZ, dt, &state);
 }
 
-static void positionEstimateInternal(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, uint32_t tick, struct selfState_s* state) {
+static void positionEstimateInternal(state_t* estimate, const baro_t* baro, const tofMeasurement_t* tofMeasurement, float dt, stabilizerStep_t stabilizerStep, struct selfState_s* state) {
   float filteredZ;
   static float prev_estimatedZ = 0;
   static bool surfaceFollowingMode = false;

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -239,7 +239,7 @@ static void setMotorRatios(const motors_thrust_pwm_t* motorPwm)
  */
 static void stabilizerTask(void* param)
 {
-  uint32_t tick;
+  stabilizerStep_t stabilizerStep;
   uint32_t lastWakeTime;
   vTaskSetApplicationTaskTag(0, (void*)TASK_STABILIZER_ID_NBR);
 
@@ -253,8 +253,8 @@ static void stabilizerTask(void* param)
   while(!sensorsAreCalibrated()) {
     vTaskDelayUntil(&lastWakeTime, F2T(RATE_MAIN_LOOP));
   }
-  // Initialize tick to something else then 0
-  tick = 1;
+  // Initialize stabilizerStep to something else than 0
+  stabilizerStep = 1;
 
   rateSupervisorInit(&rateSupervisorContext, xTaskGetTickCount(), M2T(1000), 997, 1003, 1);
 
@@ -265,7 +265,7 @@ static void stabilizerTask(void* param)
     sensorsWaitDataReady();
 
     // update sensorData struct (for logging variables)
-    sensorsAcquire(&sensorData, tick);
+    sensorsAcquire(&sensorData);
 
     if (healthShallWeRunTest()) {
       healthRunTests(&sensorData);
@@ -281,19 +281,19 @@ static void stabilizerTask(void* param)
         controllerType = controllerGetType();
       }
 
-      stateEstimator(&state, tick);
+      stateEstimator(&state, stabilizerStep);
       compressState();
 
-      if (crtpCommanderHighLevelGetSetpoint(&tempSetpoint, &state, tick)) {
+      if (crtpCommanderHighLevelGetSetpoint(&tempSetpoint, &state, stabilizerStep)) {
         commanderSetSetpoint(&tempSetpoint, COMMANDER_PRIORITY_HIGHLEVEL);
       }
 
       commanderGetSetpoint(&setpoint, &state);
       compressSetpoint();
 
-      collisionAvoidanceUpdateSetpoint(&setpoint, &sensorData, &state, tick);
+      collisionAvoidanceUpdateSetpoint(&setpoint, &sensorData, &state, stabilizerStep);
 
-      controller(&control, &setpoint, &sensorData, &state, tick);
+      controller(&control, &setpoint, &sensorData, &state, stabilizerStep);
 
       checkEmergencyStopTimeout();
 
@@ -316,12 +316,12 @@ static void stabilizerTask(void* param)
       // Log data to uSD card if configured
       if (usddeckLoggingEnabled()
           && usddeckLoggingMode() == usddeckLoggingMode_SynchronousStabilizer
-          && RATE_DO_EXECUTE(usddeckFrequency(), tick)) {
+          && RATE_DO_EXECUTE(usddeckFrequency(), stabilizerStep)) {
         usddeckTriggerLogging();
       }
 #endif
       calcSensorToOutputLatency(&sensorData);
-      tick++;
+      stabilizerStep++;
       STATS_CNT_RATE_EVENT(&stabilizerRate);
 
       if (!rateSupervisorValidate(&rateSupervisorContext, xTaskGetTickCount())) {

--- a/test_python/test_controller_brescianini.py
+++ b/test_python/test_controller_brescianini.py
@@ -37,9 +37,9 @@ def test_controller_brescianini():
     sensors.gyro.y = 0
     sensors.gyro.z = 0
 
-    tick = 100
+    step = 100
 
-    cffirmware.controllerBrescianini(control, setpoint,sensors,state,tick)
+    cffirmware.controllerBrescianini(control, setpoint,sensors,state,step)
     assert control.controlMode == cffirmware.controlModeForceTorque
     # control.thrustSi will be at a (tuned) hover-state
     assert control.torqueX == 0

--- a/test_python/test_controller_mellinger.py
+++ b/test_python/test_controller_mellinger.py
@@ -35,9 +35,9 @@ def test_controller_mellinger():
     sensors.gyro.y = 0
     sensors.gyro.z = 0
 
-    tick = 100
+    step = 100
 
-    cffirmware.controllerMellinger(ctrl, control, setpoint,sensors,state,tick)
+    cffirmware.controllerMellinger(ctrl, control, setpoint,sensors,state,step)
     assert control.controlMode == cffirmware.controlModeLegacy
     # control.thrust will be at a (tuned) hover-state
     assert control.roll == 0

--- a/test_python/test_controller_pid.py
+++ b/test_python/test_controller_pid.py
@@ -33,9 +33,9 @@ def test_controller_pid():
     sensors.gyro.y = 0
     sensors.gyro.z = 0
 
-    tick = 100
+    step = 100
 
-    cffirmware.controllerPid(control, setpoint,sensors,state,tick)
+    cffirmware.controllerPid(control, setpoint,sensors,state,step)
     assert control.controlMode == cffirmware.controlModeLegacy
     # control.thrust will be at a (tuned) hover-state
     assert control.roll == 0


### PR DESCRIPTION
The variable `tick` in the stabilizer loop is not the same thing as the system tick, but the naming makes it very confusing. This PR introduces a new type as well as changes the name to make the difference more obvious.
