### PR TITLE
Minor brushless configuration changes

### DIFF
--- a/src/platform/interface/platform_defaults_cf21bl.h
+++ b/src/platform/interface/platform_defaults_cf21bl.h
@@ -35,7 +35,7 @@
 
 // Default values for battery limits
 #define DEFAULT_BAT_LOW_VOLTAGE 3.35f
-#define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE 3.3f
+#define DEFAULT_BAT_CRITICAL_LOW_VOLTAGE 3.0f
 #define DEFAULT_BAT_LOW_DURATION_TO_TRIGGER_SEC 5
 
 // Default value for system shutdown in minutes after radio silence.

--- a/src/platform/src/platform_cf2.c
+++ b/src/platform/src/platform_cf2.c
@@ -51,13 +51,6 @@ static platformConfig_t configs[] = {
     .physicalLayoutAntennasAreClose = true,
     .motorMap = motorMapDefaultBrushed,
   },
-  {
-    .deviceType = "C21B",
-    .deviceTypeName = "Crazyflie 2.1 Brushless",
-    .sensorImplementation = SensorImplementation_bmi088_bmp3xx,
-    .physicalLayoutAntennasAreClose = true,
-    .motorMap = motorMapCF21Brushless,
-  },
 #endif
 };
 


### PR DESCRIPTION
- Decrease CF21BL critically low voltage to 3.0
- Remove legacy brushless devicetype from CF2 platform. Use platform_cf21bl instead.