### PR TITLE
Add a warning if motor power is capped

### DIFF
--- a/src/modules/interface/power_distribution.h
+++ b/src/modules/interface/power_distribution.h
@@ -47,8 +47,10 @@ void powerDistribution(const control_t *control, motors_thrust_uncapped_t* motor
  *
  * @param motorThrustBatCompUncapped The desired thrust for the motors
  * @param motorPwm The capped thrust
+ * @return true   Thrust was capped
+ * @return false  Thrust was unchanged and not capped
  */
-void powerDistributionCap(const motors_thrust_uncapped_t* motorThrustBatCompUncapped, motors_thrust_pwm_t* motorPwm);
+bool powerDistributionCap(const motors_thrust_uncapped_t* motorThrustBatCompUncapped, motors_thrust_pwm_t* motorPwm);
 
 /**
  * Returns a 1 when motor 'id' gives thrust, returns 0 otherwise

--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -218,6 +218,14 @@ config ENABLE_THRUST_BAT_COMPENSATED
         The compensation is based on thrust measurements, which are only valid for CF2.X stock configuration.
         Not applied for brushless motor setup.
 
+config LOG_MOTOR_CAP_WARNING
+    bool "Log a warning if the motor thrust is capped"
+    default n
+    help
+        If the computed thrust of one or more motors is outside of the possible range, the thrust will be capped or
+        reduced for one or more motors depending on configuration. Enabeling this setting will report in the console log
+        that the thrust has been capped.
+
 endmenu
 
 menu "Parameter subsystem"

--- a/src/modules/src/power_distribution_quadrotor.c
+++ b/src/modules/src/power_distribution_quadrotor.c
@@ -134,9 +134,10 @@ void powerDistribution(const control_t *control, motors_thrust_uncapped_t* motor
   }
 }
 
-void powerDistributionCap(const motors_thrust_uncapped_t* motorThrustBatCompUncapped, motors_thrust_pwm_t* motorPwm)
+bool powerDistributionCap(const motors_thrust_uncapped_t* motorThrustBatCompUncapped, motors_thrust_pwm_t* motorPwm)
 {
   const int32_t maxAllowedThrust = UINT16_MAX;
+  bool isCapped = false;
 
   // Find highest thrust
   int32_t highestThrustFound = 0;
@@ -153,6 +154,7 @@ void powerDistributionCap(const motors_thrust_uncapped_t* motorThrustBatCompUnca
   if (highestThrustFound > maxAllowedThrust)
   {
     reduction = highestThrustFound - maxAllowedThrust;
+    isCapped = true;
   }
 
   for (int motorIndex = 0; motorIndex < STABILIZER_NR_OF_MOTORS; motorIndex++)
@@ -160,6 +162,8 @@ void powerDistributionCap(const motors_thrust_uncapped_t* motorThrustBatCompUnca
     int32_t thrustCappedUpper = motorThrustBatCompUncapped->list[motorIndex] - reduction;
     motorPwm->list[motorIndex] = capMinThrust(thrustCappedUpper, idleThrust);
   }
+
+  return isCapped;
 }
 
 uint32_t powerDistributionGetIdleThrust() {

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -232,10 +232,25 @@ static void updateStateEstimatorAndControllerTypes() {
   }
 }
 
+static void logCapWarning(const bool isCapped) {
+  #ifdef CONFIG_LOG_MOTOR_CAP_WARNING
+  static uint32_t nextReportTick = 0;
+
+  if (isCapped) {
+    uint32_t now = xTaskGetTickCount();
+    if (now > nextReportTick) {
+      DEBUG_PRINT("Motor thrust was capped\n");
+      nextReportTick = now + M2T(3000);
+    }
+  }
+  #endif
+}
+
 static void controlMotors(const control_t* control) {
   powerDistribution(control, &motorThrustUncapped);
   batteryCompensation(&motorThrustUncapped, &motorThrustBatCompUncapped);
-  powerDistributionCap(&motorThrustBatCompUncapped, &motorPwm);
+  const bool isCapped = powerDistributionCap(&motorThrustBatCompUncapped, &motorPwm);
+  logCapWarning(isCapped);
   setMotorRatios(&motorPwm);
 }
 

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -239,7 +239,7 @@ static void logCapWarning(const bool isCapped) {
   if (isCapped) {
     uint32_t now = xTaskGetTickCount();
     if (now > nextReportTick) {
-      DEBUG_PRINT("Motor thrust was capped\n");
+      DEBUG_PRINT("Warning: motor thrust saturated\n");
       nextReportTick = now + M2T(3000);
     }
   }

--- a/test_python/test_power_distribution.py
+++ b/test_python/test_power_distribution.py
@@ -120,10 +120,11 @@ def test_power_distribution_cap_when_in_range():
     actual = cffirmware.motors_thrust_pwm_t()
 
     # Test
-    cffirmware.powerDistributionCap(input, actual)
+    isCapped = cffirmware.powerDistributionCap(input, actual)
 
     # Assert
     # control.thrust will be at a (tuned) hover-state
+    assert not isCapped
     assert actual.motors.m1 == input.motors.m1
     assert actual.motors.m2 == input.motors.m2
     assert actual.motors.m3 == input.motors.m3
@@ -141,9 +142,10 @@ def test_power_distribution_cap_when_all_negative():
     actual = cffirmware.motors_thrust_pwm_t()
 
     # Test
-    cffirmware.powerDistributionCap(input, actual)
+    isCapped = cffirmware.powerDistributionCap(input, actual)
 
     # Assert
+    assert not isCapped
     assert actual.motors.m1 == 0
     assert actual.motors.m2 == 0
     assert actual.motors.m3 == 0
@@ -161,9 +163,10 @@ def test_power_distribution_cap_when_all_above_range():
     actual = cffirmware.motors_thrust_pwm_t()
 
     # Test
-    cffirmware.powerDistributionCap(input, actual)
+    isCapped = cffirmware.powerDistributionCap(input, actual)
 
     # Assert
+    assert isCapped
     assert actual.motors.m1 == 0xffff
     assert actual.motors.m2 == 0xffff
     assert actual.motors.m3 == 0xffff
@@ -181,9 +184,10 @@ def test_power_distribution_cap_reduces_thrust_equally_much():
     actual = cffirmware.motors_thrust_pwm_t()
 
     # Test
-    cffirmware.powerDistributionCap(input, actual)
+    isCapped = cffirmware.powerDistributionCap(input, actual)
 
     # Assert
+    assert isCapped
     assert actual.motors.m1 == 0xffff - 14
     assert actual.motors.m2 == 0xffff - 10
     assert actual.motors.m3 == 0xffff - 5
@@ -201,9 +205,10 @@ def test_power_distribution_cap_reduces_thrust_equally_much_with_lower_cap():
     actual = cffirmware.motors_thrust_pwm_t()
 
     # Test
-    cffirmware.powerDistributionCap(input, actual)
+    isCapped = cffirmware.powerDistributionCap(input, actual)
 
     # Assert
+    assert isCapped
     assert actual.motors.m1 == 0
     assert actual.motors.m2 == 0
     assert actual.motors.m3 == 1000 - 10


### PR DESCRIPTION
There is functionality to limit the motor thrust if the commanded thrust from the controller is out of range. This is a situation where the system is out side the functonal limits, and this PR adds the possibility to turn on a warning log in the console. 

Activate by enabeling from kbuild, it is off by default. 