### PR TITLE
Remove links to binaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,8 +45,8 @@ jobs:
       with:
         name: ${{ matrix.platform }}-${{ github.sha }}
         path: |
-          ${{ matrix.platform }}.bin
-          ${{ matrix.platform }}.elf
+          build/${{ matrix.platform }}.bin
+          build/${{ matrix.platform }}.elf
 
   features:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ${{ matrix.platform }}.bin
+        asset_path: build/${{ matrix.platform }}.bin
         asset_name: ${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
         asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -124,13 +124,6 @@ all: $(PROG).hex $(PROG).bin
 	@$(PYTHON) $(srctree)/tools/make/versionTemplate.py --crazyflie-base $(srctree) --print-version
 	@$(PYTHON) $(srctree)/tools/make/size.py $(SIZE) $(PROG).elf $(MEM_SIZE_FLASH_K) $(MEM_SIZE_RAM_K) $(MEM_SIZE_CCM_K)
 
-	#
-	# Create symlinks to the ouput files in the build directory
-	#
-	for f in $$(ls $(PROG).*); do \
-		ln -sf $(KBUILD_OUTPUT)/$$f $(srctree)/$$(basename $$f); \
-	done
-
 include tools/make/targets.mk
 
 size:

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ endif
 _all:
 
 all: $(PROG).hex $(PROG).bin
-	@echo "Build for the $(PLATFORM)!"
+	@echo "Build for the $(PLATFORM) platform!"
 	@$(PYTHON) $(srctree)/tools/make/versionTemplate.py --crazyflie-base $(srctree) --print-version
 	@$(PYTHON) $(srctree)/tools/make/size.py $(SIZE) $(PROG).elf $(MEM_SIZE_FLASH_K) $(MEM_SIZE_RAM_K) $(MEM_SIZE_CCM_K)
 

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -104,6 +104,8 @@ $ tb make cf2_defconfig
 $ tb make
 ```
 
+Build artifacts, including binaries, will end up in the `build` directory.
+
 ### Bolt and Roadrunner
 We have some ready-to-go config files in the `configs/` directory. So, for example, if you want to build the Roadrunner (tag) you can go:
 


### PR DESCRIPTION
This PR removes the links to binares that are generated in the root of the directory.
Build files used the links and have been updated. 

Closes #1243