### PR TITLE
controller_brescianini: use omega_yaw_max in yaw heuristic

### DIFF
--- a/src/modules/src/controller/controller_brescianini.c
+++ b/src/modules/src/controller/controller_brescianini.c
@@ -366,7 +366,7 @@ void controllerBrescianini(control_t *control,
     }
 
     if (control_omega[2] * omega[2] < 0 && fabsf(omega[2]) > heuristic_yaw) { // desired rotational rate in direction opposite to current rotational rate
-      control_omega[2] = omega_rp_max * (omega[2] < 0 ? -1 : 1); // maximum rotational rate in direction of current rotation
+      control_omega[2] = omega_yaw_max * (omega[2] < 0 ? -1 : 1); // maximum rotational rate in direction of current rotation
     }
 
     // scale the commands to satisfy rate constraints


### PR DESCRIPTION
Problem: Yaw heuristic clamps commanded yaw rate using omega_rp_max (roll/pitch limit), which can exceed intended yaw constraints and mixes axis-specific limits.

Fix: Clamp yaw heuristic using omega_yaw_max.

Impact: Ensures yaw axis respects yaw rate limits consistently, improving predictability during aggressive yaw reversals.

Test: Build succeeds