### PR TITLE
Fix - logGetVarId - Return Log ID that matches the Log ID in Logs TOC

### DIFF
--- a/src/modules/src/log.c
+++ b/src/modules/src/log.c
@@ -990,6 +990,7 @@ logVarId_t logGetVarId(const char* group, const char* name)
   int i;
   logVarId_t varId = invalidVarId;
   char * currgroup = "";
+  uint16_t n = 0;
 
   for(i=0; i<logsLen; i++)
   {
@@ -997,12 +998,15 @@ logVarId_t logGetVarId(const char* group, const char* name)
       if (logs[i].type & LOG_START) {
         currgroup = logs[i].name;
       }
-    } else if ((!strcmp(group, currgroup)) && (!strcmp(name, logs[i].name))) {
-      varId = (logVarId_t)i;
-      return varId;
-    }
+    } 
+    else {
+      if ((strcmp(group, currgroup) == 0) && (strcmp(name, logs[i].name)) == 0) {
+        varId = (logVarId_t)i;
+        return n;
+        }
+        n++;
+        }
   }
-
   return invalidVarId;
 }
 


### PR DESCRIPTION
Current implementation does not return the correct log ID that matches TOC for  logGetVarId, this is a fix to address that, within the fix, the return value matches the log ID as defined in the TOC.  