### PR TITLE
Fix broken .conf overlay system

### DIFF
--- a/scripts/kconfig/merge_config.sh
+++ b/scripts/kconfig/merge_config.sh
@@ -86,7 +86,7 @@ if [ -z "$KCONFIG_CONFIG" ]; then
 	if [ "$OUTPUT" != . ]; then
 		KCONFIG_CONFIG=$(readlink -m -- "$OUTPUT/.config")
 	else
-		KCONFIG_CONFIG=.config
+		KCONFIG_CONFIG=build/.config
 	fi
 fi
 


### PR DESCRIPTION
Change merge_config.sh to look for .config in build/ directory where Crazyflie build system actually generates it