### PR TITLE
Further generalize deck backend architecture

### DIFF
--- a/src/deck/interface/deck_core.h
+++ b/src/deck/interface/deck_core.h
@@ -152,6 +152,10 @@ typedef struct deckInfo_s {
 
   /* Track which discovery backend found this deck */
   const DeckDiscoveryBackend_t *discoveryBackend;
+
+  /* Generic deck information fields */
+  char * productName;
+  char * boardRevision;
 } DeckInfo;
 
 /**
@@ -229,15 +233,6 @@ typedef struct deckMemDef_s {
 int deckCount(void);
 
 DeckInfo * deckInfo(int i);
-
-/* Key/value area handling */
-bool deckTlvHasElement(TlvArea *tlv, int type);
-
-int deckTlvGetString(TlvArea *tlv, int type, char *string, int maxLength);
-
-char* deckTlvGetBuffer(TlvArea *tlv, int type, int *length);
-
-void deckTlvGetTlv(TlvArea *tlv, int type, TlvArea *output);
 
 /* Defined Types */
 #define DECK_INFO_NAME 1

--- a/src/deck/interface/deck_discovery.h
+++ b/src/deck/interface/deck_discovery.h
@@ -47,7 +47,6 @@ typedef struct deckDiscoveryBackend_s {
  * @brief Shared functions available to all backends
  */
 const DeckDriver* findDriver(DeckInfo *deck);    ///< Find driver for deck
-bool infoDecode(DeckInfo *info);                 ///< Decode and validate deck memory
 void printDeckInfo(DeckInfo *info);              ///< Print deck debug info
 
 /**


### PR DESCRIPTION
#1519 introduced a deck discovery backend architecture. Some of the shared functionality still relied on TLV. This PR further generalizes and cleans up the architecture.

  - Add generic productName and boardRevision fields to DeckInfo
  - Remove hardcoded TLV assumptions from core deck functions
  - Centralize driver finding in enumerateDecks()

This should enable non-TLV backends to work with the deck backend system.

TLV field remains in DeckInfo for now - further generalization needed to fully decouple from OneWire-specific structures.