### PR TITLE
Fixed enabling-the-BigQuad issues

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -85,6 +85,13 @@ config DECK_BIGQUAD_ENABLE_PM
     bool "Enable Bigquad deck PM"
     default n
 
+config DECK_BIGQUAD_ENABLE_CPPM
+    depends on DECK_BIGQUAD
+    bool "Enable Bigquad deck CPPM"
+    default n
+    help
+      This enables external CPPM input.
+
 config DECK_BUZZ
     bool "Support the Buzzer deck"
     default y

--- a/src/deck/drivers/src/bigquad.c
+++ b/src/deck/drivers/src/bigquad.c
@@ -82,7 +82,9 @@ static void bigquadInit(DeckInfo *info)
 
   DEBUG_PRINT("Switching to brushless.\n");
   motorsInit(motorMapBigQuadDeck);
-  extRxInit();
+  #ifdef CONFIG_DECK_BIGQUAD_ENABLE_CPPM
+    extRxInit();
+  #endif
 
   // Ignore charging/charged state to allow low-battery warning.
   pmIgnoreChargedState(true);

--- a/src/platform/interface/platform_defaults_cf2.h
+++ b/src/platform/interface/platform_defaults_cf2.h
@@ -129,3 +129,7 @@
 #define PID_POS_VEL_X_MAX 1.0f
 #define PID_POS_VEL_Y_MAX 1.0f
 #define PID_POS_VEL_Z_MAX 1.0f
+
+#if defined(CONFIG_DECK_BIGQUAD) && defined(MOTORS_REQUIRE_ARMING)
+    #define CONFIG_MOTORS_DEFAULT_IDLE_THRUST 7000
+#endif


### PR DESCRIPTION
It was observed in [this discussion](https://github.com/orgs/bitcraze/discussions/1829) and in [this forum](https://forum.bitcraze.io/viewtopic.php?t=3931) that the external CPPM was taking priority over the other inputs, meaning that if CPPM wasn't used, the BigQuad would not take off.
This PR fixes this issue, adding a CPPM option in Kconfig.

Also, the idleThrust is now set to 7000 when the BigQuad is attached, as it might be dangerous not to have an indication when the platform is armed or not. The user should now be encouraged to use arming.

This fixes #1467.