### PR TITLE
Optimize UART read for lighthouse

### DIFF
--- a/src/drivers/interface/uart1.h
+++ b/src/drivers/interface/uart1.h
@@ -95,11 +95,24 @@ bool uart1GetDataWithDefaultTimeout(uint8_t *c);
  *
  * @param[in] size  Number of bytes to read
  * @param[out] data  Pointer to data
- * 
+ *
  * @return number of bytes read
  */
 void uart1GetBytesWithDefaultTimeout(uint32_t size, uint8_t* data);
 
+/**
+ * @brief Get the number of bytes available in the UART1 in queue
+ *
+ * @return uint32_t  Number of bytes available
+ */
+uint32_t uart1bytesAvailable();
+
+/**
+ * @brief Get the maximum number of bytes that can be stored in the UART1 in queue
+ *
+ * @return uint32_t  The maximum length of the in queue
+ */
+uint32_t uart1QueueMaxLength();
 
 /**
  * Sends raw data using a lock. Should be used from

--- a/src/drivers/src/uart1.c
+++ b/src/drivers/src/uart1.c
@@ -48,8 +48,9 @@
  */
 //#define ENABLE_UART1_DMA
 
+#define QUEUE_LENGTH 64
 static xQueueHandle uart1queue;
-STATIC_MEM_QUEUE_ALLOC(uart1queue, 64, sizeof(uint8_t));
+STATIC_MEM_QUEUE_ALLOC(uart1queue, QUEUE_LENGTH, sizeof(uint8_t));
 
 static bool isInit = false;
 static bool hasOverrun = false;
@@ -261,6 +262,16 @@ int uart1Putchar(int ch)
 void uart1Getchar(char * ch)
 {
   xQueueReceive(uart1queue, ch, portMAX_DELAY);
+}
+
+uint32_t uart1bytesAvailable()
+{
+  return uxQueueMessagesWaiting(uart1queue);
+}
+
+uint32_t uart1QueueMaxLength()
+{
+  return QUEUE_LENGTH;
 }
 
 bool uart1DidOverrun()


### PR DESCRIPTION
This PR reduces the CPU load when using the lighthouse system by optimizing the process of reading from the UART.

The current implementation works by using a queue that is filled from an interrupt, triggered when one more byte is available on the UART. The lighthouse task is removing bytes from the queue when reading the next frame and is locking on the queue to get the next byte as soon as possible. This locking (and task switching?) seems to take a long time. This PR uses a `vTaskDelay()` in a loop to make sure there are enough data in the buffer before reading to avoid the queue lock.

With 4 base stations received CPU load for the LH taks goes down from 21% to 6%.

By increasing the time in the `vTaskDelay()` to 2, the CPU load goes down one or two % more, but it also adds a delay.

 