### PR TITLE
Updated deckctl_protocol doc to fit the website format

### DIFF
--- a/docs/functional-areas/deckctrl_protocol.md
+++ b/docs/functional-areas/deckctrl_protocol.md
@@ -3,7 +3,7 @@ title: DeckCtrl protocol specification
 page_id: deckctrl_protocol
 ---
 
-# DeckCtrl protocol specification
+## DeckCtrl protocol specification
 
 The DeckCtrl backend implements an I2C-based deck and control discovery mechanism that uses microcontrollers on deck boards (_deck controllers_) to enable dynamic enumeration of multiple decks.
 The microcontroller implementing the DeckCtrl protocol is exclusively used for that purpose, deck functionalities are implemented on


### PR DESCRIPTION
Apparently single '#' in firmware docs break the auto-generated documentation in the website.