### PR TITLE
Add CPX_F_APP in cpxInternalRouter

### DIFF
--- a/src/modules/src/cpx/cpx_internal_router.c
+++ b/src/modules/src/cpx/cpx_internal_router.c
@@ -76,6 +76,7 @@ void cpxInternalRouterRouteIn(const CPXRoutablePacket_t* packet) {
       case CPX_F_SYSTEM:
       case CPX_F_CONSOLE:
       case CPX_F_WIFI_CTRL:
+      case CPX_F_APP:
       case CPX_F_BOOTLOADER:
       case CPX_F_TEST:
         xQueueSend(mixedQueue, packet, portMAX_DELAY);


### PR DESCRIPTION
CPX packet on CPX_F_APP function not handled in `cpxInternalRouterRouteIn()`.
Currently, the user can't receive packets using `cpxInternalRouterReceiveOthers()` to develop their own app.