### PR TITLE
Stop high level commander instead of disable

### DIFF
--- a/src/modules/src/commander.c
+++ b/src/modules/src/commander.c
@@ -84,9 +84,8 @@ void commanderSetSetpoint(setpoint_t *setpoint, int priority)
     xQueueOverwrite(setpointQueue, setpoint);
     xQueueOverwrite(priorityQueue, &priority);
     if (priority > COMMANDER_PRIORITY_HIGHLEVEL) {
-      // Disable the high-level planner so it will forget its current state and
-      // start over if we switch from low-level to high-level in the future.
-      crtpCommanderHighLevelDisable();
+      // Stop the high-level planner so it will forget its current state
+      crtpCommanderHighLevelStop();
     }
   }
 }

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -321,8 +321,9 @@ bool crtpCommanderHighLevelGetSetpoint(setpoint_t* setpoint, const state_t *stat
     yaw = radians(state->attitude.yaw);
     if (plan_is_stopped(&planner)) {
       // Return a null setpoint - when the HLcommander is stopped, it wants the
-      // motors to be off. Only reason they should be spinning is if the
-      // HLcommander has been preempted by a streaming setpoint command.
+      // motors to be off.
+      // Note: this set point will be overridden by low level set points, for instance received from an external source,
+      // due to the priority. To switch back to the high level commander, use the `commanderRelaxPriority()` functionality.
       *setpoint = nullSetpoint;
       return true;
     }


### PR DESCRIPTION
This PR changes the behavior of the high level commander when receiving low level set points, for instance from an external script. 

The new functionality is to stop the high level commander instead of disabling it. The difference is that when the high level commander is stopped, it will still send null set points to the system, while it is quiet when disabled. 
This makes a difference if a user sends in some low level set points for a while, and then whants to go back to the high level commander by using the meta message to relax the set point priority. In the current implementation, the user must first re-start the high level commander and then relax the priority. With this PR, the high level commander will still run and produce null set points which means that the user can go back to the previous state by only relaxing priority.