### PR TITLE
Align trajectory memory

### DIFF
--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -86,7 +86,7 @@ struct trajectoryDescription
 #define ALL_GROUPS 0
 
 // Global variables
-uint8_t trajectories_memory[TRAJECTORY_MEMORY_SIZE];
+uint8_t trajectories_memory[TRAJECTORY_MEMORY_SIZE] __attribute__((aligned(4)));
 static struct trajectoryDescription trajectory_descriptions[NUM_TRAJECTORY_DEFINITIONS];
 
 // Static structs are zero-initialized, so nullSetpoint corresponds to


### PR DESCRIPTION
This PR alignes the trajectory memory on 4 byte boundaries. This fixes a part of a problem that has become visible with V12 of the compiler.
The root problem is that the trajectory memory is defined as a uint8 array, when a trajectory is read, a pointer into the array is cast to a struct containing floats. Floats must be aligned and If the array is not aligned properly we get a hardfault. Most likely the array has (by chance) been aligned by the old compiler, but V12 does not and we get a hard fault.

There is still a secondary problem that this fix does not solve. It is possible to upload trajectories to an abitrary offset which can still mess up the alignment 