### PR TITLE
fix narrowing warning for param definitions

### DIFF
--- a/src/modules/interface/param.h
+++ b/src/modules/interface/param.h
@@ -107,12 +107,14 @@ typedef float * (*paramGetterFloat)(void);
 /* Macros */
 
 #define PARAM_ADD_FULL(TYPE, NAME, ADDRESS, CALLBACK, DEFAULT_GETTER) \
-    { .type = ((TYPE) <= 0xFF) ? (TYPE) : (((TYPE) | PARAM_EXTENDED) & 0xFF), \
+    { .type = ((TYPE) <= 0xFF) ? ((TYPE) & 0xFF) : (((TYPE) | PARAM_EXTENDED) & 0xFF), \
       .extended_type = (((TYPE) & 0xFF00) >> 8), \
       .name = #NAME, \
       .address = (void*)(ADDRESS), \
       .callback = (void *)CALLBACK, \
       .getter = (void *)DEFAULT_GETTER, },
+// Storing (TYPE) & 0xFF instead of just (TYPE) in the first branch is a no-op,
+// but it prevents noisy spurious warnings when compiling bindings with Clang.
 
 #define PARAM_ADD(TYPE, NAME, ADDRESS) \
     PARAM_ADD_FULL(TYPE, NAME, ADDRESS, 0, 0)


### PR DESCRIPTION
When compiling the Python bindings with Clang 11, the param definitions give many noisy warnings of the form:

```
src/modules/src/controller/attitude_pid_controller.c:328:23: warning: implicit conversion from
      'int' to 'uint8_t' (aka 'unsigned char') changes value from 262 to 6
      [-Wconstant-conversion]
PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, roll_kp, &pidRoll.kp)
~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/interface/param.h:118:20: note: expanded from macro 'PARAM_ADD'
    PARAM_ADD_FULL(TYPE, NAME, ADDRESS, 0, 0)
    ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/interface/param.h:110:35: note: expanded from macro 'PARAM_ADD_FULL'
    { .type = ((TYPE) <= 0xFF) ? (TYPE) : (((TYPE) | PARAM_EXTENDED) & 0xFF), \
    ~                             ^~~~
```
It appears to be a limitation of Clang: It is worried about storing a value greater than `0xFF` in a `uint8_t` field `.type`, but it does not recognize that the ternary expression branch will never be hit because of the `(TYPE) <= 0xFF` check.

It can be fixed by storing `TYPE & 0xFF` instead. This is a no-op, but since everything's a compile-time constant it shouldn't cause any change in the generated code.

I guess few people are compiling the bindings with Clang, so I understand if you reject the PR because it adds complexity for a niche case.