### PR TITLE
Added brushed support for Bolt 1.1 (HW mod required)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -85,6 +85,15 @@ config PLATFORM_FLAPPER
 
 endchoice
 
+config BOLT11_BRUSHED
+    bool "Bolt 1.1: Use brushed motor driver (HW mod required)"
+    depends on PLATFORM_BOLT
+    default n
+    help
+        0R resistors 0402 (or simple wire to short) should be mounted at 
+        R19, R22, R33, R34 and motor override signals will be disabled (high impedance).
+        Brushed motor should be connected + and - at motor connector (not S).
+
 endmenu
 
 menu "IMU configuration"

--- a/src/drivers/interface/motors.h
+++ b/src/drivers/interface/motors.h
@@ -259,6 +259,7 @@ extern const MotorPerifDef* motorMapDefaltConBrushless[NBR_OF_MOTORS];
 extern const MotorPerifDef* motorMapBigQuadDeck[NBR_OF_MOTORS];
 extern const MotorPerifDef* motorMapBoltBrushless[NBR_OF_MOTORS];
 extern const MotorPerifDef* motorMapBolt11Brushless[NBR_OF_MOTORS];
+extern const MotorPerifDef* motorMapBolt11Brushed[NBR_OF_MOTORS];
 extern const MotorPerifDef* motorMapCF21Brushless[NBR_OF_MOTORS];
 
 /**

--- a/src/drivers/src/motors_def.c
+++ b/src/drivers/src/motors_def.c
@@ -112,6 +112,27 @@ static const MotorPerifDef MOTORS_PB9_TIM4_CH4_BRUSHED =
     .ocInit        = TIM_OC4Init,
     .preloadConfig = TIM_OC4PreloadConfig,
 };
+// Bolt 1.1 M4, PB10, TIM2_CH3, Brushed config
+static const MotorPerifDef MOTORS_PB10_TIM2_CH3_BRUSHED =
+{
+    .drvType       = BRUSHED,
+    .gpioPerif     = RCC_AHB1Periph_GPIOB,
+    .gpioPort      = GPIOB,
+    .gpioPin       = GPIO_Pin_10,
+    .gpioPinSource = GPIO_PinSource10,
+    .gpioOType     = GPIO_OType_PP,
+    .gpioAF        = GPIO_AF_TIM2,
+    .timPerif      = RCC_APB1Periph_TIM2,
+    .tim           = TIM2,
+    .timPolarity   = TIM_OCPolarity_High,
+    .timDbgStop    = DBGMCU_TIM2_STOP,
+    .timPeriod     = MOTORS_PWM_PERIOD,
+    .timPrescaler  = MOTORS_PWM_PRESCALE,
+    .setCompare    = TIM_SetCompare3,
+    .getCompare    = TIM_GetCapture3,
+    .ocInit        = TIM_OC3Init,
+    .preloadConfig = TIM_OC3PreloadConfig,
+};
 
 // CF2.X connector M1, PA1, TIM2_CH2, Brushless config, inversed
 static const MotorPerifDef MOTORS_PA1_TIM2_CH2_BRUSHLESS_INV_PP =
@@ -758,6 +779,19 @@ const MotorPerifDef* motorMapBolt11Brushless[NBR_OF_MOTORS] =
   &MOTORS_PB11_TIM2_CH4_BRUSHLESS_PP,
   &MOTORS_PA15_TIM2_CH1_BRUSHLESS_PP,
   &MOTORS_PB10_TIM2_CH3_BRUSHLESS_PP
+};
+
+/**
+ * Brushed motors mapped to the Bolt 1.1 PWM outputs.
+ * 0R resistors 0402 should be mounted at R19, R22, R33, R34 and
+ * motor override signals will be disabled (high impedance).
+ */
+const MotorPerifDef* motorMapBolt11Brushed[NBR_OF_MOTORS] =
+{
+  &MOTORS_PA1_TIM2_CH2_BRUSHED,
+  &MOTORS_PB11_TIM2_CH4_BRUSHED,
+  &MOTORS_PA15_TIM2_CH1_BRUSHED,
+  &MOTORS_PB10_TIM2_CH3_BRUSHED
 };
 
 /**

--- a/src/modules/src/controller/position_controller_pid.c
+++ b/src/modules/src/controller/position_controller_pid.c
@@ -524,7 +524,7 @@ PARAM_GROUP_START(posCtlPid)
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, xKp, &this.pidX.pid.kp)
 /**
- * @brief Proportional gain for the position PID in the body-yaw-aligned X direction
+ * @brief Integral gain for the position PID in the body-yaw-aligned X direction
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, xKi, &this.pidX.pid.ki)
 /**

--- a/src/platform/src/platform_bolt.c
+++ b/src/platform/src/platform_bolt.c
@@ -56,7 +56,11 @@ static platformConfig_t configs[] = {
     .deviceTypeName = "Crazyflie Bolt 1.1",
     .sensorImplementation = SensorImplementation_bmi088_spi_bmp388,
     .physicalLayoutAntennasAreClose = false,
+  #ifdef CONFIG_BOLT11_BRUSHED
+    .motorMap = motorMapBolt11Brushed,
+  #else
     .motorMap = motorMapBolt11Brushless,
+  #endif
   }
 #endif
 };


### PR DESCRIPTION
On Bolt 1.1 brushed motors can be supported with a hardware modification: 
- 0R resistors 0402 (or simple wire to short) should be mounted at R19, R22, R33, R34 and motor override signals will be disabled (high impedance). Brushed motor should be connected + and - at motor connector (not S).

A new motor mapping is added as well as a kconfig to enable it. Under "Platform configuration" select Bolt then the brushed alternative will become available.

This is also possible for Bolt 1.0 but support not added in this PR.