### PR TITLE
Bump CRTP version

### DIFF
--- a/src/modules/interface/crtp.h
+++ b/src/modules/interface/crtp.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define CRTP_PROTOCOL_VERSION 6
+#define CRTP_PROTOCOL_VERSION 7
 
 #define CRTP_MAX_DATA_SIZE 30
 


### PR DESCRIPTION
This PR increases the CRTP version to 7.

This indicates to the python client that the "locked" bit is transmitted from the supervisor