### PR TITLE
Updated Propeller Test in cfclient

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -218,7 +218,7 @@
  * This is the threshold for a propeller/motor to pass. It calculates the variance of the accelerometer X+Y
  * when the propeller is spinning.
  */
-#define PROPELLER_BALANCE_TEST_THRESHOLD  2.5f
+#define PROPELLER_BALANCE_TEST_THRESHOLD  0.0f
 
 /**
  * \def BAT_LOADING_SAG_THRESHOLD

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -214,13 +214,6 @@
 #define RADIO_ADDRESS 0xE7E7E7E7E7ULL
 
 /**
- * \def PROPELLER_BALANCE_TEST_THRESHOLD
- * This is the threshold for a propeller/motor to pass. It calculates the variance of the accelerometer X+Y
- * when the propeller is spinning.
- */
-#define PROPELLER_BALANCE_TEST_THRESHOLD  0.0f
-
-/**
  * \def BAT_LOADING_SAG_THRESHOLD
  * This is the threshold for a battery and connector to pass. It loads the power path by spinning all 4 motors
  * and measure the voltage sag. The threshold is very experimental and dependent on stock configuration. It is

--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -53,6 +53,8 @@
 static bool startPropTest = false;
 static bool startBatTest = false;
 
+static float propTestThreshold = PROPELLER_BALANCE_TEST_THRESHOLD;
+
 static uint16_t propTestPWMRatio = CONFIG_MOTORS_DEFAULT_PROP_TEST_PWM_RATIO;
 static uint16_t batTestPWMRatio = CONFIG_MOTORS_DEFAULT_BAT_TEST_PWM_RATIO;
 
@@ -115,13 +117,26 @@ static float variance(float *buffer, uint32_t length)
  */
 static bool evaluatePropTest(float low, float high, float value, uint8_t motor)
 {
-  if (value < low || value > high)
+  if (high != 0)
   {
-    DEBUG_PRINT("Propeller test on M%d [FAIL]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
-                motor + 1, (double)low, (double)high, (double)value);
-    return false;
+    if (value < low || value > high)
+    {
+      DEBUG_PRINT("Propeller test on M%d [FAIL]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
+                  motor + 1, (double)low, (double)high, (double)value);
+      return false;
+    }
+    else if (value > low && value < high)
+    {
+      DEBUG_PRINT("Propeller test on M%d [PASS]. low: %0.2f, high: %0.2f, measured: %0.2f\n",
+        motor + 1, (double)low, (double)high, (double)value);
+      return true;
+    }
   }
-
+  else
+  {
+    DEBUG_PRINT("Propeller test on M%d. No threshold set. measured: %0.2f\n",
+      motor + 1, (double)value);
+  }
   motorPass |= (1 << motor);
 
   return true;
@@ -289,7 +304,7 @@ void healthRunTests(sensorData_t *sensors)
   {
     for (int m = 0; m < NBR_OF_MOTORS; m++)
     {
-      if (!evaluatePropTest(0, PROPELLER_BALANCE_TEST_THRESHOLD,  accVarX[m] + accVarY[m], m))
+      if (!evaluatePropTest(0, propTestThreshold,  accVarX[m] + accVarY[m], m))
       {
         nrFailedTests++;
         for (int j = 0; j < 3; j++)
@@ -333,6 +348,11 @@ PARAM_ADD_CORE(PARAM_UINT8, startPropTest, &startPropTest)
  * @brief Set nonzero to initiate test of battery
  */
 PARAM_ADD_CORE(PARAM_UINT8, startBatTest, &startBatTest)
+
+/**
+ * @brief Set nonzero to create a threshold ([0 - propTestThreshold]) for the propeller test.
+ */
+PARAM_ADD_CORE(PARAM_FLOAT | PARAM_PERSISTENT, propTestThreshold, &propTestThreshold)
 
 /**
  * @brief PWM ratio to use when testing propellers. Required for brushless motors. [0 - UINT16_MAX]

--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -48,12 +48,14 @@
 
 #include "static_mem.h"
 
+#include "platform_defaults.h"
+
 #define PROPTEST_NBR_OF_VARIANCE_VALUES   100
 
 static bool startPropTest = false;
 static bool startBatTest = false;
 
-static float propTestThreshold = PROPELLER_BALANCE_TEST_THRESHOLD;
+static float propTestThreshold = HEALTH_PROPELLER_TEST_THRESHOLD;
 
 static uint16_t propTestPWMRatio = CONFIG_MOTORS_DEFAULT_PROP_TEST_PWM_RATIO;
 static uint16_t batTestPWMRatio = CONFIG_MOTORS_DEFAULT_BAT_TEST_PWM_RATIO;

--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -186,3 +186,8 @@
 #endif
 
 
+// This is the threshold for a propeller/motor to pass. It calculates the
+// variance of the accelerometer X+Y when the propeller is spinning.
+#ifndef HEALTH_PROPELLER_TEST_THRESHOLD
+    #define HEALTH_PROPELLER_TEST_THRESHOLD  0.0f
+#endif


### PR DESCRIPTION
This is based on [this](https://github.com/bitcraze/crazyflie-clients-python/issues/744) client issue.

I added a float persisted parameter called "`propTestThreshold`" that is 0 by default.
When running the propeller test in cfclient, there are 2 options:
1. If `propTestThreshold == 0`, the console prints the acceleration variance of each motor.
2. If `propTestThreshold != 0`, the console also prints `[PASS]` if the measured value is within threshold, and `[FAIL]` if the measured value is outside the threshold.