### PR TITLE
Accept DeckCtrl decks under production

### DIFF
--- a/src/deck/backends/Kconfig
+++ b/src/deck/backends/Kconfig
@@ -29,6 +29,13 @@ config DECK_BACKEND_DECKCTRL_DEBUG
       This will output additional information about deck detection,
       initialization, and communication for debugging purposes.
 
+config ACCEPT_DECKCTRL_DECKS_UNDER_PRODUCTION
+    bool "Accept DeckCtrl decks under production"
+    default n
+    help
+      Accept decks wich still has no production test passed date set. Only
+      for use in production.
+
 config DECK_BACKEND_DECKCTRL_MAX_DECKS
     depends on DECK_BACKEND_DECKCTRL
     int "Maximum number of DeckCtrl decks supported"

--- a/src/deck/backends/deck_backend_deckctrl.c
+++ b/src/deck/backends/deck_backend_deckctrl.c
@@ -265,9 +265,8 @@ static DeckInfo* deckctrl_getNextDeck(void)
     {
         DEBUG_PRINT("Invalid production date read from deck controller: %02d-%02d-%02d\n",
             info->production_year, info->production_month, info->production_day);
-#ifndef CONFIG_DEBUG
-        // When debug is enabled allow a deck without a valid production date to be used.
-        // This is the case in production until the decks pass testing and the date is set
+#ifndef CONFIG_ACCEPT_DECKCTRL_DECKS_UNDER_PRODUCTION
+        // Allow a deck without a valid production date to be used.
         return NULL;
 #endif
     } else {


### PR DESCRIPTION
Instead of using the DEBUG define a separate define has been added to accept decks which are under production (i.e has no production date set yet).