### PR TITLE
add supervisor infoBitFields for high level controller

### DIFF
--- a/src/modules/interface/crtp_commander_high_level.h
+++ b/src/modules/interface/crtp_commander_high_level.h
@@ -294,4 +294,13 @@ bool crtpCommanderHighLevelReadTrajectory(const uint32_t offset, const uint32_t 
  */
 bool crtpCommanderHighLevelIsTrajectoryFinished();
 
+
+/**
+ * @brief Query the current state of the planner in high level control
+ *
+ * @return trajectory state enum defined in planner.h
+ */
+
+enum trajectory_state crtpCommanderHighLevelGetPlannerState();
+
 #endif /* CRTP_COMMANDER_HIGH_LEVEL_H_ */

--- a/src/modules/src/crtp_commander_high_level.c
+++ b/src/modules/src/crtp_commander_high_level.c
@@ -1007,6 +1007,11 @@ bool crtpCommanderHighLevelReadTrajectory(const uint32_t offset, const uint32_t 
   return result;
 }
 
+
+enum trajectory_state crtpCommanderHighLevelGetPlannerState() {
+  return planner.state;
+}
+
 bool crtpCommanderHighLevelIsTrajectoryFinished() {
   float t = usecTimestamp() / 1e6;
   return plan_is_finished(&planner, t);

--- a/src/modules/src/planner.c
+++ b/src/modules/src/planner.c
@@ -78,6 +78,9 @@ void plan_stop(struct planner *p)
 
 bool plan_is_finished(struct planner *p, float t)
 {
+	if (p->trajectory == NULL) {
+		return 1;
+	}
 	switch (p->type) {
 		case TRAJECTORY_TYPE_PIECEWISE:
 			return piecewise_is_finished(p->trajectory, t);

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -542,6 +542,10 @@ LOG_GROUP_START(supervisor)
  * Bit 4 = is flying - the Crazyflie is flying.
  * Bit 5 = is tumbled - the Crazyflie is up side down.
  * Bit 6 = is locked - the Crazyflie is in the locked state and must be restarted.
+ * Bit 7 = is crashed - the Crazyflie has crashed.
+ * Bit 8 = high level control is actively flying the drone
+ * Bit 9 = high level trajectory has finished
+ * Bit 10 = high level control is disabled and not producing setpoints
  */
 LOG_ADD(LOG_UINT16, info, &supervisorMem.infoBitfield)
 LOG_GROUP_STOP(supervisor)


### PR DESCRIPTION
Putting this up for discussion as it relates to https://github.com/IMRCLab/crazyswarm2/discussions/704 

We have tested locally, and are now using 

```
# High Level Commander States
uint16 SUPERVISOR_INFO_HLC_FLYING   = 256
uint16 SUPERVISOR_INFO_HLC_FINISHED = 512
uint16 SUPERVISOR_INFO_HLC_DISABLED = 1024
```
in our `Status.msg`.

The change to planner.c is required otherwise the is_finished checks crash on null trajectory.