### PR TITLE
Add `nix develop` support

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -9,6 +9,9 @@ You'll need to use either the [Crazyflie VM](https://github.com/bitcraze/bitcraz
 [the toolbelt](https://github.com/bitcraze/toolbelt) or
 install some ARM toolchain.
 
+There is also experimental support for [building with nix](./nix.md).
+This allows to build the firmware in a reproducable way.
+
 ### Install a toolchain
 
 #### Toolchain and compiler version policy

--- a/docs/building-and-flashing/nix.md
+++ b/docs/building-and-flashing/nix.md
@@ -1,0 +1,29 @@
+---
+title: Building using nix
+page_id: nix
+---
+
+The [Nix package manager](https://nixos.org) can be used to build the firmware in a reliable way without having to install all the dependencies on your system.
+All that is needed is to have the nix package manager installed with [Flake support enabled](https://nixos.wiki/wiki/flakes).
+The easiest if nix is not installed yet is to install it from [zero to Nix](https://zero-to-nix.com/start/install/).
+Nix support in this project is currently experimental.
+
+## Development shell
+
+To get into a development shell where required tools for building the project are present:
+
+``` bash
+nix develop
+```
+
+## Building with Nix
+
+The following command will produce a clean build for the Crazyflie 2. The command can be changed to build for other target:
+
+``` bash
+nix develop -i --command bash -c 'make mrproper && make cf2_defconfig && make -j`nproc`'
+```
+
+## Updating the flake
+
+One great advantage of working with Nix is that the versions are locked in the `nix.lock` file. This means that build are reproducable. Running `nix flake update` can be used to update dependencies. The file `nix.lock` then need to be commited and pushed.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Crazyflie firmware development environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem
+    (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        formatter = pkgs.alejandra;
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            gcc
+            gnumake
+            gcc-arm-embedded
+            python3
+            git
+          ];
+        };
+      }
+    );
+}

--- a/tools/kbuild/Makefile.kbuild
+++ b/tools/kbuild/Makefile.kbuild
@@ -137,7 +137,7 @@ ifneq ($(KBUILD_OUTPUT),)
 # check that the output directory actually exists
 saved-output := $(KBUILD_OUTPUT)
 KBUILD_OUTPUT := $(shell mkdir -p $(KBUILD_OUTPUT) && cd $(KBUILD_OUTPUT) \
-								&& /bin/pwd)
+								&& pwd)
 $(if $(KBUILD_OUTPUT),, \
      $(error failed to create output directory "$(saved-output)"))
 


### PR DESCRIPTION
Add `flake.nix` to support the `nix develop` command and document the nix way of building the firmware.

This allows to build the firmware in a reproducible way since all the build dependencies versions are specified in the `flake.lock` file.

This is a first experimental step that could be used, for example. from CI (maybe in parallel to the current CI at first?).