### PR TITLE
Enable deck firmware flashing when deck tests fail

### DIFF
--- a/src/modules/src/crtp_mem.c
+++ b/src/modules/src/crtp_mem.c
@@ -107,11 +107,9 @@ bool crtpMemTest(void) {
 static void memTask(void* param) {
 	crtpInitTaskQueue(CRTP_PORT_MEM);
 
-  // This should be synced with decks starting up, otherwise
-  // there might be late arrivals for the registration that will
-  // trigger assert.
-
-  systemWaitStart();
+  // All memory handlers are registered during deckInit() before this task is created.
+  // Not waiting for systemStart() allows memory operations (e.g., firmware flashing)
+  // to work even when system tests fail.
 
   // Do not allow registration of new handlers after this point as clients now can start
   // to query for available memories


### PR DESCRIPTION
Remove systemWaitStart() call from crtp_mem task to allow memory operations to function even when deck tests fail. This enables recovery from bad deck firmware via flashing.

The systemWaitStart() call was added to ensure synchronization "with decks starting up" to prevent "late arrivals for the registration that will trigger assert." However, this synchronization is unnecessary because all memory handler registration happens synchronously during deckInit() before the crtp_mem task is created. Memory handlers are registered exclusively in deck init functions, never in deck tasks, so there is no possibility of late arrivals that could trigger the registration assert.

This change allows the memory subsystem to work independently of deck test results, while still correctly preventing dangerous systems (motors, stabilizer, sensors) from starting when tests fail.

Fixes issue where Color LED deck could not be reflashed after flashing incorrect firmware that fails deck test.