### PR TITLE
Fix multi-deck multi-memory OTA flashing

### DIFF
--- a/src/deck/core/deck_memory.c
+++ b/src/deck/core/deck_memory.c
@@ -168,14 +168,14 @@ static void populateDeckMemoryInfos(uint8_t buffer[], const int deckNr) {
 
     const DeckMemDef_t* deckMemDef = info->driver->memoryDef;
     if (deckMemDef) {
-        uint32_t baseAddress = (deckNr + 1) * DECK_MEM_MAX_SIZE;
+        uint32_t baseAddress = (2 * deckNr + 1) * DECK_MEM_MAX_SIZE;
         populateDeckMemoryInfoBuffer(deckMemDef, info->driver->name,
                                      baseAddress, buffer);
     }
 
     const DeckMemDef_t* deckMemDefSecondary = info->driver->memoryDefSecondary;
     if (deckMemDefSecondary) {
-        uint32_t baseAddress = (deckNr + 2) * DECK_MEM_MAX_SIZE;
+        uint32_t baseAddress = (2 * deckNr + 2) * DECK_MEM_MAX_SIZE;
         populateDeckMemoryInfoBuffer(deckMemDefSecondary, info->driver->name,
                                      baseAddress, buffer + DECK_MEMORY_INFO_SIZE);
     }
@@ -234,7 +234,7 @@ static bool handleDeckSectionRead(const uint32_t memAddr, const uint8_t readLen,
 
     if (deckMemDef) {
         if (deckMemDef->read) {
-            uint32_t baseAddress = (deckNr + 1) * DECK_MEM_MAX_SIZE + selector * DECK_MEM_MAX_SIZE;
+            uint32_t baseAddress = (2 * deckNr + 1) * DECK_MEM_MAX_SIZE + selector * DECK_MEM_MAX_SIZE;
             uint32_t deckAddress = memAddr - baseAddress;
             result = deckMemDef->read(deckAddress, readLen, buffer);
         }
@@ -295,7 +295,7 @@ static bool handleDeckSectionWrite(const uint32_t memAddr, const uint8_t writeLe
 
     if (deckMemDef) {
         if (deckMemDef->write) {
-            uint32_t baseAddress = (deckNr + 1) * DECK_MEM_MAX_SIZE + selector * DECK_MEM_MAX_SIZE;
+            uint32_t baseAddress = (deckNr * 2 + 1) * DECK_MEM_MAX_SIZE + selector * DECK_MEM_MAX_SIZE;
             uint32_t deckAddress = memAddr - baseAddress;
             result = deckMemDef->write(deckAddress, writeLen, buffer, deckMemDef);
         }

--- a/test/deck/core/test_deck_memory.c
+++ b/test/deck/core/test_deck_memory.c
@@ -448,7 +448,7 @@ void testBaseAddressSecondDeckPrimary() {
     deckInfo_ExpectAndReturn(0, &stockInfo);
     deckInfo_ExpectAndReturn(1, &stockInfo);
 
-    uint32_t expected = DECK_MEM_MAP_SIZE * 2;
+    uint32_t expected = DECK_MEM_MAP_SIZE * 3;
 
     // Test
     handleMemRead(0, BUF_SIZE, buffer);
@@ -468,7 +468,7 @@ void testBaseAddressSecondDeckSecondary() {
 
     stockDriver.memoryDefSecondary = &stockSecondaryMemDef;
 
-    uint32_t expected = DECK_MEM_MAP_SIZE * 2 + DECK_MEM_MAP_SIZE;
+    uint32_t expected = DECK_MEM_MAP_SIZE * 3 + DECK_MEM_MAP_SIZE;
 
     // Test
     handleMemRead(0, BUF_SIZE, buffer);
@@ -624,6 +624,24 @@ void testWriteToSecondaryDeckMemory() {
     TEST_ASSERT_TRUE(actual);
 }
 
+void testWriteToSecondDeckPrimaryMemory() {
+    // // Fixture
+    stockPrimaryMemDef.write = mockWrite;
+
+    deckCount_ExpectAndReturn(2);
+    deckInfo_ExpectAndReturn(1, &stockInfo);
+
+    // Test
+    bool actual = handleMemWrite(DECK_MEM_MAP_SIZE * 3 + 100, 30, buffer);
+
+    // Assert
+    TEST_ASSERT_TRUE(write_isCalled);
+    TEST_ASSERT_EQUAL_UINT32(100, write_vAddr);
+    TEST_ASSERT_EQUAL_UINT8(30, write_len);
+    TEST_ASSERT_TRUE(actual);
+}
+
+
 void testWriteToSecondaryDeckMemoryPassesInMemDef() {
     // Fixture
     stockSecondaryMemDef.write = mockWrite;
@@ -637,6 +655,24 @@ void testWriteToSecondaryDeckMemoryPassesInMemDef() {
 
     // Assert
     TEST_ASSERT_EQUAL_PTR(stockDriver.memoryDefSecondary, write_memDef);
+}
+
+void testWriteToSecondDeckSecondaryMemory() {
+    // Fixture
+    stockSecondaryMemDef.write = mockWrite;
+    stockDriver.memoryDefSecondary = &stockSecondaryMemDef;
+
+    deckCount_ExpectAndReturn(2);
+    deckInfo_ExpectAndReturn(1, &stockInfo);
+
+    // Test
+    bool actual = handleMemWrite(DECK_MEM_MAP_SIZE * 4 + 100, 30, buffer);
+
+    // Assert
+    TEST_ASSERT_TRUE(write_isCalled);
+    TEST_ASSERT_EQUAL_UINT32(100, write_vAddr);
+    TEST_ASSERT_EQUAL_UINT8(30, write_len);
+    TEST_ASSERT_TRUE(actual);
 }
 
 void testWriteToDeckWithoutWriteFunction() {


### PR DESCRIPTION
Fixes multi-deck multi-memory OTA flashing of the AI-deck. The `baseAddress` did not account for decks now having two possible memories. 

I added tests for writing to second deck primary and secondary memories and corrected base address tests. 

---

Tested flashing the GAP8 in the following configurations of Crazyflie 2.1 with:

| AI deck  | Multi-ranger deck | Flow deck |
| ------------- | ------------- |-------------|
| x  | x  |  |
| x  |    | x |
| x | x | x|

And the ESP32 in the following config:
| AI deck  | Multi-ranger deck | Flow deck |
| ------------- | ------------- |-------------|
| x | x | x|