### PR TITLE
Addr pca interface

### DIFF
--- a/src/deck/drivers/src/multiranger.c
+++ b/src/deck/drivers/src/multiranger.c
@@ -63,7 +63,7 @@ static bool mrInitSensor(VL53L1_Dev_t *pdev, uint32_t pca95pin, char *name)
     bool status;
 
     // Bring up VL53 by releasing XSHUT
-    pca95x4SetOutput(pca95pin);
+    pca95x4SetOutput(PCA95X4_DEFAULT_ADDRESS, pca95pin);
     // Let VL53 boot
     vTaskDelay(M2T(2));
     // Init VL53
@@ -153,13 +153,15 @@ static void mrInit()
 
     pca95x4Init();
 
-    pca95x4ConfigOutput(~(MR_PIN_UP |
+    pca95x4ConfigOutput(PCA95X4_DEFAULT_ADDRESS,
+                        ~(MR_PIN_UP |
                           MR_PIN_RIGHT |
                           MR_PIN_LEFT |
                           MR_PIN_FRONT |
                           MR_PIN_BACK));
 
-    pca95x4ClearOutput(MR_PIN_UP |
+    pca95x4ClearOutput(PCA95X4_DEFAULT_ADDRESS,
+                       MR_PIN_UP |
                        MR_PIN_RIGHT |
                        MR_PIN_LEFT |
                        MR_PIN_FRONT |

--- a/src/deck/drivers/src/oa.c
+++ b/src/deck/drivers/src/oa.c
@@ -91,13 +91,15 @@ static void oaInit()
 
   pca95x4Init();
 
-  pca95x4ConfigOutput(~(OA_PIN_UP |
+  pca95x4ConfigOutput(PCA95X4_DEFAULT_ADDRESS,
+                      ~(OA_PIN_UP |
                         OA_PIN_RIGHT |
                         OA_PIN_LEFT |
                         OA_PIN_FRONT |
                         OA_PIN_BACK));
 
-  pca95x4ClearOutput(OA_PIN_UP |
+  pca95x4ClearOutput(PCA95X4_DEFAULT_ADDRESS,
+                     OA_PIN_UP |
                      OA_PIN_RIGHT |
                      OA_PIN_LEFT |
                      OA_PIN_FRONT |
@@ -118,7 +120,7 @@ static bool oaTest()
     return false;
   }
 
-  pca95x4SetOutput(OA_PIN_FRONT);
+  pca95x4SetOutput(PCA95X4_DEFAULT_ADDRESS, OA_PIN_FRONT);
   if (vl53l0xInit(&devFront, I2C1_DEV, true)) {
     DEBUG_PRINT("Init front sensor [OK]\n");
   } else {
@@ -126,7 +128,7 @@ static bool oaTest()
     pass = false;
   }
 
-  pca95x4SetOutput(OA_PIN_BACK);
+  pca95x4SetOutput(PCA95X4_DEFAULT_ADDRESS, OA_PIN_BACK);
   if (vl53l0xInit(&devBack, I2C1_DEV, true)) {
     DEBUG_PRINT("Init back sensor [OK]\n");
   } else {
@@ -134,7 +136,7 @@ static bool oaTest()
     pass = false;
   }
 
-  pca95x4SetOutput(OA_PIN_UP);
+  pca95x4SetOutput(PCA95X4_DEFAULT_ADDRESS, OA_PIN_UP);
   if (vl53l0xInit(&devUp, I2C1_DEV, true)) {
     DEBUG_PRINT("Init up sensor [OK]\n");
   } else {
@@ -142,7 +144,7 @@ static bool oaTest()
     pass = false;
   }
 
-  pca95x4SetOutput(OA_PIN_LEFT);
+  pca95x4SetOutput(PCA95X4_DEFAULT_ADDRESS, OA_PIN_LEFT);
   if (vl53l0xInit(&devLeft, I2C1_DEV, true)) {
     DEBUG_PRINT("Init left sensor [OK]\n");
   } else {
@@ -150,7 +152,7 @@ static bool oaTest()
     pass = false;
   }
 
-  pca95x4SetOutput(OA_PIN_RIGHT);
+  pca95x4SetOutput(PCA95X4_DEFAULT_ADDRESS, OA_PIN_RIGHT);
   if (vl53l0xInit(&devRight, I2C1_DEV, true)) {
     DEBUG_PRINT("Init right sensor [OK]\n");
   } else {

--- a/src/drivers/src/vl53l1x.c
+++ b/src/drivers/src/vl53l1x.c
@@ -48,8 +48,8 @@
 	#define VL53L1_get_register_name(a,b)
 #endif
 
-// Set the start address 8 step after the VL53L0 dynamic addresses
-static int nextI2CAddress = VL53L1X_DEFAULT_ADDRESS+8;
+// Set the start address 1 step after the VL53L0 dynamic addresses
+static int nextI2CAddress = VL53L1X_DEFAULT_ADDRESS+1;
 
 
 bool vl53l1xInit(VL53L1_Dev_t *pdev, I2C_Dev *I2Cx)

--- a/src/hal/interface/pca95x4.h
+++ b/src/hal/interface/pca95x4.h
@@ -53,21 +53,21 @@ void pca95x4Init();
 /**
  * Test the PCA95X4 sub-system.
  */
-bool pca95x4Test();
+bool pca95x4Test(uint8_t devAddr);
 
 /**
  * Set the output register value.
  */
-bool pca95x4ConfigOutput(uint32_t val);
+bool pca95x4ConfigOutput(uint8_t devAddr, uint32_t val);
 
 /**
  * Set output bits.
  */
-bool pca95x4SetOutput(uint32_t mask);
+bool pca95x4SetOutput(uint8_t devAddr, uint32_t mask);
 
 /**
  * Reset output bits.
  */
-bool pca95x4ClearOutput(uint32_t mask);
+bool pca95x4ClearOutput(uint8_t devAddr, uint32_t mask);
 
 #endif //__PCA95X4_H__

--- a/src/hal/src/pca95x4.c
+++ b/src/hal/src/pca95x4.c
@@ -40,7 +40,7 @@ void pca95x4Init()
   devAddr = PCA95X4_DEFAULT_ADDRESS;
 }
 
-bool pca95x4Test()
+bool pca95x4Test(uint8_t devAddr)
 {
   uint8_t tb;
   bool pass;
@@ -51,14 +51,14 @@ bool pca95x4Test()
   return pass;
 }
 
-bool pca95x4ConfigOutput(uint32_t val) {
+bool pca95x4ConfigOutput(uint8_t devAddr, uint32_t val) {
   bool pass;
 
   pass = i2cdevWriteByte(I2Cx, devAddr, PCA95X4_CONFIG_REG, val);
   return pass;
 }
 
-bool pca95x4SetOutput(uint32_t mask) {
+bool pca95x4SetOutput(uint8_t devAddr, uint32_t mask) {
   uint8_t val;
   bool pass;
 
@@ -69,7 +69,7 @@ bool pca95x4SetOutput(uint32_t mask) {
   return pass;
 }
 
-bool pca95x4ClearOutput(uint32_t mask) {
+bool pca95x4ClearOutput(uint8_t devAddr, uint32_t mask) {
   uint8_t val;
   bool pass;
 


### PR DESCRIPTION
changed pca95x4 inferface to take as parameter the address written on instead of having it staticly through macro.

We currently are using a version of the multiranger we manufactured, with 9 lasers, so we couldn't use the regular pca95x4 interface that only allow reading of 8 data at a time. We changed the signature of a few of theses functions so that we have 2 pca95x4 configurations to read data from, in our mrTask.