### PR TITLE
Removed -nostdlib from LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIB = $(srctree)/src/lib
 PROCESSOR = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
 LINKER_DIR = $(srctree)/tools/make/F405/linker
 
-LDFLAGS += --specs=nosys.specs --specs=nano.specs $(PROCESSOR) -nostdlib
+LDFLAGS += --specs=nosys.specs --specs=nano.specs $(PROCESSOR)
 image_LDFLAGS += -Wl,-Map=$(PROG).map,--cref,--gc-sections,--undefined=uxTopUsedPriority
 image_LDFLAGS += -L$(srctree)/tools/make/F405/linker
 image_LDFLAGS += -T $(LINKER_DIR)/FLASH_CLOAD.ld


### PR DESCRIPTION
`-nostdlib` was added to `LDFLAGS` when we converted to kbuild, which makes it impossible to use the `atof()` function. This PR removes `-nostdlib` again.

Fixes #1299