### PR TITLE
Fix stabilizer locked assert when passthrough interface is active

### DIFF
--- a/src/hal/interface/sensors.h
+++ b/src/hal/interface/sensors.h
@@ -60,6 +60,11 @@ void sensorsSuspend();
 void sensorsResume();
 
 /**
+ * Check if sensors are suspended (sensor interrupts disabled)
+ * @return true if they are, else false
+ */
+bool isSensorsSuspended();
+/**
  * Set acc mode, one of accModes enum
  */
 void sensorsSetAccMode(accModes accMode);

--- a/src/hal/src/sensors.c
+++ b/src/hal/src/sensors.c
@@ -145,6 +145,7 @@ static const sensorsImplementation_t sensorImplementations[SensorImplementation_
 static const sensorsImplementation_t* activeImplementation;
 static bool isInit = false;
 static const sensorsImplementation_t* findImplementation(SensorImplementation_t implementation);
+static bool sensorsSuspended = false;
 
 void sensorsInit(void) {
   if (isInit) {
@@ -208,12 +209,18 @@ void sensorsSetAccMode(accModes accMode) {
 void sensorsSuspend()
 {
   NVIC_DisableIRQ(EXTI15_10_IRQn);
+  sensorsSuspended = true;
 }
 
 void sensorsResume()
 {
   NVIC_EnableIRQ(EXTI15_10_IRQn);
+  sensorsSuspended = false;
+}
 
+bool isSensorsSuspended(void)
+{
+  return sensorsSuspended;
 }
 
 void __attribute__((used)) EXTI14_Callback(void) {

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -269,9 +269,12 @@ void rateSupervisorTask(void *pvParameters) {
         }
       }
     } else {
-      // Handle the case where the semaphore was not given within the timeout
-      DEBUG_PRINT("ERROR: stabilizerTask is blocking\n");
-      ASSERT(false); // For safety, assert if the stabilizer task is blocking to ensure motor shutdown
+      // Don't assert if sensors are suspended
+      if (isSensorsSuspended() == false) {
+        // Handle the case where the semaphore was not given within the timeout
+        DEBUG_PRINT("ERROR: stabilizerTask is blocking\n");
+        ASSERT(false); // For safety, assert if the stabilizer task is blocking to ensure motor shutdown
+      }
     }
   }
 }


### PR DESCRIPTION
In PR #1415 a safety mechanism was added. This did not work together with the passthrough interface which disables the sensor interrups and thus stops the stabilizer loop. A fix for this has been implemented.