### PR TITLE
Fix pitch rotation sign in accelerometer alignment

### DIFF
--- a/src/hal/src/sensors_bmi088_bmp3xx.c
+++ b/src/hal/src/sensors_bmi088_bmp3xx.c
@@ -936,7 +936,7 @@ static void sensorsAccAlignToGravity(Axis3f* in, Axis3f* out)
   // Rotate around y-axis
   ry.x = rx.x * cosPitch - rx.z * sinPitch;
   ry.y = rx.y;
-  ry.z = -rx.x * sinPitch + rx.z * cosPitch;
+  ry.z = rx.x * sinPitch + rx.z * cosPitch;
 
   out->x = ry.x;
   out->y = ry.y;

--- a/src/hal/src/sensors_bosch.c
+++ b/src/hal/src/sensors_bosch.c
@@ -938,7 +938,7 @@ static void sensorsAccAlignToGravity(Axis3f* in, Axis3f* out)
   // Rotate around y-axis
   ry.x = rx.x * cosPitch - rx.z * sinPitch;
   ry.y = rx.y;
-  ry.z = -rx.x * sinPitch + rx.z * cosPitch;
+  ry.z = rx.x * sinPitch + rx.z * cosPitch;
 
   out->x = ry.x;
   out->y = ry.y;

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -914,7 +914,7 @@ static void sensorsAccAlignToGravity(Axis3f* in, Axis3f* out)
   // Rotate around y-axis
   ry.x = rx.x * cosPitch - rx.z * sinPitch;
   ry.y = rx.y;
-  ry.z = -rx.x * sinPitch + rx.z * cosPitch;
+  ry.z = rx.x * sinPitch + rx.z * cosPitch;
 
   out->x = ry.x;
   out->y = ry.y;


### PR DESCRIPTION
Corrects sign in y-axis rotation matrix within the function that compensates for a misaligned accelerometer. The rotation now correctly applies a left-handed pitch adjustment using trim data from the config block, ensuring alignment with gravity.