### PR TITLE
Unblocking Doxygen build and enabling config generation in doc CI

### DIFF
--- a/tools/build-docs/build-docs
+++ b/tools/build-docs/build-docs
@@ -6,6 +6,12 @@ doxDir=$scriptDir/../../generated/dox
 xmlDir=$doxDir/xml
 apiDocsDir=$scriptDir/../../docs/api
 
+# submodules required for rendering documentation
+git submodule update --init --recursive
+
+# config required to generate documentation
+make cf2_defconfig
+
 # Generate xml from the source code
 mkdir -p $doxDir
 [ -d "$xmlDir" ] && rm -r $xmlDir

--- a/tools/gen-dox/Doxyfile
+++ b/tools/gen-dox/Doxyfile
@@ -768,7 +768,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = NO
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -2077,8 +2077,7 @@ INCLUDE_PATH = vendor/CMSIS/CMSIS/Core/Include \
                src/lib/STM32_USB_OTG_Driver/inc \
                src/lib/STM32F4xx_StdPeriph_Driver/inc \
                src/lib/vl53l1 \
-               src/lib/vl53l1/core/inc \
-               build/include/generated
+               src/lib/vl53l1/core/inc
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the


### PR DESCRIPTION
This PR makes a few adjustments to support the changes introduced in [crazyflie-firmware#1464](https://github.com/bitcraze/crazyflie-firmware/pull/1464), which now requires the firmware to be built (`make`) in order to access the kbuild-generated configuration (`autoconf.h`). Since Doxygen does not integrate well with kbuild or highly configurable builds, this approach may be the most viable path forward.

However, our current documentation builder Docker image does not include `arm-none-eabi-gcc`, which is required for the firmware build. To avoid blocking documentation builds entirely, this PR temporarily disables the "warnings as errors" setting in Doxygen. This gives us time to implement a more complete solution while keeping the web build functional.

Additionally, this PR addresses a smaller but related issue: accessing `autoconf.h` requires certain headers and libraries, some of which are managed as git submodules. These were not previously initialized in the CI environment. This PR adds submodule initialization and update steps to fix that.

Finally, it also ensures that the configuration is generated during the CI process, also required by [#1464](https://github.com/bitcraze/crazyflie-firmware/pull/1464), which I had initially overlooked for CI workflows.