### PR TITLE
Fix LH as ground truth for LH1

### DIFF
--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -301,7 +301,10 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
         sweepInfo.calib = &bsCalib->sweep[0];
         sweepInfo.sweepId = 0;
 
-        estimatorEnqueueSweepAngles(&sweepInfo);
+        #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
+          estimatorEnqueueSweepAngles(&sweepInfo);
+        #endif
+
         STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
         STATS_CNT_RATE_EVENT(&positionRate);
       }

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -303,10 +303,10 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
 
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           estimatorEnqueueSweepAngles(&sweepInfo);
-        #endif
 
-        STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-        STATS_CNT_RATE_EVENT(&positionRate);
+          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+          STATS_CNT_RATE_EVENT(&positionRate);
+        #endif
       }
 
       sweepInfo.measuredSweepAngle = measurement->angles[1];
@@ -318,10 +318,10 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
 
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           estimatorEnqueueSweepAngles(&sweepInfo);
-        #endif
 
-        STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-        STATS_CNT_RATE_EVENT(&positionRate);
+          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+          STATS_CNT_RATE_EVENT(&positionRate);
+        #endif
       }
     }
   }
@@ -350,9 +350,10 @@ static void estimatePositionSweepsLh2(const pulseProcessor_t* appState, pulsePro
         sweepInfo.sweepId = 0;
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           estimatorEnqueueSweepAngles(&sweepInfo);
+
+          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+          STATS_CNT_RATE_EVENT(&positionRate);
         #endif
-        STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-        STATS_CNT_RATE_EVENT(&positionRate);
       }
 
       sweepInfo.measuredSweepAngle = measurement->angles[1];
@@ -362,9 +363,10 @@ static void estimatePositionSweepsLh2(const pulseProcessor_t* appState, pulsePro
         sweepInfo.sweepId = 1;
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           estimatorEnqueueSweepAngles(&sweepInfo);
+
+          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+          STATS_CNT_RATE_EVENT(&positionRate);
         #endif
-        STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-        STATS_CNT_RATE_EVENT(&positionRate);
       }
     }
   }


### PR DESCRIPTION
When the lighthouse system is used as the ground truth, data is not pushed to the kalman estimator, instead the crossing beam method is used. 

This PR fixes a bug that pushes one of the sweeps to the estimator anyway.
It also fixes increase of stats counters that should not be increased. 