### PR TITLE
Added setup.py for installing Python bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ MOD_SRC = src/modules/src
 bindings_python build/cffirmware.py: bindings/setup.py $(MOD_SRC)/*.c
 	swig -python -I$(MOD_INC) -Isrc/hal/interface -Isrc/utils/interface -Isrc/modules/interface/controller -o build/cffirmware_wrap.c bindings/cffirmware.i
 	$(PYTHON) bindings/setup.py build_ext --inplace
+	cp cffirmware_setup.py build/setup.py
 
 test_python: build/cffirmware.py
 	PYTHONPATH=build $(PYTHON) -m pytest test_python

--- a/cffirmware_setup.py
+++ b/cffirmware_setup.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  Distutils setup file for Crazyflie Python firmware bindings
+#
+#  Automatically copied to build/ directory when you run
+#
+#      make bindings_python
+#
+#  Then you can cd to build/ and do
+#
+#      sudo python3 setup.py install
+#
+#  Copyright (C) 2023 Bitcraze AB and Simon D. Levy
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+from distutils.core import setup
+
+setup(
+    name='cffirmware',
+    version='0.1',
+    packages=[''],
+    package_dir={'': '.'},
+    package_data={'': ['_cffirmware.cpython-38-x86_64-linux-gnu.so']},
+)

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -138,7 +138,7 @@ First make sure that you have [SWIG](https://swig.org/) installed on your system
 make cf2_defconfig
 make bindings_python
 cd build
-sudo python3 setup.py install
+python3 setup.py install --user
 ```
 
 ## Make targets

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -137,8 +137,9 @@ First make sure that you have [SWIG](https://swig.org/) installed on your system
 ```bash
 make cf2_defconfig
 make bindings_python
+cd build
+sudo python3 setup.py install
 ```
-
 
 ## Make targets
 


### PR DESCRIPTION
This feature allows you to install the Python cffirmware lib globally. 