### PR TITLE
Fixed quaternion estimate in kalmanCoreUpdateWithPose

### DIFF
--- a/src/modules/src/kalman_core/mm_pose.c
+++ b/src/modules/src/kalman_core/mm_pose.c
@@ -40,7 +40,7 @@ void kalmanCoreUpdateWithPose(kalmanCoreData_t* this, poseMeasurement_t *pose)
   // compute orientation error
   struct quat const q_ekf = mkquat(this->q[1], this->q[2], this->q[3], this->q[0]);
   struct quat const q_measured = mkquat(pose->quat.x, pose->quat.y, pose->quat.z, pose->quat.w);
-  struct quat const q_residual = qqmul(qinv(q_ekf), q_measured);
+  struct quat const q_residual = qqmul(q_measured, qinv(q_ekf));
   // small angle approximation, see eq. 141 in http://mars.cs.umn.edu/tr/reports/Trawny05b.pdf
   struct vec const err_quat = vscl(2.0f / q_residual.w, quatimagpart(q_residual));
 


### PR DESCRIPTION
This PR fixes #1292.

When sending full pose measurements to the Crazyflie (position and quaternion in the world frame) a known issue described in #1292 occurs when the yaw is larger than about 90 degrees. Users have observed the filtered quaternion data goes unstable and the quadrotor also becomes unstable and crashes. This occurs due to an error in `mm_pose.c` which updates the kalman filter with position and attitude error.

The terms fed into the kalman filter via `kalmanCoreScalarUpdate` should represent "the measured value minus the ekf value". Thus, `q_residual` should represent a rotation from vectors in the ekf frame to the measured frame. So we need to undo the ekf rotation and then apply the measured rotation. By [definition](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation) of quaternion multiplication, this is done by $q_{res}=q_{meas}q_{ekf}^{-1}$. Currently, the code does the multiplication in the reverse order which is wrong since quaternion multiplication is not commutative.

After testing with this new calculation, the issue seems to be fully resolved. To recreate the issue and fix, use a positioning method that calls `kalmanCoreUpdateWithPose` (the only one I know of is mocap) and send a setpoint that causes the yaw to exceed 90 degrees.