### PR TITLE
Fix: Use malloc and free for cv_stack to avoid dangling pointer warning

### DIFF
--- a/scripts/kconfig/symbol.c
+++ b/scripts/kconfig/symbol.c
@@ -1097,10 +1097,14 @@ static void sym_check_print_recursive(struct symbol *last_sym)
 	struct symbol *sym, *next_sym;
 	struct menu *menu = NULL;
 	struct property *prop;
-	struct dep_stack cv_stack;
+	struct dep_stack *cv_stack = malloc(sizeof(struct dep_stack));
+	if (!cv_stack) {
+		fprintf(stderr, "failed to allocate memory for recursive dependency check\n");
+		return;
+	}
 
 	if (sym_is_choice_value(last_sym)) {
-		dep_stack_insert(&cv_stack, last_sym);
+		dep_stack_insert(cv_stack, last_sym);
 		last_sym = prop_get_symbol(sym_get_choice_prop(last_sym));
 	}
 
@@ -1109,6 +1113,7 @@ static void sym_check_print_recursive(struct symbol *last_sym)
 			break;
 	if (!stack) {
 		fprintf(stderr, "unexpected recursive dependency error\n");
+		free(cv_stack);
 		return;
 	}
 
@@ -1161,8 +1166,9 @@ static void sym_check_print_recursive(struct symbol *last_sym)
 		}
 	}
 
-	if (check_top == &cv_stack)
+	if (check_top == cv_stack)
 		dep_stack_remove();
+	free(cv_stack);
 }
 
 static struct symbol *sym_check_expr_deps(struct expr *e)


### PR DESCRIPTION
Before the change, running `make cf2_defconfig` and `make clean` generated warnings about dangling pointers in the configuration process.
```
In function ‘dep_stack_insert’,
    inlined from ‘sym_check_print_recursive’ at ../scripts/kconfig/symbol.c:1103:3,
    inlined from ‘sym_check_deps’ at ../scripts/kconfig/symbol.c:1280:3:
../scripts/kconfig/symbol.c:1079:19: warning: storing the address of local variable ‘cv_stack’ in ‘check_top’ [-Wdangling-pointer=]
 1079 |         check_top = stack;
      |         ~~~~~~~~~~^~~~~~~
../scripts/kconfig/symbol.c: In function ‘sym_check_deps’:
../scripts/kconfig/symbol.c:1100:26: note: ‘cv_stack’ declared here
 1100 |         struct dep_stack cv_stack;
      |                          ^~~~~~~~
../scripts/kconfig/symbol.c:1070:4: note: ‘check_top’ declared here
 1070 | } *check_top;
      |    ^~~~~~~~~
```
After the update, the command completes without any warnings. 

The changes in this PR shouldn't practically change anything except acknowledge that we are responsible for cv_stack. The function in question is called during recursive dependency checking. I tested this PR by deliberately introducing recursive dependency in kconfig.