### PR TITLE
Disarming improvements

### DIFF
--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -264,7 +264,7 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
     supervisorSetLatestLandingTime(this, currentTick);
   }
 
-  if ((previousState == supervisorStateLanded) && (newState == supervisorStateReset)) {
+  if ((previousState == supervisorStateFlying || previousState == supervisorStateLanded) && (newState == supervisorStateReset)) {
     DEBUG_PRINT("Disarming\n");
   }
 

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -263,9 +263,9 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
   if (newState == supervisorStateLanded) {
     supervisorSetLatestLandingTime(this, currentTick);
   }
-  
+
   if ((previousState == supervisorStateLanded) && (newState == supervisorStateReset)) {
-    DEBUG_PRINT("Landing timeout, disarming\n");
+    DEBUG_PRINT("Disarming\n");
   }
 
   if (newState == supervisorStateLocked) {

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -160,7 +160,7 @@ static SupervisorStateTransition_t transitionsFlying[] = {
     .newState = supervisorStateExceptFreeFall,
 
     .triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_EMERGENCY_STOP,
-    .negatedTriggers = SUPERVISOR_CB_ARMED,
+    .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAny,
 
     .blockerCombiner = supervisorNever,
@@ -169,7 +169,7 @@ static SupervisorStateTransition_t transitionsFlying[] = {
     .newState = supervisorStateCrashed,
 
     .triggers = SUPERVISOR_CB_IS_TUMBLED,
-    .negatedTriggers = SUPERVISOR_CB_ARMED,
+    .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAny,
 
     .blockerCombiner = supervisorNever,
@@ -230,7 +230,7 @@ static SupervisorStateTransition_t transitionsWarningLevelOut[] = {
     .newState = supervisorStateExceptFreeFall,
 
     .triggers = SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT | SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_EMERGENCY_STOP,
-    .negatedTriggers = SUPERVISOR_CB_ARMED,
+    .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAny,
 
     .blockerCombiner = supervisorNever,

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -175,6 +175,15 @@ static SupervisorStateTransition_t transitionsFlying[] = {
     .blockerCombiner = supervisorNever,
   },
   {
+    .newState = supervisorStateReset,
+
+    .triggers = SUPERVISOR_CB_NONE,
+    .negatedTriggers = SUPERVISOR_CB_ARMED,
+    .triggerCombiner = supervisorAll,
+
+    .blockerCombiner = supervisorNever,
+  },
+  {
     .newState = supervisorStateWarningLevelOut,
 
     .triggers = SUPERVISOR_CB_COMMANDER_WDT_WARNING,

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -199,8 +199,8 @@ static SupervisorStateTransition_t transitionsLanded[] = {
     .newState = supervisorStateReset,
 
     .triggers = SUPERVISOR_CB_LANDING_TIMEOUT,
-    .negatedTriggers = SUPERVISOR_CB_NONE,
-    .triggerCombiner = supervisorAll,
+    .negatedTriggers = SUPERVISOR_CB_ARMED,
+    .triggerCombiner = supervisorAny,
 
     .blockerCombiner = supervisorNever,
   },


### PR DESCRIPTION
Previously, sending a "disarm" request while the drone was in an unexpected state—such as still being in flight mode when the user believed it had landed—could unintentionally trigger an emergency stop or crash state. This issue arises because the drone’s internal supervisor state is largely hidden from the user, leading to confusion when attempting to disarm in states that instead trigger an emergency stop.

This PR fixes the issue by ensuring that disarm requests no longer trigger an emergency stop or crash state. If a disarm command is sent before the system confirms the landing, it will not result in an emergency stop or system lock-up. However, users can still trigger an emergency stop through the correct command as intended.

In the event that users have been deliberately using the disarm command to trigger an emergency stop, they must now switch to using the dedicated emergency stop command.

This fix addresses issue #1425.

---

Furthermore, sending a disarm request while in landed state now allows you to skip waiting for the disarming timeout and disarm early.