### PR TITLE
Storage; Defragment kve storage when starting up by default

### DIFF
--- a/src/hal/src/storage.c
+++ b/src/hal/src/storage.c
@@ -54,6 +54,14 @@
 #define KVE_PARTITION_START (1024)
 #define KVE_PARTITION_LENGTH (7*1024)
 
+#define DEFAULT_DEFRAG_ON_STARTUP true
+
+#ifdef CONFIG_DEFRAG_STORAGE_ON_STARTUP
+#define DEFRAG_ON_STARTUP CONFIG_DEFRAG_STORAGE_ON_STARTUP
+#else
+#define DEFRAG_ON_STARTUP DEFAULT_DEFRAG_ON_STARTUP
+#endif
+
 static SemaphoreHandle_t storageMutex;
 
 static size_t readEeprom(size_t address, void* data, size_t length)
@@ -127,6 +135,9 @@ void storageInit()
   storageMutex = xSemaphoreCreateMutex();
 
   isInit = true;
+  if (DEFRAG_ON_STARTUP) {
+    kveDefrag(&kve);
+  }
 }
 
 bool storageTest()

--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -239,4 +239,12 @@ config PARAM_SILENT_UPDATES
         about parameter updates, so this option should be enabled if you know
         what you are doing.
 
+config DEFRAG_STORAGE_ON_STARTUP
+    bool "Defrag_on_startup"
+    default y
+    help
+        This enables defragmentation of parameter storage memory everytime the
+        CPU is started. It increases startup time, depending on
+        fragmentation level.
+
 endmenu


### PR DESCRIPTION
The kve will be defragmented before running the kve sanity check. Defragmenting before checking will make sure that the kve is sane after defragmentation and if not the kve will be reformatted.

This can be turned off in the Kconfig, so that users that do not want this to possibly change their startup time (if eeprom is severely fragmented) can go back to only defragmenting once kve is full