### PR TITLE
Automatically disarm after N seconds without flying

### DIFF
--- a/src/modules/interface/supervisor_state_machine.h
+++ b/src/modules/interface/supervisor_state_machine.h
@@ -50,6 +50,7 @@ typedef enum {
   supervisorConditionCommanderWdtTimeout,
   supervisorConditionEmergencyStop,
   supervisorConditionIsCrashed,
+  supervisorConditionPreflightTimeout,
   supervisorConditionLandingTimeout,
   supervisorCondition_NrOfConditions,
 } supervisorConditions_t;
@@ -65,6 +66,7 @@ typedef uint32_t supervisorConditionBits_t;
 #define SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT (1 << supervisorConditionCommanderWdtTimeout)
 #define SUPERVISOR_CB_EMERGENCY_STOP (1 << supervisorConditionEmergencyStop)
 #define SUPERVISOR_CB_CRASHED (1 << supervisorConditionIsCrashed)
+#define SUPERVISOR_CB_PREFLIGHT_TIMEOUT (1 << supervisorConditionPreflightTimeout)
 #define SUPERVISOR_CB_LANDING_TIMEOUT (1 << supervisorConditionLandingTimeout)
 
 

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -73,9 +73,6 @@ typedef struct {
   uint16_t infoBitfield;
   uint8_t paramEmergencyStop;
 
-  // Deprecated, remove after 2024-06-01
-  int8_t deprecatedArmParam;
-
   // The time (in ticks) of the first tumble event. 0=no tumble
   uint32_t initialTumbleTick;
 
@@ -118,7 +115,7 @@ bool supervisorCanArm() {
 }
 
 bool supervisorIsArmed() {
-  return supervisorMem.isArmingActivated || supervisorMem.deprecatedArmParam;
+  return supervisorMem.isArmingActivated;
 }
 
 bool supervisorIsLocked() {
@@ -309,7 +306,7 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
   }
 
   // We do not require an arming action by the user, auto arm
-  if (AUTO_ARMING || this->deprecatedArmParam) {
+  if (AUTO_ARMING) {
     if (newState == supervisorStatePreFlChecksPassed) {
       supervisorRequestArming(true);
     }
@@ -385,7 +382,7 @@ static void updateLogData(SupervisorMem_t* this, const supervisorConditionBits_t
   if (supervisorIsArmed()) {
     this->infoBitfield |= 0x0002;
   }
-  if(AUTO_ARMING || this->deprecatedArmParam) {
+  if(AUTO_ARMING) {
     this->infoBitfield |= 0x0004;
   }
   if (this->canFly) {
@@ -515,17 +512,6 @@ PARAM_GROUP_START(stabilizer)
  */
 PARAM_ADD_CORE(PARAM_UINT8, stop, &supervisorMem.paramEmergencyStop)
 PARAM_GROUP_STOP(stabilizer)
-
-
-PARAM_GROUP_START(system)
-
-/**
- * @brief Set to nonzero to arm the system. A nonzero value enables the auto arm functionality
- *
- * Deprecated, will be removed after 2024-06-01. Use the CRTP `PlatformCommand` `armSystem` on the CRTP_PORT_PLATFORM port instead.
- */
-PARAM_ADD_CORE(PARAM_INT8, arm, &supervisorMem.deprecatedArmParam)
-PARAM_GROUP_STOP(system)
 
 
 /**

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -293,11 +293,6 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
     supervisorRequestCrashRecovery(false);
   }
 
-  if ((previousState == supervisorStateNotInitialized || previousState == supervisorStateReadyToFly || previousState == supervisorStateFlying) &&
-      newState != supervisorStateReadyToFly && newState != supervisorStateFlying && newState != supervisorStateLanded) {
-    DEBUG_PRINT("Can not fly\n");
-  }
-
   if (newState != supervisorStateReadyToFly &&
       newState != supervisorStateFlying &&
       newState != supervisorStateWarningLevelOut &&

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -271,7 +271,9 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
   const supervisorState_t newState = this->state;
 
   if (newState == supervisorStateReadyToFly) {
-    DEBUG_PRINT("Ready to fly\n");
+    if (!AUTO_ARMING){
+      DEBUG_PRINT("Ready to fly\n");
+    }
     supervisorSetLatestArmingTime(this, currentTick);
   }
 
@@ -281,7 +283,9 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
 
   if (((previousState == supervisorStateFlying || previousState == supervisorStateLanded) && (newState == supervisorStateReset))
        || (previousState == supervisorStateReadyToFly && newState == supervisorStatePreFlChecksPassed)) {
-    DEBUG_PRINT("Disarming\n");
+    if (!AUTO_ARMING){
+      DEBUG_PRINT("Disarming\n");
+    }
   }
 
   if (newState == supervisorStateLocked) {

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -59,6 +59,7 @@ static const char* const conditionNames[] = {
   "commanderWdtTimeout",
   "emergencyStop",
   "isCrashed",
+  "preflightTimeout",
   "landingTimeout",
 };
 static_assert(sizeof(conditionNames) / sizeof(conditionNames[0]) == supervisorCondition_NrOfConditions);
@@ -138,7 +139,7 @@ static SupervisorStateTransition_t transitionsReadyToFly[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED,
+    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_PREFLIGHT_TIMEOUT,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 

--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -147,6 +147,11 @@
     #define SUPERVISOR_TUMBLE_CHECK_ACCEPTED_UPSIDEDOWN_TIME 100
 #endif
 
+// Pre-flight disarming timeout
+#ifndef PREFLIGHT_TIMEOUT_MS
+    #define PREFLIGHT_TIMEOUT_MS 30000
+#endif
+
 // Landing timeout before disarming
 #ifndef LANDING_TIMEOUT_MS
     #define LANDING_TIMEOUT_MS 3000

--- a/src/platform/interface/platform_defaults_cf21bl.h
+++ b/src/platform/interface/platform_defaults_cf21bl.h
@@ -130,5 +130,4 @@
 #define PID_POS_VEL_Y_MAX 1.0f
 #define PID_POS_VEL_Z_MAX 1.0f
 
-// Manual arming, default idle thrust
 #define CONFIG_MOTORS_DEFAULT_IDLE_THRUST 7000


### PR DESCRIPTION
This PR introduces automatic disarming of the Crazyflie if no flight is started within 30 seconds after arming. This time-out is configurable. Implementation largely identical to post-flight auto-disarming. 

Since we currently print to console when ready to fly and when disarming, this introduces "spam" to the console when using auto-arming. Considering removing these printouts.

Possible discussion points:
- Trigger disarm after how many seconds?
- Removing disarming and ready to fly debug prints.

