### PR TITLE
Fix i2c address collisions

### DIFF
--- a/src/deck/drivers/src/acs37800.c
+++ b/src/deck/drivers/src/acs37800.c
@@ -76,7 +76,6 @@
 #define ACSREG_DSP_STATUS   0x2D
 #define ACSREG_ACCESS_CODE  0x2F
 
-#define ACS_I2C_ADDR        0x7F
 #define ACS_ACCESS_CODE     0x4F70656E
 
 

--- a/src/deck/drivers/src/acs37800.c
+++ b/src/deck/drivers/src/acs37800.c
@@ -167,12 +167,12 @@ float convertSignedFixedPoint(uint32_t inputValue, uint16_t binaryPoint, uint16_
 
 static bool asc37800Read32(uint8_t reg, uint32_t *data32)
 {
-  return i2cdevReadReg8(I2C1_DEV, ACS_I2C_ADDR, reg, 4, (uint8_t *)data32);
+  return i2cdevReadReg8(I2C1_DEV, ACS_DECK_I2C_ADDR, reg, 4, (uint8_t *)data32);
 }
 
 static bool asc37800Write32(uint8_t reg, uint32_t data32)
 {
-  return i2cdevWriteReg8(I2C1_DEV, ACS_I2C_ADDR, reg, 4, (uint8_t *)&data32);
+  return i2cdevWriteReg8(I2C1_DEV, ACS_DECK_I2C_ADDR, reg, 4, (uint8_t *)&data32);
 }
 
 static void ascFindAndSetAddress(void)
@@ -212,7 +212,7 @@ static void asc37800Init(DeckInfo *info)
     return;
   }
 
-  if (i2cdevWrite(I2C1_DEV, ACS_I2C_ADDR, 1, (uint8_t *)&dummy))
+  if (i2cdevWrite(I2C1_DEV, ACS_DECK_I2C_ADDR, 1, (uint8_t *)&dummy))
   {
     asc37800Write32(ACSREG_ACCESS_CODE, ACS_ACCESS_CODE);
     DEBUG_PRINT("ACS37800 I2C [OK]\n");

--- a/src/deck/drivers/src/activeMarkerDeck.c
+++ b/src/deck/drivers/src/activeMarkerDeck.c
@@ -80,7 +80,7 @@ EVENTTRIGGER(activeMarkerModeChanged, uint8, mode)
 static bool activeMarkerDeckCanStart = false;
 #endif
 
-#define DECK_I2C_ADDRESS 0x2E
+
 #define VERSION_STRING_LEN 12
 
 enum version_e {
@@ -105,7 +105,7 @@ static void activeMarkerDeckInit(DeckInfo *info) {
 
 #ifndef ACTIVE_MARKER_DECK_TEST
   memset(versionString, 0, VERSION_STRING_LEN + 1);
-  i2cOk = i2cdevReadReg8(I2C1_DEV, DECK_I2C_ADDRESS, MEM_ADR_VER, VERSION_STRING_LEN, (uint8_t*)versionString);
+  i2cOk = i2cdevReadReg8(I2C1_DEV, ACTIVE_MARKER_DECK_I2C_ADDRESS, MEM_ADR_VER, VERSION_STRING_LEN, (uint8_t*)versionString);
   DEBUG_PRINT("Deck FW %s\n", versionString);
 #endif
 
@@ -146,14 +146,14 @@ static void handleIdUpdate() {
   }
 
   if (isDifferent) {
-      i2cdevWriteReg8(I2C1_DEV, DECK_I2C_ADDRESS, MEM_ADR_LED, LED_COUNT, currentId);
+      i2cdevWriteReg8(I2C1_DEV, ACTIVE_MARKER_DECK_I2C_ADDRESS, MEM_ADR_LED, LED_COUNT, currentId);
   }
 }
 
 static void handleModeUpdate() {
   if (currentDeckMode != requestedDeckMode) {
     currentDeckMode = requestedDeckMode;
-    i2cdevWriteReg8(I2C1_DEV, DECK_I2C_ADDRESS, MEM_ADR_MODE, 1, &currentDeckMode);
+    i2cdevWriteReg8(I2C1_DEV, ACTIVE_MARKER_DECK_I2C_ADDRESS, MEM_ADR_MODE, 1, &currentDeckMode);
 
     eventTrigger_activeMarkerModeChanged_payload.mode = currentDeckMode;
     eventTrigger(&eventTrigger_activeMarkerModeChanged);
@@ -164,7 +164,7 @@ static void handleButtonSensorRead() {
   if (doPollDeckButtonSensor) {
     uint32_t now = xTaskGetTickCount();
     if (now > nextPollTime) {
-      i2cdevReadReg8(I2C1_DEV, DECK_I2C_ADDRESS, MEM_ADR_BUTTON_SENSOR, 1, &deckButtonSensorValue);
+      i2cdevReadReg8(I2C1_DEV, ACTIVE_MARKER_DECK_I2C_ADDRESS, MEM_ADR_BUTTON_SENSOR, 1, &deckButtonSensorValue);
       nextPollTime = now + pollIntervall;
     }
   }
@@ -177,7 +177,7 @@ static void task(void *param) {
   while (!activeMarkerDeckCanStart) {
     vTaskDelay(100);
   }
-  i2cOk = i2cdevReadReg8(I2C1_DEV, DECK_I2C_ADDRESS, MEM_ADR_VER, VERSION_STRING_LEN, (uint8_t*)versionString);
+  i2cOk = i2cdevReadReg8(I2C1_DEV, ACTIVE_MARKER_DECK_I2C_ADDRESS, MEM_ADR_VER, VERSION_STRING_LEN, (uint8_t*)versionString);
 #endif
 
   while (1) {

--- a/src/drivers/interface/eeprom.h
+++ b/src/drivers/interface/eeprom.h
@@ -31,7 +31,6 @@
 #include <stdbool.h>
 #include "i2cdev.h"
 
-#define EEPROM_I2C_ADDR     0x50
 #define EEPROM_SIZE         0x1FFF
 
 /**

--- a/src/drivers/interface/i2cdev.h
+++ b/src/drivers/interface/i2cdev.h
@@ -46,6 +46,18 @@ typedef I2cDrv    I2C_Dev;
 #define i2cdevWrite16 i2cdevWriteReg16
 #define i2cdevRead16  i2cdevReadReg16
 
+//I2cAddress list
+#define RANGER_DECKS_DEFAULT_ADDRESS   0x29
+#define ACTIVE_MARKER_DECK_I2C_ADDRESS 0x2E
+#define LIGHTHOUSE_DECK_I2C_ADDR       0x2F
+#define EEPROM_I2C_ADDR                0x50
+#define PRESSURE_DECK_I2C_ADDRESS      0x5D
+#define RANGER_DECKS_ADDRESS_START     0x60
+#define RANGER_DECKS_ADDRESS_END       0x6F
+#define ACS_DECK_I2C_ADDR              0x7F
+
+
+
 /**
  * Read bytes from an I2C peripheral
  * @param dev  Pointer to I2C peripheral to read from

--- a/src/drivers/interface/vl53l0x.h
+++ b/src/drivers/interface/vl53l0x.h
@@ -29,8 +29,6 @@
 
 #include "i2cdev.h"
 
-#define VL53L0X_DEFAULT_ADDRESS 0b0101001
-
 #define VL53L0X_RA_SYSRANGE_START                              0x00
 
 #define VL53L0X_REG_I2C_SLAVE_DEVICE_ADDRESS                   0x8a
@@ -156,7 +154,7 @@ typedef struct
 } VL53L0xDev;
 
 /** Default constructor, uses external I2C address.
- * @see VL53L0X_DEFAULT_ADDRESS
+ * @see RANGER_DECKS_DEFAULT_ADDRESS
  */
 bool vl53l0xInit(VL53L0xDev* dev, I2C_Dev *I2Cx, bool io_2V8);
 

--- a/src/drivers/interface/vl53l1x.h
+++ b/src/drivers/interface/vl53l1x.h
@@ -39,7 +39,6 @@ extern "C"
 {
 #endif
 
-#define VL53L1X_DEFAULT_ADDRESS 0b0101001
 
 #define USE_I2C_2V8
 

--- a/src/drivers/src/lh_bootloader.c
+++ b/src/drivers/src/lh_bootloader.c
@@ -34,7 +34,7 @@
 #include "debug.h"
 #include "i2cdev.h"
 
-#define LH_I2C_ADDR         0x2F
+
 #define LH_FW_SIZE          0x020000
 #define LH_FLASH_PAGE_SIZE  256
 #define LH_WRITE_BUF_SIZE   (5 + 4 + LH_FLASH_PAGE_SIZE)
@@ -96,7 +96,7 @@ bool lhblInit()
   if (isInit)
     return true;
 
-  devAddr = LH_I2C_ADDR;
+  devAddr = LIGHTHOUSE_DECK_I2C_ADDR;
 
   isInit = true;
 

--- a/src/drivers/src/lh_flasher.c
+++ b/src/drivers/src/lh_flasher.c
@@ -66,7 +66,6 @@ INCBIN(bootloader, "bootloader.bin");
 #define LH_SPI_CS DECK_GPIO_IO1
 #define LH_FPGA_RESET DECK_GPIO_RX2
 
-#define LH_I2C_ADDR         0x2F
 #define LH_FLASH_PAGE_SIZE  256
 #define LH_WRITE_BUF_SIZE   (5 + 4 + LH_FLASH_PAGE_SIZE)
 

--- a/src/drivers/src/lps25h.c
+++ b/src/drivers/src/lps25h.c
@@ -46,7 +46,7 @@ bool lps25hInit(I2C_Dev *i2cPort)
     return true;
 
   I2Cx = i2cPort;
-  devAddr = LPS25H_I2C_ADDR;
+  devAddr = PRESSURE_DECK_I2C_ADDRESS;
 
   vTaskDelay(M2T(5));
 

--- a/src/drivers/src/vl53l0x.c
+++ b/src/drivers/src/vl53l0x.c
@@ -124,6 +124,10 @@ bool vl53l0xInit(VL53L0xDev* dev, I2C_Dev *I2Cx, bool io_2V8)
   taskENTER_CRITICAL();
   newAddress = nextI2CAddress++;
   taskEXIT_CRITICAL();
+  if(newAddress > RANGER_DECKS_ADDRESS_END)
+  {
+    return false;
+  }
 
   return vl53l0xSetI2CAddress(dev, newAddress);
 }

--- a/src/drivers/src/vl53l0x.c
+++ b/src/drivers/src/vl53l0x.c
@@ -96,16 +96,16 @@ static uint16_t vl53l0xReadReg16Bit(VL53L0xDev* dev, uint8_t reg);
 static bool vl53l0xWriteReg16Bit(VL53L0xDev* dev, uint8_t reg, uint16_t val);
 static bool vl53l0xWriteReg32Bit(VL53L0xDev* dev, uint8_t reg, uint32_t val);
 
-static int nextI2CAddress = VL53L0X_DEFAULT_ADDRESS+1;
+static int nextI2CAddress = RANGER_DECKS_ADDRESS_START+1;
 
 /** Default constructor, uses default I2C address.
- * @see VL53L0X_DEFAULT_ADDRESS
+ * @see RANGER_DECKS_DEFAULT_ADDRESS
  */
 
 bool vl53l0xInit(VL53L0xDev* dev, I2C_Dev *I2Cx, bool io_2V8)
 {
   dev->I2Cx = I2Cx;
-  dev->devAddr = VL53L0X_DEFAULT_ADDRESS;
+  dev->devAddr = RANGER_DECKS_DEFAULT_ADDRESS;
 
   dev->io_timeout = 0;
   dev->did_timeout = 0;

--- a/src/drivers/src/vl53l1x.c
+++ b/src/drivers/src/vl53l1x.c
@@ -49,7 +49,7 @@
 #endif
 
 // Set the start address 1 step after the VL53L0 dynamic addresses
-static int nextI2CAddress = VL53L1X_DEFAULT_ADDRESS+1;
+static int nextI2CAddress = RANGER_DECKS_ADDRESS_START +1;
 
 
 bool vl53l1xInit(VL53L1_Dev_t *pdev, I2C_Dev *I2Cx)
@@ -57,7 +57,7 @@ bool vl53l1xInit(VL53L1_Dev_t *pdev, I2C_Dev *I2Cx)
   VL53L1_Error status = VL53L1_ERROR_NONE;
 
   pdev->I2Cx = I2Cx;
-  pdev->devAddr = VL53L1X_DEFAULT_ADDRESS;
+  pdev->devAddr = RANGER_DECKS_ADDRESS_START;
 
   /* Move initialized sensor to a new I2C address */
   int newAddress;

--- a/src/drivers/src/vl53l1x.c
+++ b/src/drivers/src/vl53l1x.c
@@ -65,10 +65,17 @@ bool vl53l1xInit(VL53L1_Dev_t *pdev, I2C_Dev *I2Cx)
   taskENTER_CRITICAL();
   newAddress = nextI2CAddress++;
   taskEXIT_CRITICAL();
+  if(newAddress > RANGER_DECKS_ADDRESS_END)
+  {
+	status = VL53L1_ERROR_UNDEFINED;
+  }
 
-  vl53l1xSetI2CAddress(pdev, newAddress);
+  if (status == VL53L1_ERROR_NONE)
+  {
+  	vl53l1xSetI2CAddress(pdev, newAddress);
 
-  status = VL53L1_DataInit(pdev);
+	status = VL53L1_DataInit(pdev);
+  }
 
   if (status == VL53L1_ERROR_NONE)
   {

--- a/src/drivers/src/vl53l1x.c
+++ b/src/drivers/src/vl53l1x.c
@@ -57,7 +57,7 @@ bool vl53l1xInit(VL53L1_Dev_t *pdev, I2C_Dev *I2Cx)
   VL53L1_Error status = VL53L1_ERROR_NONE;
 
   pdev->I2Cx = I2Cx;
-  pdev->devAddr = RANGER_DECKS_ADDRESS_START;
+  pdev->devAddr = RANGER_DECKS_DEFAULT_ADDRESS;
 
   /* Move initialized sensor to a new I2C address */
   int newAddress;


### PR DESCRIPTION
Added a list of used i2c addresses to our i2c header file.

Changed the addresses of the Ranger decks. I.e I changed only the addresses they are moved too, not the default. 
These addresses where previously overlapping with the Lighthouse and Active marker decks, and made the
decks incompatible when using multiranger. 

These are then internally used by all decks that use i2c.
I only "exported" those that are decks, and read by the Crazyflie. 
Renamed the addresses to be easier to read.

The pressure sensor lps25 seem to be both read and used by the crazyflie and by one of the bosch sensors, so I left 
the bosch define for that reading. 