### PR TITLE
fixed the way of building apps with any disired config

### DIFF
--- a/tools/make/oot.mk
+++ b/tools/make/oot.mk
@@ -9,6 +9,7 @@ OOT ?= $(PWD)
 # build.
 #
 OOT_CONFIG ?= $(OOT)/oot-config
+ANY_CONFIG := $(OOT)/build/oot-config
 
 OOT_ARGS ?= -C $(CRAZYFLIE_BASE) OOT=$(OOT) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
 
@@ -18,10 +19,17 @@ ifneq ($(OOT_USES_CXX),)
 OOT_ARGS += OOT_USES_CXX=1
 endif
 
-.PHONY: all clean
+.PHONY: all clean cload any
 
+#
+# the alldefconfig does not exist as a file in the code as for example cf2_defconfig.
+# Selecting it with a path given with KCONFIG_ALLCONFIG var has the firmware be compiled
+# with the config file pointed by this path.
+#
+# default path to alldefconfig file is: $CRAZYFLIE_BASE/configs/all.config
+#
 all:
-	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) KCONFIG_ALLCONFIG=$(OOT_CONFIG) $(CONFIG)
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) KCONFIG_ALLCONFIG=$(OOT_CONFIG) alldefconfig
 	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) -j 12
 
 clean:
@@ -29,3 +37,16 @@ clean:
 
 cload:
 	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) cload
+
+#
+# eg: sh$ CONFIG=bolt_defconfig make any
+# will provide as config file, the concatenation of cf2_defconfig+$(OOT_CONFIG)
+#
+# NB. we use 'grep -h' and not 'cat' here to ensure newline character is present between files
+#
+any:
+	mkdir -p $(OOT)/build
+	[ "${CONFIG}" = alldefconfig ] && cp $(OOT_CONFIG) $(ANY_CONFIG) \
+		|| grep -h "" $(OOT)/$(CRAZYFLIE_BASE)/configs/$(CONFIG) $(OOT_CONFIG) > $(ANY_CONFIG)
+	OOT='$(OOT)' OOT_CONFIG='$(ANY_CONFIG)' OOT_ARGS='$(OOT_ARGS)' \
+		$(MAKE) all


### PR DESCRIPTION
Hello, 
First, I am deeply sorry as i misunderstood the way building an app works. So the way of building an app, previously proposed from a PR, wasn't able to do the job it was supposed to, but didn't compromise the way of doing so that was already in place.
Using the previous Makefile file with CONFIG="" only compiled the firmware and not the app !

The modifications here are comments explaining the difference of building the apps.
the all rule allow to build an app with any config (eg. bolt) BUT requires the config file to be already included in the app-config file.
This might or not be desired.

In case not, the any rule concats the desired config file in a tmp oot-config file (eg. bolt_defconfig) before the app-config file
THEN calls the all rule.

NB. Binary files are also present in the app filesystem after compiling (*.o and *.o.cmd) (they were already from legacy) that are not caught by the clean rule. But that's not the subject of this PR.