### PR TITLE
The max size of the data in crtp is 30 not 31.

### DIFF
--- a/docs/functional-areas/crtp/crtp_console.md
+++ b/docs/functional-areas/crtp/crtp_console.md
@@ -15,7 +15,7 @@ Crazyflie to a host using the consoleprintf function.
             +---------//-----------+
             | PRINTED CONSOLE TEXT |
             +---------//-----------+
-    Length          0-31
+    Length          0-30
 
 The content is the text from the console. The encoding is ascii/UTF8 however
 this cannot be guaranteed so the packet receiver should be ready for binary
@@ -28,6 +28,6 @@ port: it could be a line, multiple line, part of a line, ...
 The current algorithm in the Crazyflie is to send a console packet is any of
 these condition are fulfilled:
 
- - The output buffer (of 31 bytes) is full
+ - The output buffer (of 30 bytes) is full
  - A \"newline\" character has to be send (\\n and/or \\r)
  - The flush function has been called

--- a/docs/functional-areas/crtp/index.md
+++ b/docs/functional-areas/crtp/index.md
@@ -80,7 +80,7 @@ Each CRTP packets carries one *port* number, a *channel* number as well as a
 Payload:
  - The `port` range between 0 and 15 (4 bits)
  - The `channel` ranges between 0 and 3 (2 bits)
- - The payload is a data buffer of up to 31 bytes
+ - The payload is a data buffer of up to 30 bytes
 
 The couple `port`:`channel` can be written separated by a color in this documentation.
 

--- a/docs/userguides/app_layer.md
+++ b/docs/userguides/app_layer.md
@@ -96,7 +96,7 @@ It is possible to run LED sequences from the app layer to control the four LEDs 
 ## App channel: packet based communication between the Crazyflie and the Python lib
 
 The Appchannel API allows to communicate using radio packets with an app.
-The packets can contain anything of a size up to 31 bytes, the protocol is defined by the app.
+The packets can contain anything of a size up to 30 bytes, the protocol is defined by the app.
 
 For more information about the API see the header file `src/modules/interface/app_channel.h`.
 An example of how to use the app channel is in `examples/app_appchannel_test/`

--- a/src/modules/interface/app_channel.h
+++ b/src/modules/interface/app_channel.h
@@ -29,7 +29,7 @@
 #include "crtp.h"
 
 #define APPCHANNEL_WAIT_FOREVER (-1)
-#define APPCHANNEL_MTU (31)
+#define APPCHANNEL_MTU (30)
 
 /**
  * Send an app-channel packet - deprecated (removed after August 2023). Use appchannelSendDataPacketBlock() instead.


### PR DESCRIPTION
Fix this so that documentation and code matches.
In the lib the max size is set to 30.

Fixes https://github.com/bitcraze/crazyflie-firmware/issues/1445