### PR TITLE
Remove "charger connected" from supervisor

### DIFF
--- a/docs/functional-areas/supervisor/states.md
+++ b/docs/functional-areas/supervisor/states.md
@@ -8,6 +8,12 @@ page_id: supervisor_states
      Boot|
          V
 +-------------------+
++  Not initialized  +
++                   +
++--------+----------+
+         |
+         V
++-------------------+
 + Pre-flight checks +<------------+
 +    not passed     +<--+         |
 +-------+-----------+   |         |

--- a/src/modules/interface/supervisor_state_machine.h
+++ b/src/modules/interface/supervisor_state_machine.h
@@ -41,14 +41,15 @@ typedef enum {
 } supervisorState_t;
 
 // Conditions supported by the supervisor
-enum {
+typedef enum {
   supervisorConditionArmed = 0,
   supervisorConditionIsFlying,
   supervisorConditionIsTumbled,
   supervisorConditionCommanderWdtWarning,
   supervisorConditionCommanderWdtTimeout,
   supervisorConditionEmergencyStop,
-};
+  supervisorCondition_NrOfConditions,
+} supervisorConditions_t;
 
 typedef uint32_t supervisorConditionBits_t;
 
@@ -92,3 +93,6 @@ typedef struct {
 #define SUPERVISOR_TRANSITION_ENTRY(TRANSITION_DEF) .transitionList=TRANSITION_DEF, .length=(sizeof(TRANSITION_DEF) / sizeof(SupervisorStateTransition_t))
 
 supervisorState_t supervisorStateUpdate(const supervisorState_t currentState, const supervisorConditionBits_t conditions);
+
+const char* supervisorGetStateName(const supervisorState_t currentState);
+const char* supervisorGetConditionName(const supervisorState_t condition);

--- a/src/modules/interface/supervisor_state_machine.h
+++ b/src/modules/interface/supervisor_state_machine.h
@@ -27,7 +27,8 @@
 #include <stdint.h>
 
 typedef enum {
-    supervisorStatePreFlChecksNotPassed = 0,
+    supervisorStateNotInitialized = 0,
+    supervisorStatePreFlChecksNotPassed,
     supervisorStatePreFlChecksPassed,
     supervisorStateReadyToFly,
     supervisorStateFlying,

--- a/src/modules/interface/supervisor_state_machine.h
+++ b/src/modules/interface/supervisor_state_machine.h
@@ -43,7 +43,6 @@ typedef enum {
 // Conditions supported by the supervisor
 enum {
   supervisorConditionArmed = 0,
-  supervisorConditionChargerConnected,
   supervisorConditionIsFlying,
   supervisorConditionIsTumbled,
   supervisorConditionCommanderWdtWarning,
@@ -56,7 +55,6 @@ typedef uint32_t supervisorConditionBits_t;
 // Condition bit definitions
 #define SUPERVISOR_CB_NONE (0)
 #define SUPERVISOR_CB_ARMED (1 << supervisorConditionArmed)
-#define SUPERVISOR_CB_CHARGER_CONNECTED (1 << supervisorConditionChargerConnected)
 #define SUPERVISOR_CB_IS_FLYING (1 << supervisorConditionIsFlying)
 #define SUPERVISOR_CB_IS_TUMBLED (1 << supervisorConditionIsTumbled)
 #define SUPERVISOR_CB_COMMANDER_WDT_WARNING (1 << supervisorConditionCommanderWdtWarning)

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -161,7 +161,7 @@ static void transitionActions(const supervisorState_t currentState, const superv
     DEBUG_PRINT("Locked, reboot required\n");
   }
 
-  if ((currentState == supervisorStateReadyToFly || currentState == supervisorStateFlying) &&
+  if ((currentState == supervisorStateNotInitialized || currentState == supervisorStateReadyToFly || currentState == supervisorStateFlying) &&
       newState != supervisorStateReadyToFly && newState != supervisorStateFlying) {
     DEBUG_PRINT("Can not fly\n");
   }

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -27,6 +27,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "FreeRTOS.h"
 #include "task.h"

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -28,11 +28,13 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "FreeRTOS.h"
+#include "task.h"
+
 #include "log.h"
 #include "param.h"
 #include "motors.h"
 #include "power_distribution.h"
-#include "pm.h"
 #include "supervisor.h"
 #include "supervisor_state_machine.h"
 #include "platform_defaults.h"
@@ -172,10 +174,6 @@ static supervisorConditionBits_t updateAndpopulateConditions(SupervisorMem_t* th
 
   if (systemIsArmed()) {
     conditions |= SUPERVISOR_CB_ARMED;
-  }
-
-  if (pmIsChargerConnected()) {
-    conditions |= SUPERVISOR_CB_CHARGER_CONNECTED;
   }
 
   const bool isFlying = isFlyingCheck(this, currentTick);

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -25,6 +25,7 @@
 #include <stdbool.h>
 #include <assert.h>
 #include "supervisor_state_machine.h"
+#include "platform_defaults.h"
 #include "test_support.h"
 
 // #define DEBUG_ME
@@ -49,6 +50,12 @@ static_assert(sizeof(stateNames) / sizeof(stateNames[0]) == supervisorState_NrOf
 #endif
 
 
+#if SUPERVISOR_TUMBLE_CHECK_ENABLE
+  #define SUPERVISOR_CB_CONF_IS_TUMBLED (SUPERVISOR_CB_IS_TUMBLED)
+#else
+  #define SUPERVISOR_CB_CONF_IS_TUMBLED (SUPERVISOR_CB_NONE)
+#endif
+
 // State transition definitions
 static SupervisorStateTransition_t transitionsNotInitialized[] = {
   {
@@ -64,7 +71,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksNotPassed[] = {
 
     .triggerCombiner = supervisorAlways,
 
-    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .blockers = SUPERVISOR_CB_CONF_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedBlockers = SUPERVISOR_CB_NONE,
     .blockerCombiner = supervisorAny,
   }
@@ -74,7 +81,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksPassed[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .triggers = SUPERVISOR_CB_CONF_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAny,
 
@@ -87,7 +94,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksPassed[] = {
     .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAll,
 
-    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .blockers = SUPERVISOR_CB_CONF_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedBlockers = SUPERVISOR_CB_NONE,
     .blockerCombiner = supervisorAny,
   },
@@ -97,7 +104,7 @@ static SupervisorStateTransition_t transitionsReadyToFly[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .triggers = SUPERVISOR_CB_CONF_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 
@@ -118,7 +125,7 @@ static SupervisorStateTransition_t transitionsFlying[] = {
   {
     .newState = supervisorStateExceptFreeFall,
 
-    .triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_CONF_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 
@@ -168,7 +175,7 @@ static SupervisorStateTransition_t transitionsWarningLevelOut[] = {
   {
     .newState = supervisorStateExceptFreeFall,
 
-    .triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_CONF_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -34,8 +34,10 @@
 #define DEBUG_MODULE "SUPST"
 #include "debug.h"
 #include "cfassert.h"
+#endif
 
 static const char* const stateNames[] = {
+  "Not initialized",
   "Pre-flight checks not passed",
   "Pre-flight checks passed",
   "Ready to fly",
@@ -47,8 +49,16 @@ static const char* const stateNames[] = {
   "Locked",
 };
 static_assert(sizeof(stateNames) / sizeof(stateNames[0]) == supervisorState_NrOfStates);
-#endif
 
+static const char* const conditionNames[] = {
+  "armed",
+  "isFlying",
+  "isTumbled",
+  "commanderWdtWarning",
+  "commanderWdtTimeout",
+  "emergencyStop",
+};
+static_assert(sizeof(conditionNames) / sizeof(conditionNames[0]) == supervisorCondition_NrOfConditions);
 
 #if SUPERVISOR_TUMBLE_CHECK_ENABLE
   #define SUPERVISOR_CB_CONF_IS_TUMBLED (SUPERVISOR_CB_IS_TUMBLED)
@@ -301,4 +311,12 @@ supervisorState_t supervisorStateUpdate(const supervisorState_t currentState, co
   #endif
 
   return newState;
+}
+
+const char* supervisorGetStateName(const supervisorState_t state) {
+  return stateNames[state];
+}
+
+const char* supervisorGetConditionName(const supervisorState_t condition) {
+  return conditionNames[condition];
 }

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -64,7 +64,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksNotPassed[] = {
 
     .triggerCombiner = supervisorAlways,
 
-    .blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedBlockers = SUPERVISOR_CB_NONE,
     .blockerCombiner = supervisorAny,
   }
@@ -74,7 +74,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksPassed[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAny,
 
@@ -87,7 +87,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksPassed[] = {
     .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAll,
 
-    .blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedBlockers = SUPERVISOR_CB_NONE,
     .blockerCombiner = supervisorAny,
   },
@@ -97,7 +97,7 @@ static SupervisorStateTransition_t transitionsReadyToFly[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_EMERGENCY_STOP,
+    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -50,6 +50,14 @@ static_assert(sizeof(stateNames) / sizeof(stateNames[0]) == supervisorState_NrOf
 
 
 // State transition definitions
+static SupervisorStateTransition_t transitionsNotInitialized[] = {
+  {
+    .newState = supervisorStatePreFlChecksNotPassed,
+    .triggerCombiner = supervisorAlways,
+    .blockerCombiner = supervisorNever,
+  }
+};
+
 static SupervisorStateTransition_t transitionsPreFlChecksNotPassed[] = {
   {
     .newState = supervisorStatePreFlChecksPassed,
@@ -198,6 +206,7 @@ static SupervisorStateTransition_t transitionsLocked[] = {
 };
 
 SupervisorStateTransitionList_t transitionLists[] = {
+  {SUPERVISOR_TRANSITION_ENTRY(transitionsNotInitialized)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsPreFlChecksNotPassed)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsPreFlChecksPassed)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsReadyToFly)},

--- a/test/modules/src/test_supervisor_state_machine.c
+++ b/test/modules/src/test_supervisor_state_machine.c
@@ -79,9 +79,9 @@ void testTransitionWithNoConditionsBlockAlways(void) {
 
 void testTransitionOneRequiredConditionMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
@@ -98,7 +98,7 @@ void testTransitionOneRequiredConditionNotMet(void) {
   // Fixture
   supervisorConditionBits_t conditions = SUPERVISOR_CB_ARMED;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
@@ -113,10 +113,10 @@ void testTransitionOneRequiredConditionNotMet(void) {
 
 void testTransitionOneNegatedRequiredConditionNotMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -133,7 +133,7 @@ void testTransitionOneNegatedRequiredConditionMet(void) {
   supervisorConditionBits_t conditions = 0;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -147,9 +147,9 @@ void testTransitionOneNegatedRequiredConditionMet(void) {
 
 void testTransitionMultiRequiredConditionsMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
@@ -164,9 +164,9 @@ void testTransitionMultiRequiredConditionsMet(void) {
 
 void testTransitionMultiRequiredConditionsMetWithOtherBitsSet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_EMERGENCY_STOP;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_EMERGENCY_STOP;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
@@ -181,9 +181,9 @@ void testTransitionMultiRequiredConditionsMetWithOtherBitsSet(void) {
 
 void testTransitionMultiRequiredConditionsOneMissing(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
@@ -198,9 +198,9 @@ void testTransitionMultiRequiredConditionsOneMissing(void) {
 
 void testTransitionMultiRequiredConditionsOneMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAny;
 
@@ -218,7 +218,7 @@ void testTransitionMultiNegatedRequiredConditionOneNotMet(void) {
   supervisorConditionBits_t conditions = SUPERVISOR_CB_ARMED;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -235,7 +235,7 @@ void testTransitionMultiNegatedRequiredConditionsMet(void) {
   supervisorConditionBits_t conditions = 0;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -252,7 +252,7 @@ void testTransitionMultiMixedRequiredConditionsAllMet(void) {
   supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -269,7 +269,7 @@ void testTransitionMultiMixedRequiredConditionsOnePositiveNotMet(void) {
   supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -283,10 +283,10 @@ void testTransitionMultiMixedRequiredConditionsOnePositiveNotMet(void) {
 
 void testTransitionMultiMixedRequiredConditionsOneNegativeNotMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -300,10 +300,10 @@ void testTransitionMultiMixedRequiredConditionsOneNegativeNotMet(void) {
 
 void testTransitionMultiMixedOnePositiveRequirementMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAny;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -317,10 +317,10 @@ void testTransitionMultiMixedOnePositiveRequirementMet(void) {
 
 void testTransitionMultiMixedNoRequirementMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_IS_FLYING | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_IS_FLYING | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAny;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -334,10 +334,10 @@ void testTransitionMultiMixedNoRequirementMet(void) {
 
 void testTransitionMultiMixedOneNegativeRequirementMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_IS_FLYING | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED;
-  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
+  supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_IS_FLYING | SUPERVISOR_CB_ARMED | SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAny;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
@@ -351,9 +351,9 @@ void testTransitionMultiMixedOneNegativeRequirementMet(void) {
 
 void testTransitionMultiRequiredConditionsOneMissingButOtherBitsSet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
 
-  supervisorConditionBits_t triggers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_ARMED;
+  supervisorConditionBits_t triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_ARMED;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
@@ -374,7 +374,7 @@ void testTransitionOneProhibitedConditionMet(void) {
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -385,13 +385,13 @@ void testTransitionOneProhibitedConditionMet(void) {
 
 void testTransitionOneProhibitedConditionNotMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -402,13 +402,13 @@ void testTransitionOneProhibitedConditionNotMet(void) {
 
 void testTransitionOneProhibitedConditionNotMetWithOtherBitsSet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -425,7 +425,7 @@ void testTransitionMultiProhibitedConditionsMet(void) {
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -442,7 +442,7 @@ void testTransitionMultiProhibitedConditionsOneNotMet(void) {
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -453,13 +453,13 @@ void testTransitionMultiProhibitedConditionsOneNotMet(void) {
 
 void testTransitionMultiProhibitedConditionsAllNotMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAll;
 
@@ -470,13 +470,13 @@ void testTransitionMultiProhibitedConditionsAllNotMet(void) {
 
 void testTransitionMultiProhibitedConditionsAllMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAll;
 
@@ -487,14 +487,14 @@ void testTransitionMultiProhibitedConditionsAllMet(void) {
 
 void testTransitionMultiNegativeProhibitedConditionsNoneMet(void) {
   // Fixture
-  supervisorConditionBits_t conditions = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t conditions = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
 
   supervisorConditionBits_t triggers = SUPERVISOR_CB_NONE;
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
   // Test
@@ -511,7 +511,7 @@ void testTransitionMultiNegativeProhibitedConditionsOneMet(void) {
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
   // Test
@@ -528,7 +528,7 @@ void testTransitionMultiNegativeProhibitedConditionsOneNotMet(void) {
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAll;
 
   // Test
@@ -545,7 +545,7 @@ void testTransitionMultiNegativeProhibitedConditionsAllMet(void) {
   SupervisorConditionCombiner_t triggerCombiner = supervisorAlways;
 
   supervisorConditionBits_t blockers = SUPERVISOR_CB_NONE;
-  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_IS_TUMBLED;
+  supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_IS_TUMBLED;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAll;
 
   // Test
@@ -561,7 +561,7 @@ void testTransitionMultiRequiredAndProhibitedConditionsMet(void) {
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_EMERGENCY_STOP;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_EMERGENCY_STOP;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -578,7 +578,7 @@ void testTransitionMultiRequiredAndProhibitedConditionsOneRequiredNotMet(void) {
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_EMERGENCY_STOP;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_EMERGENCY_STOP;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -595,7 +595,7 @@ void testTransitionMultiRequiredAndProhibitedConditionsOneProhibitedNotMet(void)
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_EMERGENCY_STOP;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_EMERGENCY_STOP;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 
@@ -612,7 +612,7 @@ void testTransitionMultiRequiredAndProhibitedConditionsMultipleNotMet(void) {
   supervisorConditionBits_t negatedTriggers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t triggerCombiner = supervisorAll;
 
-  supervisorConditionBits_t blockers = SUPERVISOR_CB_CHARGER_CONNECTED | SUPERVISOR_CB_EMERGENCY_STOP;
+  supervisorConditionBits_t blockers = SUPERVISOR_CB_COMMANDER_WDT_WARNING | SUPERVISOR_CB_EMERGENCY_STOP;
   supervisorConditionBits_t negatedBlockers = SUPERVISOR_CB_NONE;
   SupervisorConditionCombiner_t blockerCombiner = supervisorAny;
 


### PR DESCRIPTION
Currently the supervisor checks if we are connected to a chargers, the idea being that we should not try to fly when connected to USB. 

The problem is that It is not possible to detect if a USB cable is connected (due to hardware) and currently the check actually means something closer to "are we charging". The problem is that this also includes the Qi charger which prevents take-offs when charging on a charging pad.

This PR removes all charging related functionatlity from the supervisor.

The PR also includes some improved logging, including a dump of the supervisor state.