### PR TITLE
Several small documentation updates

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -12,21 +12,13 @@ install some ARM toolchain.
 ### Install a toolchain
 
 #### Toolchain and compiler version policy
-Our policy for toolchain is to follow what is available in the oldest [Ubuntu Long Term Support release](https://wiki.ubuntu.com/Releases) and treat that as the oldest supported version. At the time of writing this (September 6 2021) the oldest LTS release is 18.04. And in Ubuntu 18.04 (bionic) the version of gcc-arm-none-eabi is 6.3.
+Our toolchain policy is to support the [oldest Ubuntu Long Term Support (LTS) release that is still within its Standard Support period](https://wiki.ubuntu.com/Releases). This means that we do not support Ubuntu releases that have reached End of Standard Support. As of October 15th, 2024, the oldest Ubuntu LTS release still receiving Standard Support is 20.04 (Focal Fossa). In Ubuntu 20.04, the version of `gcc-arm-none-eabi` available is 9.
 
-This means that if the firmware can not be compiled using gcc 6.3, **or anything newer**, it should be considered a bug.
+This means that if the firmware can not be compiled using gcc 9, **or anything newer**, it should be considered a bug.
 
 ##### Ubuntu
-For Ubuntu 20.04 and 22.04:
 ```
 $ sudo apt-get install make gcc-arm-none-eabi
-```
-
-For Ubuntu 18.04:
-```
-$ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
-$ sudo apt-get update
-$ sudo apt install gcc-arm-embedded
 ```
 
 ##### macOS
@@ -109,7 +101,7 @@ $ make -j$(sysctl -n hw.ncpu)
 ```
 
 >  Alternatively, to configure and build with the toolbelt, prepend `tb` to the make commands as follows:
->  
+>
 >  ```
 >  $ tb make cf2_defconfig
 >  $ tb make

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -57,7 +57,7 @@ This repository uses git submodules. Clone with the `--recursive` flag
 $ git clone --recursive https://github.com/bitcraze/crazyflie-firmware.git
 ```
 
-**Note** Make sure there are no spaces in the folder structure leading up to the repository (example: _/a/path/with/no/spaces/crazyflie-firmware/_ vs _a/path with spaces/crazyflie-firmware/_). Our build system can not handle file system paths with spaces in them, and compilation will fail.
+> Note: Make sure there are no spaces in the folder structure leading up to the repository (example: _/a/path/with/no/spaces/crazyflie-firmware/_ vs _a/path with spaces/crazyflie-firmware/_). Our build system can not handle file system paths with spaces in them, and compilation will fail.
 
 If you already have cloned the repo without the `--recursive` option, you need to
 get the submodules manually

--- a/docs/development/openocd_gdb_debugging.md
+++ b/docs/development/openocd_gdb_debugging.md
@@ -101,24 +101,8 @@ You should now see WSL Ubuntu installing the VS Code Server program. Shortly aft
 > Note: In addition to the Arm-Cortex Debugging Extension (Version 1.2.2!), which is installed later in this instruction, you should also install Microsofts C/C++ Extension Pack and its recommended Extensions. 
 
 ##### Attach the ST-Link V2 USB device directly to WSL
-In contrast to `make cload`, which uses the windows programs to interface with usb devices such as Crazyradio PA, the openocd wants to communicate directly in WSL with your ST-Link V2. So it's not sufficient to just connect it to your Windows machine, you also have to attach it to WSL. For that we need to install USBIPD on Windows.
 
-In Windows Powershell(Admin), execute
-
-    winget install --interactive --exact dorssel.usbipd-win
-
-In WSL Ubuntu, execute
-
-    sudo apt install linux-tools-5.4.0-77-generic hwdata -y 
-    sudo update-alternatives --install /usr/local/bin/usbip usbip /usr/lib/linux-tools/5.4.0-77-generic/usbip 20
-
-After that you can use the following Commands in Windows Powershell(Admin)
-- List all USB Devices: ```usbipd wsl list```
-- Attach USB Device to WSL: 
-    - ```usbipd wsl attach -b <busid of ST-Link>```
-    - ```usbipd wsl attach -b <busid of ST-Link> -d <Name of specific WSL Distro if you have more than one>```
-    - Example: ```usbipd wsl attach -b 2-6 -d Ubuntu-20.04```
-- Detach USB Device to WSL: ```usbipd wsl detach -b <busid of ST-Link>``` (or just unplug it)
+Unlike make cload, which uses Windows programs to connect with USB devices like the Crazyradio PA, OpenOCD needs to communicate directly with your ST-Link V2 in WSL. Simply connecting it to your Windows machine isn’t enough; you also need to attach it to WSL. To do this, you'll need to install `USBIPD` on Windows. Follow the instructions on[ how to install USBIPD](https://github.com/dorssel/usbipd-win?tab=readme-ov-file#how-to-install) and [how to attach a device to WSL](https://github.com/dorssel/usbipd-win?tab=readme-ov-file#connecting-devices).
 
 Now make sure that it is connected to WSL by listing all usb devices with ```lsusb```
 Currently only the Superuser has read/write access to that usb device, change that by

--- a/docs/functional-areas/crtp/crtp_platform.md
+++ b/docs/functional-areas/crtp/crtp_platform.md
@@ -123,12 +123,13 @@ Answer:
 
 Returns a string representation of the device type the firmware is running on. The currently existing device types are:
 
-| Device Type | Device type name |
-|-------------|------------------|
-| RZ10        | Crazyflie Bolt    |
-| CF20        | Crazyflie 2.0    |
-| CF2.1       | Crazyflie 2.1    |
-| RR10        | Roadrunner 1.0   |
+| Device Type | Device type name        |
+|-------------|-------------------------|
+| RZ10        | Crazyflie Bolt          |
+| CF20        | Crazyflie 2.0           |
+| CF2.1       | Crazyflie 2.1           |
+| C21B        | Crazyflie 2.1 Brushless |
+| RR10        | Roadrunner 1.0          |
 
 ## App channel
 

--- a/docs/userguides/configuration/loco_tx_power.md
+++ b/docs/userguides/configuration/loco_tx_power.md
@@ -18,7 +18,7 @@ Note that the Loco deck is only transmitting in TWR mode or when setting anchor 
 Loco deck does not increase the space that a TDoA system covers.
 
 To change to full power:
-1. In a terminal, run `make meuconfig`
+1. In a terminal, run `make menuconfig`
 2. Go to `Expansion deck configuration`
 3. Check the `Full TX power` option under the `Support the Loco positioning deck` section
 4. Save and exit

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -50,7 +50,8 @@ An identifier is stored in the physical hardware of each device, which is ued to
 |----------|---------------------------------------------|
 | Platform | Supported hardware (device type)            |
 |----------|---------------------------------------------|
-| cf2      | Crazyflie 2.0 (CF20), Crazyflie 2.1 (CF21) |
+| cf2      | Crazyflie 2.0 (CF20), Crazyflie 2.1 (CF21)  |
+| cf21bl   | Crazyflie 2.1 Brushless (C21B)              |
 | bolt     | Crazyflie Bolt 1.0 (CB10)                   |
 | tag      | Roadrunner 1.0 (RR10)                       |
 |----------|---------------------------------------------|


### PR DESCRIPTION
- Update documentation to reflect that we no longer provide support for Ubuntu 18.04
- Link to official USBIPD documentation for installation and usage instructions
- Add brushless to platform documentation
- Small formatting and typo fixes