### PR TITLE
Documentation: Add instructions for workaround for deadlysignal in un…

### DIFF
--- a/docs/development/unit_testing.md
+++ b/docs/development/unit_testing.md
@@ -44,6 +44,16 @@ used in the unit tests as well. In some cases unit tests must be disabled based 
 if a particular file is not included in the build. A unit test file can be disabled based on configuration by using
 an annotation like this:
 
+## AddressSanitizer
+If you are facing issues running the unit tests locally and ending up in an endless loop of
+
+        Addressanitizer:DEADLY SIGNAL
+
+This is due to a incompatibility between TSan vesion and the high number of entropy bits used for randomization in recent Ubuntu versions.
+Solutions for this (until a fix is in place) is to run the tests with the toolbelt or temporarily bump your systems entropy bits down to 28 using; 
+
+`sudo sysctl vm.mmap_rnd_bits=28`
+
 ``` c
 // @IGNORE_IF_NOT CONFIG_DECK_LIGHTHOUSE
 ```


### PR DESCRIPTION
…it tests.

There is a incompatibility between address sanitizer and recent ubuntu versions that causes an eternal loop of deadly signal when running unit tests in local environment. See this issue for more info https://github.com/google/sanitizers/issues/1716