### PR TITLE
Added radiotest deck driver for radiotesting

### DIFF
--- a/src/deck/drivers/src/test/Kbuild
+++ b/src/deck/drivers/src/test/Kbuild
@@ -2,3 +2,4 @@ obj-y += exptest.o
 obj-y += exptestCfBl.o
 obj-y += exptestRR.o
 obj-y += exptestBolt11.o
+obj-y += radiotest.o

--- a/src/deck/drivers/src/test/radiotest.c
+++ b/src/deck/drivers/src/test/radiotest.c
@@ -1,0 +1,126 @@
+/*
+ *    ||          ____  _ __
+ * +------+      / __ )(_) /_______________ _____  ___
+ * | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+ * +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+ *  ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+ *
+ * Crazyflie control firmware
+ *
+ * Copyright (C) 2024 Bitcraze AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, in version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * radiotest.c - Use this deck driver to test the radio
+ */
+#define DEBUG_MODULE "RADIOTEST"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "stm32fxxx.h"
+#include "config.h"
+#include "debug.h"
+#include "deck.h"
+#include "syslink.h"
+#include "param.h"
+
+//Hardware configuration
+static bool isInit;
+static uint8_t channel = 80;
+static int8_t power = -16;
+static uint8_t contwave = 0;
+static uint8_t old_channel;
+static int8_t old_power;
+static uint8_t old_contwave;
+
+static void radiotestTask(void *param)
+{
+
+  SyslinkPacket slp;
+  old_channel = 0;
+  old_power = 0;
+  old_contwave = contwave;
+
+  while (1)
+  {
+    vTaskDelay(M2T(1000));
+
+    if (contwave != old_contwave)
+    {
+      slp.type = SYSLINK_RADIO_CONTWAVE;
+      slp.length = 1;
+      slp.data[0] = contwave;
+      syslinkSendPacket(&slp);
+      old_contwave = contwave;
+    }
+    if (channel != old_channel)
+    {
+      slp.type = SYSLINK_RADIO_CHANNEL;
+      slp.length = 1;
+      slp.data[0] = channel;
+      syslinkSendPacket(&slp);
+      old_channel = channel;
+    }
+    if (power != old_power)
+    {
+      slp.type = SYSLINK_RADIO_POWER;
+      slp.length = 1;
+      slp.data[0] = power;
+      syslinkSendPacket(&slp);
+      old_power = power;
+    }
+  }
+}
+
+
+static void radiotestInit(DeckInfo *info)
+{
+  if(isInit)
+    return;
+
+  xTaskCreate(radiotestTask, "RADIOTEST", configMINIMAL_STACK_SIZE, NULL, 1, NULL);
+
+  isInit = true;
+}
+
+static bool radiotestTest()
+{
+  bool status = true;
+
+  if(!isInit)
+    return false;
+
+  return status;
+}
+
+static const DeckDriver radiotest_deck = {
+  .vid = 0,
+  .pid = 0,
+  .name = "bcRadioTest",
+
+  .init = radiotestInit,
+  .test = radiotestTest,
+};
+
+DECK_DRIVER(radiotest_deck);
+
+PARAM_GROUP_START(radiotest)
+PARAM_ADD(PARAM_UINT8, channel, &channel)
+PARAM_ADD(PARAM_INT8,  power, &power)
+PARAM_ADD(PARAM_UINT8, contwave, &contwave)
+
+PARAM_GROUP_STOP(radiotest)


### PR DESCRIPTION
This driver exposes params to change continuos wave/output power/channel. 
It also enables sending random data on a thread continuously (if continous wave is off). 

**Note:** This needs a special radio FW that is build with these features enabled to properly work.