### PR TITLE
Correct param update initiated in the CF

### DIFF
--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -578,6 +578,7 @@ void paramSetInt(paramVarId_t varid, int valuei)
     pk.data[0] = MISC_VALUE_UPDATED;
     pk.data[1] = varid.id & 0xffu;
     pk.data[2] = (varid.id >> 8) & 0xffu;
+    memcpy(&pk.data[3], &valuei, paramSize);
     pk.size = 3 + paramSize;
     const int sendResult = crtpSendPacket(&pk);
     if (sendResult == errQUEUE_FULL)
@@ -605,9 +606,8 @@ void paramSetFloat(paramVarId_t varid, float valuef)
     pk.data[0] = MISC_VALUE_UPDATED;
     pk.data[1] = varid.id & 0xffu;
     pk.data[2] = (varid.id >> 8) & 0xffu;
-    pk.size = 3;
-    memcpy(&pk.data[2], &valuef, 4);
-    pk.size += 4;
+    memcpy(&pk.data[3], &valuef, 4);
+    pk.size = 3 + 4;
     const int sendResult = crtpSendPacket(&pk);
     if (sendResult == errQUEUE_FULL)
     {


### PR DESCRIPTION
This PR fixes bugs related to parameter updates initiated in the Crazyflie. If corrects the contents of the CRTP packets that are sent to the ground station

Related to https://github.com/bitcraze/crazyflie-clients-python/issues/657