### PR TITLE
Move worker to its own task

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -101,7 +101,8 @@
 #define UART2_TASK_PRI            3
 #define CRTP_SRV_TASK_PRI         0
 #define PLATFORM_SRV_TASK_PRI     0
-#define COLORLED_TASK_PRIO       1
+#define COLORLED_TASK_PRIO        1
+#define WORKER_TASK_PRI           1
 
 // Not compiled
 #if 0
@@ -161,7 +162,8 @@
 #define CPX_TASK_NAME             "CPX"
 #define APP_TASK_NAME             "APP"
 #define FLAPPERDECK_TASK_NAME     "FLAPPERDECK"
-#define COLORLED_TASK_NAME       "COLORLED-DECK"
+#define COLORLED_TASK_NAME        "COLORLED-DECK"
+#define WORKER_TASK_NAME          "WORKER"
 
 
 //Task stack sizes
@@ -209,7 +211,8 @@
 #define KALMAN_TASK_STACKSIZE           (3 * configMINIMAL_STACK_SIZE)
 #define FLAPPERDECK_TASK_STACKSIZE      (2 * configMINIMAL_STACK_SIZE)
 #define ERROR_UKF_TASK_STACKSIZE        (4 * configMINIMAL_STACK_SIZE)
-#define COLORLED_TASK_STACKSIZE        configMINIMAL_STACK_SIZE
+#define COLORLED_TASK_STACKSIZE         configMINIMAL_STACK_SIZE
+#define WORKER_TASK_STACKSIZE           configMINIMAL_STACK_SIZE
 
 //The radio channel. From 0 to 125
 #define RADIO_CHANNEL 80

--- a/src/modules/src/system.c
+++ b/src/modules/src/system.c
@@ -325,9 +325,6 @@ void systemTask(void *arg)
   }
   DEBUG_PRINT("Free heap: %d bytes\n", xPortGetFreeHeapSize());
 
-  workerLoop();
-
-  //Should never reach this point!
   while(1)
     vTaskDelay(portMAX_DELAY);
 }

--- a/src/modules/src/worker.c
+++ b/src/modules/src/worker.c
@@ -45,6 +45,9 @@ struct worker_work {
 static xQueueHandle workerQueue;
 STATIC_MEM_QUEUE_ALLOC(workerQueue, WORKER_QUEUE_LENGTH, sizeof(struct worker_work));
 
+void workerTask(void *arg);
+STATIC_MEM_TASK_ALLOC(workerTask, WORKER_TASK_STACKSIZE);
+
 void workerInit()
 {
   if (workerQueue)
@@ -52,6 +55,9 @@ void workerInit()
 
   workerQueue = STATIC_MEM_QUEUE_CREATE(workerQueue);
   DEBUG_QUEUE_MONITOR_REGISTER(workerQueue);
+
+  STATIC_MEM_TASK_CREATE(workerTask, workerTask, WORKER_TASK_NAME, NULL, WORKER_TASK_PRI);
+
 }
 
 bool workerTest()
@@ -59,7 +65,7 @@ bool workerTest()
   return (workerQueue != NULL);
 }
 
-void workerLoop()
+void workerTask(void *arg)
 {
   struct worker_work work;
 


### PR DESCRIPTION
This change moves the worker loop to its own task. This enables workers to function even if the system self-tests pass.

The reason for this change is to enable using the worker for restarting the platform via the DeckCtrlDFU memory even when the self-tests fail. In this memory the worker is used to delay the restart to finish the memory write transaction correctly.