### PR TITLE
Revert "Removed -nostdlib from LDFLAGS"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LIB = $(srctree)/src/lib
 PROCESSOR = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
 LINKER_DIR = $(srctree)/tools/make/F405/linker
 
-LDFLAGS += --specs=nosys.specs --specs=nano.specs $(PROCESSOR)
+LDFLAGS += --specs=nosys.specs --specs=nano.specs $(PROCESSOR) -nostdlib
 image_LDFLAGS += -Wl,-Map=$(PROG).map,--cref,--gc-sections,--undefined=uxTopUsedPriority
 image_LDFLAGS += -L$(srctree)/tools/make/F405/linker
 image_LDFLAGS += -T $(LINKER_DIR)/FLASH_CLOAD.ld


### PR DESCRIPTION
This reverts commit af0cbe50cc38dfeb0bc5f3c098b683e22614f05c.

`-nostdlib` was added to LDFLAGS when we converted to kbuild. PR #1310 removed `-nostdlib` in order to make it possible to use the `atof()` function. However, this now causes similar linker warnings to those it was trying to solve ([discussion 784](https://github.com/orgs/bitcraze/discussions/784)). From what I can tell this occurs with newer version of newlib on e.g. Ubuntu 24.04. 

420 days later, `atof()` is not being used anywhere internally. Discussion in #1299 is not very convincing on why `atof()` is needed. The arguing mostly relies that the cost in flash and RAM is so low that there is no good reason not to do it. However, it now causes linker warnings.

This PR fixes the linker warnings by reverting this commit. It comes with a bonus reduced flashed and RAM usage, but at a cost of losing the `atof()` fn.

I haven't been able to find a way, but am open to suggestions that preserve `atof()` functionality.