### PR TITLE
Fix USD deck graceful shutdown file corruption

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -458,7 +458,7 @@ static void usdInit(DeckInfo *info)
 
     logFileMutex = xSemaphoreCreateMutex();
     logBufferMutex = xSemaphoreCreateMutex();
-    shutdownMutex = xSemaphoreCreateMutex();
+    shutdownMutex = xSemaphoreCreateBinary();
 
     /* try to mount drives before creating the tasks */
     if (f_mount(&FatFs, "", 1) == FR_OK) {
@@ -543,8 +543,9 @@ static void usddeckEventtriggerCallback(const eventtrigger *event)
 
 static void usdGracefulShutdownCallback()
 {
-  uint32_t timeout = 15; /* ms */
+  uint32_t timeout = 100; /* ms */
   in_shutdown = true;
+  enableLogging = false;
   vTaskResume(xHandleWriteTask);
   xSemaphoreTake(shutdownMutex, M2T(timeout));
 }


### PR DESCRIPTION
The shutdown callback was using a mutex (starts available) instead of a binary semaphore (starts empty), causing it to return immediately without waiting for the write task to finish flushing data and closing the file. This resulted in file corruption when powering off during active logging. 

Changes: 
- Use binary semaphore for shutdown synchronization
- Set enableLogging=false to exit logging loop on shutdown 
- Increase timeout from 15ms to 100ms for safety

Thanks to @krombel for reporting and investigating this issue in #1532