### PR TITLE
Updated building and flashing instrcutions

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -196,13 +196,13 @@ $ make cload
 
 It will try to find a Crazyflie in bootloader mode and flash the binary to it.
 
-Warning: if multiple Crazyflies within range are in bootloader mode the result is unpredictable. This method is not suitable in classroom situation where it is likely that several students are flashing at the same time. Also remember that the Crazyradio PA often reaches into the next room.
+Warning: if multiple Crazyflies within range are in bootloader mode the result is unpredictable. This method is not suitable in classroom situation where it is likely that several students are flashing at the same time. Also remember that the Crazyradio often reaches into the next room.
 
 #### Automatically enter bootloader mode
 * Make sure the Crazyflie is on
 * In your terminal, run `CLOAD_CMDS="-w [CRAZYFLIE_URI]" make cload`
-* or run `cfloader flash build/cf2.bin stm32-fw -w [CRAZYFLIE_URI]`
-with [CRAZYFLIE_URI] being the uri of the crazyflie.
+* or run `cfloader flash build/[BINARY_FILE] stm32-fw -w [CRAZYFLIE_URI]`
+with [BINARY_FILE] being the binary file (**cf2.bin** for Crazyflie 2.x, **cf21bl.bin** for Crazyflie 2.1 Brushless etc.) and [CRAZYFLIE_URI] being the uri of the Crazyflie.
 
 It will connect to the Crazyflie with the specified address, put it in bootloader mode and flash the binary. This method is suitable for classroom situations.
 

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -179,7 +179,7 @@ The supported way to flash when developping for the Crazyflie is to use the Craz
 
 #### Prerequisites
 * A Crazyradio with drivers installed
-* [Crazyflie Client](https://github.com/bitcraze/crazyflie-clients-python) installed in a Python virtual environment, either via pip (not using Snap on Ubuntu or .exe on Windows) or by cloning from source.
+* [Crazyflie Client](https://github.com/bitcraze/crazyflie-clients-python) installed in a Python virtual environment, either via pip or by cloning from source.
   * Note than when developping in WSL on Windows, the client needs to be installed on Windows. See the [Windows build instruction](#windows) above.
 * The firmware has been built
 * The current working directory is the root of the crazyflie-firmware project

--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -179,7 +179,7 @@ The supported way to flash when developping for the Crazyflie is to use the Craz
 
 #### Prerequisites
 * A Crazyradio with drivers installed
-* [Crazyflie Client installed](https://github.com/bitcraze/crazyflie-clients-python) with Python's pip (so not by Snap (Ubuntu) or the .exe (Windows))
+* [Crazyflie Client](https://github.com/bitcraze/crazyflie-clients-python) installed in a Python virtual environment, either via pip (not using Snap on Ubuntu or .exe on Windows) or by cloning from source.
   * Note than when developping in WSL on Windows, the client needs to be installed on Windows. See the [Windows build instruction](#windows) above.
 * The firmware has been built
 * The current working directory is the root of the crazyflie-firmware project


### PR DESCRIPTION
This PR clarifies that you need a python venv to be able to flash the Crazyflie. 
Also, it updates the flashing instructions to avoid flashing the wrong binary file to a platform.