### PR TITLE
Change NUM_TRAJECTORY_DEFINITIONS to match documentation - fix only 10 trajectories bug.

### DIFF
--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -46,7 +46,7 @@ Header file for high-level commander that computes smooth setpoints based on hig
 
 #include "stabilizer_types.h"
 
-#define NUM_TRAJECTORY_DEFINITIONS 10
+#define NUM_TRAJECTORY_DEFINITIONS 31
 
 typedef enum {
   CRTP_CHL_TRAJECTORY_TYPE_POLY4D = 0, // struct poly4d, see pptraj.h


### PR DESCRIPTION
Changing the constant value of NUM_TRAJECTORY_DEFINITIONS to match the documentation (which states that up to 31 trajectories can be uploaded at a time).

This change fixes the maximum of 10 trajectories issue: https://github.com/bitcraze/crazyflie-firmware/issues/1393.