### PR TITLE
Flapper Roll bias fix

### DIFF
--- a/src/modules/src/power_distribution_flapper.c
+++ b/src/modules/src/power_distribution_flapper.c
@@ -87,7 +87,7 @@ static uint8_t limitServoNeutral(uint8_t value)
   return (uint8_t)value;
 }
 
-static int8_t limitRollBias(uint8_t value)
+static int8_t limitRollBias(int8_t value)
 {
   if(value > 25)
   {


### PR DESCRIPTION
roll bias is a signed integer, since it can range from -25 to 25. Input to limitRollBias was an unsigned integer, so any negative values stored/chosen would result in the maximum (25). Changed to int8_t and then it works as it should.