### PR TITLE
Update brushless thrust coefficients

### DIFF
--- a/src/platform/interface/platform_defaults_cf21bl.h
+++ b/src/platform/interface/platform_defaults_cf21bl.h
@@ -48,9 +48,9 @@
 // Update this value with the mass of your specific setup if different.
 #define CF_MASS 0.0393f  // kg
 // Thrust coefficients
-#define THRUST_MIN      0.02f // TODO, value is for the legacy propellers
-#define THRUST_MAX      0.1125f // TODO, value is for the legacy propellers
-#define THRUST2TORQUE   0.005964552f // TODO, value is for the legacy propellers
+#define THRUST_MIN      0.03f // TODO, value is for the thrust upgrade kit
+#define THRUST_MAX      0.1625f // TODO, value is for the thrust upgrade kit
+#define THRUST2TORQUE   0.004899994f
 
 // Default PID gains
 #define PID_ROLL_RATE_KP 200.0


### PR DESCRIPTION
When flying the Crazyflie 2.1 brushless with the Lee controller (which uses `controlModeForceTorque`) I noticed oscillations during flight. This is because it relies on the `THRUST_MAX` platform default which for now is set to the legacy value. I changed `THRUST_MIN` and `THRUST_MAX` to the ones set for the thrust upgrade kit and performance was much improved. These should suffice until a full system ID can be taken for the Crazyflie 2.1 brushless since the max thrust with prop guards is similar to the thrust upgrade.

I also measured the thrust to torque ratio with prop guards using an ATI force/torque sensor mounted on a 1 meter pole to reduce ground effect and added that value to `THRUST2TORQUE`.