### PR TITLE
Enable OOT estimator in menuconfig

### DIFF
--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -82,6 +82,7 @@ config ESTIMATOR_OUTLIER_FILTERS
 choice
     prompt "Default estimator"
     default CONFIG_ESTIMATOR_AUTO_SELECT
+    depends on !ESTIMATOR_OOT
 
 config ESTIMATOR_AUTO_SELECT
     bool "Auto select Estimator"

--- a/src/modules/src/estimator/estimator.c
+++ b/src/modules/src/estimator/estimator.c
@@ -122,6 +122,8 @@ void stateEstimatorSwitchTo(StateEstimatorType estimator) {
     #define ESTIMATOR StateEstimatorTypeUkf
   #elif defined(CONFIG_ESTIMATOR_COMPLEMENTARY)
     #define ESTIMATOR StateEstimatorTypeComplementary
+  #elif defined(CONFIG_ESTIMATOR_OOT)
+    #define ESTIMATOR StateEstimatorTypeOutOfTree
   #else
     #define ESTIMATOR StateEstimatorTypeAutoSelect
   #endif


### PR DESCRIPTION
This PR makes the OOT estimator configurable in Kconfig, following the same structure as the OOT controller.
Based on #1476.