### PR TITLE
Add Lee Controller as option in Kconfig

### DIFF
--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -42,6 +42,11 @@ config CONTROLLER_BRESCIANINI
     help
         Use the Brescianini controller as default
 
+config CONTROLLER_LEE
+    bool "Lee controller"
+    help
+        Use the Lee controller as default
+
 endchoice
 
 config CONTROLLER_OOT


### PR DESCRIPTION
## Problem Statement

When using the `make menuconfig` tool, it is currently not possible to select the `Lee controller` as the controller, even though all other types of controllers defined in `src/modules/src/controller/controller.c` can be selected. It looks like the `Lee controller` was simply forgotten about in the `Kconfig` file, as there are checks to see whether `CONFIG_CONTROLLER_LEE` is set within the `controller.c` file [here](https://github.com/bitcraze/crazyflie-firmware/blob/e81084df59f95329f92b03d44ebc70e35a0f8174/src/modules/src/controller/controller.c#L58C1-L59C41). The Lee Controller was added in #1343 but this PR did not modify the `Kconfig` file.

## Solution

With this PR, one can select the `Lee controller` as the controller option:

![image](https://github.com/user-attachments/assets/0bf4a070-f7d3-408b-bb0e-df266ee586ed)

## Verification

After running `make menuconfig` and selecting the `Lee controller` option, the following is put into `build/.config`:

```
#
# Controllers and Estimators
#
# CONFIG_CONTROLLER_AUTO_SELECT is not set
# CONFIG_CONTROLLER_PID is not set
# CONFIG_CONTROLLER_INDI is not set
# CONFIG_CONTROLLER_MELLINGER is not set
# CONFIG_CONTROLLER_BRESCIANINI is not set
CONFIG_CONTROLLER_LEE=y
# CONFIG_CONTROLLER_OOT is not set
```

After `make` is run,  the `build/include/generated/autoconf.h` will contain the proper preprocessor command

```C
#define CONFIG_CONTROLLER_LEE 1
```

and then the `Lee controller` is selected in `controller.c`. This was also verified in the `cfclient` tool's Console which logs the `DEBUG_PRINT` statements.

```
CONTROLLER: Controller type forced
CONTROLLER: Using Lee (5) controller
```