### PR TITLE
Improvements to CPX base on PR#1273

### DIFF
--- a/src/modules/src/cpx/cpx.c
+++ b/src/modules/src/cpx/cpx.c
@@ -86,6 +86,17 @@ bool cpxCheckVersion(const uint8_t version) {
   return isVersionOk;
 }
 
+// Deepcopy from the received packet cpxRx to the provided packet
+void cpxGetRxPacket(CPXPacket_t* packet) {
+  packet->route.destination=cpxRx.route.destination;
+  packet->route.source=cpxRx.route.source;
+  packet->route.lastPacket=cpxRx.route.lastPacket;
+  packet->route.function=cpxRx.route.function;
+  packet->route.version=cpxRx.route.version;
+  packet->dataLength=cpxRx.dataLength;
+  memcpy(packet->data, cpxRx.data, cpxRx.dataLength);
+}
+
 static void cpx(void* _param) {
   systemWaitStart();
   while (1) {
@@ -144,6 +155,9 @@ static void cpx(void* _param) {
             cpxLinkSetConnected(true);
           }
         }
+        break;
+      case CPX_F_APP:
+        DEBUG_PRINT("CPX:Receive APP Message from [0x%02X]\n", cpxRx.route.source);
         break;
       default:
         DEBUG_PRINT("Not handling function [0x%02X] from [0x%02X]\n", cpxRx.route.function, cpxRx.route.source);

--- a/src/modules/src/cpx/cpx_internal_router.c
+++ b/src/modules/src/cpx/cpx_internal_router.c
@@ -77,6 +77,7 @@ void cpxInternalRouterRouteIn(const CPXRoutablePacket_t* packet) {
       case CPX_F_CONSOLE:
       case CPX_F_WIFI_CTRL:
       case CPX_F_BOOTLOADER:
+      case CPX_F_APP:
       case CPX_F_TEST:
         xQueueSend(mixedQueue, packet, portMAX_DELAY);
         break;


### PR DESCRIPTION
Dear Bitcraze:

In the PR #1273, my collaborator @RavenLite commit a PR about fixing the CPX_F_APP in CPX protocol. Now this work will be carried forward by me.

In this PR, we fix **three** main problems:

1. We add a case about putting CPX_F_APP message into **mixedQueue** in cpx_internal_router.c to **make sure that the CF can receive message with type CPX_F_APP**.

2. We add a handle in main code cpx.c. As @krichardsson said last time:"You need to add a function pointer and a function where an app can register a handler function for the pointer."But we believe that, as the name of this message category(CPX_F_APP) suggests, **processing this message should be done in a user-defined app**. So we added only an alert for the received message.

3. We add a deepcopy function to carry the CPXpacket from cpxRx to user-defined cpx packet. We do this because we can't directly use the function named **cpxInternalRouterReceiveOthers()** in the app-layer due to the repeat reception. So we believe that a deep copy function is needed. Users can copy the packets received by the system to their own app without causing conflicts.

Thank you for your reviewing.