### PR TITLE
Update build.md

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -210,7 +210,7 @@ Warning: if multiple Crazyflies within range are in bootloader mode the result i
 #### Automatically enter bootloader mode
 * Make sure the Crazyflie is on
 * In your terminal, run `CLOAD_CMDS="-w [CRAZYFLIE_URI]" make cload`
-* or run `cfloader flash cf2.bin stm32-fw -w [CRAZYFLIE_URI]`
+* or run `cfloader flash build/cf2.bin stm32-fw -w [CRAZYFLIE_URI]`
 with [CRAZYFLIE_URI] being the uri of the crazyflie.
 
 It will connect to the Crazyflie with the specified address, put it in bootloader mode and flash the binary. This method is suitable for classroom situations.


### PR DESCRIPTION
Flashing crazyflie - Automatically enter boatloader

old: cfloader flash cf2.bin stm32-fw -w [CRAZYFLIE_URI]
new: cfloader flash build/cf2.bin stm32-fw -w [CRAZYFLIE_URI]

the cf2.bin file is located inside the build folder