### PR TITLE
Disable controller selection if OOT controller is selected

### DIFF
--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -3,6 +3,7 @@ menu "Controllers and Estimators"
 choice
     prompt "Default controller"
     default CONFIG_CONTROLLER_AUTO_SELECT
+    depends on !CONTROLLER_OOT
 
 config CONTROLLER_AUTO_SELECT
     bool "Auto select Controller"

--- a/src/modules/src/controller/controller.c
+++ b/src/modules/src/controller/controller.c
@@ -47,7 +47,9 @@ void controllerInit(ControllerType controller) {
     currentController = DEFAULT_CONTROLLER;
   }
 
-  #if defined(CONFIG_CONTROLLER_PID)
+  #if defined(CONFIG_CONTROLLER_OOT)
+    #define CONTROLLER ControllerTypeOot
+  #elif defined(CONFIG_CONTROLLER_PID)
     #define CONTROLLER ControllerTypePID
   #elif defined(CONFIG_CONTROLLER_INDI)
     #define CONTROLLER ControllerTypeINDI
@@ -57,8 +59,6 @@ void controllerInit(ControllerType controller) {
     #define CONTROLLER ControllerTypeBrescianini
   #elif defined(CONFIG_CONTROLLER_LEE)
     #define CONTROLLER ControllerTypeLee
-  #elif defined(CONFIG_CONTROLLER_OOT)
-    #define CONTROLLER ControllerTypeOot
   #else
     #define CONTROLLER ControllerTypeAutoSelect
   #endif

--- a/src/modules/src/controller/controller.c
+++ b/src/modules/src/controller/controller.c
@@ -47,9 +47,7 @@ void controllerInit(ControllerType controller) {
     currentController = DEFAULT_CONTROLLER;
   }
 
-  #if defined(CONFIG_CONTROLLER_OOT)
-    #define CONTROLLER ControllerTypeOot
-  #elif defined(CONFIG_CONTROLLER_PID)
+  #if defined(CONFIG_CONTROLLER_PID)
     #define CONTROLLER ControllerTypePID
   #elif defined(CONFIG_CONTROLLER_INDI)
     #define CONTROLLER ControllerTypeINDI
@@ -59,6 +57,8 @@ void controllerInit(ControllerType controller) {
     #define CONTROLLER ControllerTypeBrescianini
   #elif defined(CONFIG_CONTROLLER_LEE)
     #define CONTROLLER ControllerTypeLee
+  #elif defined(CONFIG_CONTROLLER_OOT)
+    #define CONTROLLER ControllerTypeOot
   #else
     #define CONTROLLER ControllerTypeAutoSelect
   #endif


### PR DESCRIPTION
Currently, kconfig allows both one of the implemented controllers + the OOT controller to be selected. Since only one can be used at a time this resulted in the implemented controller being used over the OOT controller (due to the order of how they are checked in `controller.c`. This PR keeps the config/menu structure the same, but when OOT controller is selected, this automatically disables the choice of regular controller.

Visualized in menuconfig:
![Screenshot from 2024-09-09 13-12-08](https://github.com/user-attachments/assets/e901bc98-32ba-403b-a4e9-4aefb47f2286)

![Screenshot from 2024-09-09 13-12-02](https://github.com/user-attachments/assets/4084c347-b6d9-40e4-a2bc-aa4279e8bbc7)
