### PR TITLE
Enhance Makefile for OOT app layer builds

### DIFF
--- a/docs/development/oot.md
+++ b/docs/development/oot.md
@@ -50,7 +50,7 @@ If you have header files in another folder, use `EXTRA_CFLAGS` in the Makefile t
 EXTRA_CFLAGS += -I$(PWD)/src/inc
 ```
 
-And since you are providing a config file by way of `$(OOT_CONFIG)` you do not need to run any make command to create a config like `make menuconfig` or `make defconfig`. Just a simple `make` will suffice.
+OOT builds can be configured with [Kbuild](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/development/kbuild/) using terminal interfaces like `make menuconfig` or by loading a default configuration, such as with `make cf2_defconfig`. Any definitions in $(OOT_CONFIG) will override conflicting settings.
 
 ## OOT estimators
 The `config` file needs to enable ESTIMATOR_OOT, and can also set other config options:

--- a/docs/userguides/app_layer.md
+++ b/docs/userguides/app_layer.md
@@ -60,6 +60,10 @@ obj-y += your-app.o
 
 You can look at the applications in the `examples/` folder of the firmware repository.
 
+## Configuring the app layer
+
+The app layer can be configured with [Kbuild](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/development/kbuild/). Default configurations can be loaded by running `make cf2_defconfig` in the app directory.  Terminal based user interfaces ('menuconfig', 'nconfig', 'gconfig', 'xconfig') can be used to configure the app layer by e.g. running `make menuconfig` in the app directory. Note that if there are any conflicting settings, the values defined in `app-config` will take priority.
+
 ## Building the app layer
 
 In order to build the app layer, go to the root folder of the app example and run:

--- a/tools/make/oot.mk
+++ b/tools/make/oot.mk
@@ -12,20 +12,50 @@ OOT_CONFIG ?= $(OOT)/oot-config
 
 OOT_ARGS ?= -C $(CRAZYFLIE_BASE) OOT=$(OOT) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
 
-CONFIG ?= alldefconfig
+DEFAULT_CONFIG ?= alldefconfig
 
 ifneq ($(OOT_USES_CXX),)
 OOT_ARGS += OOT_USES_CXX=1
 endif
 
-.PHONY: all clean
+.PHONY: all clean menuconfig nconfig xconfig gconfig cload
+
+%_defconfig:
+	@if [ -f $(CRAZYFLIE_BASE)/configs/$@ ]; then \
+		echo "Loading defconfig $@ from configs folder"; \
+		$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) KCONFIG_ALLCONFIG=configs/$@ $(DEFAULT_CONFIG); \
+	else \
+		echo "Defconfig $@ not found in configs folder"; \
+		exit 1; \
+	fi
 
 all:
-	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) KCONFIG_ALLCONFIG=$(OOT_CONFIG) $(CONFIG)
-	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) -j 12
+	@if [ ! -f $(OOT)/build/.config ]; then \
+		$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) $(DEFAULT_CONFIG); \
+	fi
+	@if [ -f $(OOT_CONFIG) ]; then \
+        echo "Merging $(OOT_CONFIG) into .config"; \
+        ../../scripts/kconfig/merge_config.sh -O $(OOT)/build -m $(OOT)/build/.config $(OOT_CONFIG); \
+    else \
+        echo "$(OOT_CONFIG) does not exist"; \
+    fi
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) oldconfig
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS)
 
 clean:
 	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) clean
+
+menuconfig:
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) menuconfig
+
+nconfig:
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) nconfig
+
+xconfig:
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) xconfig
+
+gconfig:
+	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) gconfig
 
 cload:
 	$(MAKE) KBUILD_OUTPUT=$(OOT)/build $(OOT_ARGS) cload

--- a/tools/make/oot.mk
+++ b/tools/make/oot.mk
@@ -35,7 +35,7 @@ all:
 	fi
 	@if [ -f $(OOT_CONFIG) ]; then \
         echo "Merging $(OOT_CONFIG) into .config"; \
-        ../../scripts/kconfig/merge_config.sh -O $(OOT)/build -m $(OOT)/build/.config $(OOT_CONFIG); \
+        $(CRAZYFLIE_BASE)/scripts/kconfig/merge_config.sh -O $(OOT)/build -m $(OOT)/build/.config $(OOT_CONFIG); \
     else \
         echo "$(OOT_CONFIG) does not exist"; \
     fi


### PR DESCRIPTION
This PR enhances the Makefile for out-of-Tree (OOT) / app layer builds by adding support for kbuild configuration GUIs and loading default configurations.

* Added support for configuration GUIs:
  * Introduce targets for `menuconfig`, `nconfig`, `xconfig`, and `gconfig`
  * Example usage:
    In the app directory
    ```
    make menuconfig
    ```
* Load defconfig files
  * From `configs` folder
  * Example usage:
    In the app directory
    ```
    make bolt_defconfig
    ```
* Anything defined in `OOT_CONFIG` (e.g., `app_config` in `app_hello_world`) overwrites conflicting settings
* Documentation