### PR TITLE
Fixed cf21bl propeller test that asserted

### DIFF
--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -368,9 +368,10 @@ static void stabilizerTask(void* param)
       calcSensorToOutputLatency(&sensorData);
       stabilizerStep++;
       STATS_CNT_RATE_EVENT(&stabilizerRate);
-
-      xSemaphoreGive(xRateSupervisorSemaphore);
     }
+
+    xSemaphoreGive(xRateSupervisorSemaphore);
+
 #ifdef CONFIG_MOTORS_ESC_PROTOCOL_DSHOT
     motorsBurstDshot();
 #endif


### PR DESCRIPTION
I moved the rate supervisor watchdog reset mechanism so it works for the propeller test as well.