### PR TITLE
Motors: unify types for PWM to be uint16_t

### DIFF
--- a/src/drivers/interface/motors.h
+++ b/src/drivers/interface/motors.h
@@ -322,9 +322,9 @@ void motorsBurstDshot();
 void motorsSetRatio(uint32_t id, uint16_t ratio);
 
 /**
- * Get the PWM ratio of the motor 'id'. Return -1 if wrong ID.
+ * Get the PWM ratio of the motor 'id'.
  */
-int motorsGetRatio(uint32_t id);
+uint16_t motorsGetRatio(uint32_t id);
 
 /**
  * FreeRTOS Task to test the Motors driver

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -49,7 +49,7 @@
 
 static uint8_t motorSetEnable = 0;
 static uint16_t motorPowerSet[] = {0, 0, 0, 0}; // user-requested PWM signals (overrides)
-static uint32_t motor_ratios[] = {0, 0, 0, 0};  // actual PWM signals
+static uint16_t motor_ratios[] = {0, 0, 0, 0};  // actual PWM signals
 
 #ifdef CONFIG_MOTORS_ESC_PROTOCOL_DSHOT
 static DMA_InitTypeDef DMA_InitStructureShare;
@@ -584,7 +584,7 @@ int motorsESCIsLo(uint32_t id)
   return GPIO_ReadInputDataBit(motorMap[id]->gpioPort, motorMap[id]->gpioPin) == Bit_RESET;
 }
 
-int motorsGetRatio(uint32_t id)
+uint16_t motorsGetRatio(uint32_t id)
 {
   ASSERT(id < NBR_OF_MOTORS);
 

--- a/src/drivers/src/motors.c
+++ b/src/drivers/src/motors.c
@@ -740,17 +740,17 @@ LOG_GROUP_START(motor)
 /**
  * @brief Motor power (PWM value) for M1 [0 - UINT16_MAX]
  */
-LOG_ADD_CORE(LOG_UINT32, m1, &motor_ratios[MOTOR_M1])
+LOG_ADD_CORE(LOG_UINT16, m1, &motor_ratios[MOTOR_M1])
 /**
  * @brief Motor power (PWM value) for M2 [0 - UINT16_MAX]
  */
-LOG_ADD_CORE(LOG_UINT32, m2, &motor_ratios[MOTOR_M2])
+LOG_ADD_CORE(LOG_UINT16, m2, &motor_ratios[MOTOR_M2])
 /**
  * @brief Motor power (PWM value) for M3 [0 - UINT16_MAX]
  */
-LOG_ADD_CORE(LOG_UINT32, m3, &motor_ratios[MOTOR_M3])
+LOG_ADD_CORE(LOG_UINT16, m3, &motor_ratios[MOTOR_M3])
 /**
  * @brief Motor power (PWM value) for M4 [0 - UINT16_MAX]
  */
-LOG_ADD_CORE(LOG_UINT32, m4, &motor_ratios[MOTOR_M4])
+LOG_ADD_CORE(LOG_UINT16, m4, &motor_ratios[MOTOR_M4])
 LOG_GROUP_STOP(motor)


### PR DESCRIPTION
This uses the uint16_t type more consistently. For uSD logging this will reduce the memory needed. For CRTP logging it should not have any impact, since the user-code requests the logging variables with a desired type. Thus, "legacy" code might request the logging variable as uint32_t and it will be converted accordingly.