### PR TITLE
Fix DEBUG_DECK_IGNORE_OWS spelling

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -48,7 +48,7 @@ config DEBUG_PRINT_ON_UART1_BAUDRATE
       Set the baudrate of the debug output   
 
 
-config DEBUG_DECK_IGNORE_OW
+config DEBUG_DECK_IGNORE_OWS
     bool "Do not enumerate OW based expansion decks"
     default n
     help


### PR DESCRIPTION
This changes the Kconfig spelling of DEBUG_DECK_IGNORE_OWS to match the actual define used in the code