### PR TITLE
Added ESC bootloader wakeup signal.

### DIFF
--- a/src/modules/src/serial_4way.c
+++ b/src/modules/src/serial_4way.c
@@ -33,6 +33,10 @@
 #define USE_SERIAL_4WAY_BLHELI_BOOTLOADER
 #ifdef  USE_SERIAL_4WAY_BLHELI_INTERFACE
 
+//FreeRTOS includes
+#include "FreeRTOS.h"
+#include "task.h"
+
 #include "motors.h"
 #include "usec_time.h"
 #include "led.h"
@@ -151,6 +155,18 @@ uint8_t esc4wayInit(void)
     for (volatile uint8_t i = 0; i < NBR_OF_MOTORS; i++) {
       motorsEnablePassthough(i);
       escCount++;
+    }
+
+    // Let ESCs enter bootloader mode
+    vTaskDelay(M2T(200));
+
+    // Make them stay in bootloader mode.
+    for (volatile uint8_t i = 0; i < NBR_OF_MOTORS; i++) {
+      motorsESCSetOutput(i);
+      motorsESCSetLo(i);
+      vTaskDelay(M2T(1));
+      motorsESCSetInput(i);
+      motorsESCSetHi(i);
     }
 
     return escCount;


### PR DESCRIPTION
This PR will send a low pulse for 1 ms after the ESC has entered the bootloader to keep the bootloader alive and not go to deep sleep. This only happes then 4way interface has been enabled though a client such as the ESC-configurator and will not prevent the ESC from sleeping under normal operation.

Fixes #1443