### PR TITLE
moving some physical constants so they can be config dependants

### DIFF
--- a/src/modules/src/controller/controller_brescianini.c
+++ b/src/modules/src/controller/controller_brescianini.c
@@ -38,6 +38,7 @@
 #include "num.h"
 #include "math3d.h"
 #include "physicalConstants.h"
+#include "platform_defaults.h"
 
 static struct mat33 CRAZYFLIE_INERTIA =
     {{{16.6e-6f, 0.83e-6f, 0.72e-6f},

--- a/src/modules/src/controller/controller_mellinger.c
+++ b/src/modules/src/controller/controller_mellinger.c
@@ -42,6 +42,7 @@ We added the following:
 #include "position_controller.h"
 #include "controller_mellinger.h"
 #include "physicalConstants.h"
+#include "platform_defaults.h"
 
 // Global state variable used in the
 // firmware as the only instance and in bindings

--- a/src/modules/src/power_distribution_quadrotor.c
+++ b/src/modules/src/power_distribution_quadrotor.c
@@ -33,6 +33,7 @@
 #include "autoconf.h"
 #include "config.h"
 #include "math.h"
+#include "platform_defaults.h"
 
 #ifndef CONFIG_MOTORS_DEFAULT_IDLE_THRUST
 #  define DEFAULT_IDLE_THRUST 0
@@ -41,7 +42,7 @@
 #endif
 
 static uint32_t idleThrust = DEFAULT_IDLE_THRUST;
-static float armLength = 0.046f; // m;
+static float armLength = ARM_LENGTH; // m
 static float thrustToTorque = 0.005964552f;
 
 // thrust = a * pwm^2 + b * pwm

--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -45,6 +45,7 @@
 #endif
 
 // Drone physical constants
+// TODO provide those in each config. Those are values of cf2 platform
 #ifndef ARM_LENGTH
     // m
     #define ARM_LENGTH  0.046f

--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -44,6 +44,16 @@
     #include "platform_defaults_flapper.h"
 #endif
 
+// Drone physical constants
+#ifndef ARM_LENGTH
+    // m
+    #define ARM_LENGTH  0.046f
+#endif
+#ifndef CF_MASS
+    // kg
+    #define CF_MASS     0.027f
+#endif
+
 // IMU alignment on the airframe 
 #ifndef IMU_PHI
     #define IMU_PHI     0.0f

--- a/src/platform/interface/platform_defaults_cf2.h
+++ b/src/platform/interface/platform_defaults_cf2.h
@@ -42,6 +42,12 @@
 // Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
 
+// Drone physical constants
+// m
+#define ARM_LENGTH  0.046f
+// kg
+#define CF_MASS     0.027f
+
 // Default PID gains
 #define PID_ROLL_RATE_KP  250.0
 #define PID_ROLL_RATE_KI  500.0

--- a/src/utils/interface/physicalConstants.h
+++ b/src/utils/interface/physicalConstants.h
@@ -47,7 +47,3 @@
 #ifndef ARCMINUTE
   #define ARCMINUTE (M_PI_F / 10800.0f)
 #endif
-
-#ifndef CF_MASS
-  #define CF_MASS (0.027f) // in kg
-#endif


### PR DESCRIPTION
Hello,
The mass of the crazyflie and the arm length has been moved so they can easily be integrated to a configuration.
Have a nice day !