### PR TITLE
Correction of the kalman estimator rate

### DIFF
--- a/src/modules/src/estimator/estimator_kalman.c
+++ b/src/modules/src/estimator/estimator_kalman.c
@@ -112,7 +112,9 @@ static StaticSemaphore_t dataMutexBuffer;
 /**
  * Tuning parameters
  */
-#define PREDICT_RATE RATE_100_HZ // this is slower than the IMU update rate of 500Hz
+#define PREDICT_RATE RATE_100_HZ // this is slower than the IMU update rate of 1000Hz
+const uint32_t PREDICTION_UPDATE_INTERVAL_MS = 1000 / PREDICT_RATE;
+
 // The bounds on the covariance, these shouldn't be hit, but sometimes are... why?
 #define MAX_COVARIANCE (100)
 #define MIN_COVARIANCE (1e-6f)
@@ -233,12 +235,12 @@ static void kalmanTask(void* parameters) {
       axis3fSubSamplerFinalize(&gyroSubSampler);
 
       kalmanCorePredict(&coreData, &accSubSampler.subSample, &gyroSubSampler.subSample, nowMs, quadIsFlying);
-      nextPredictionMs = nowMs + (1000.0f / PREDICT_RATE);
+      nextPredictionMs = nowMs + PREDICTION_UPDATE_INTERVAL_MS;
 
       STATS_CNT_RATE_EVENT(&predictionCounter);
 
       if (!rateSupervisorValidate(&rateSupervisorContext, nowMs)) {
-        DEBUG_PRINT("WARNING: Kalman prediction rate low (%lu)\n", rateSupervisorLatestCount(&rateSupervisorContext));
+        DEBUG_PRINT("WARNING: Kalman prediction rate off (%lu)\n", rateSupervisorLatestCount(&rateSupervisorContext));
       }
     }
 


### PR DESCRIPTION
A float is used to compute the next time the prediction should run. When the system tick is larger than 0x2000000, the float operation gets rounding errors and the interval becomes too short.
The problem is observed after 9 hours and 20 minutes of up time and the symptom is a warning in the console log that the prediction rate is too high (around 125 Hz).
This PR fixes the problem by not using a float. 