### PR TITLE
Active Marker Deck firmware version

### DIFF
--- a/src/deck/drivers/src/activeMarkerDeck.c
+++ b/src/deck/drivers/src/activeMarkerDeck.c
@@ -117,17 +117,22 @@ static bool activeMarkerDeckTest() {
     return false;
   }
 
-#ifndef ACTIVE_MARKER_DECK_TEST
-  if (0 == strcmp("Qualisys0.A", versionString)) {
-    deckFwVersion = version_0_A;
-  } else if (0 == strcmp("Qualisys1.0", versionString)) {
-    deckFwVersion = version_1_0;
+  if (strlen(versionString) == 0) {
+    DEBUG_PRINT("Deck FW version string not available, assuming compatible\n");
+  } else {
+    DEBUG_PRINT("Deck FW %s\n", versionString);
   }
 
-  isVerified = (versionUndefined != deckFwVersion);
-  if (! isVerified) {
-    DEBUG_PRINT("Incompatible deck FW\n");
+#ifndef ACTIVE_MARKER_DECK_TEST
+  if (!i2cOk) {
+    DEBUG_PRINT("Deck I2C communication failed\n");
+    isVerified = false;
+    return false;
   }
+
+  deckFwVersion = version_1_0;
+  isVerified = true;
+
 #else
   isVerified = true;
   deckFwVersion = version_1_0;


### PR DESCRIPTION
As pointed out [here](https://github.com/bitcraze/crazyflie-release/issues/19) the **Active Marker Deck** test fails when using the latest release of the crazyflie-firmware.

In the deck driver, it is assumed that the deck exposes a static ASCII version string but this is probably not true in the current deck firmware.

In this PR the strict string matching is removed and instead the I2C connection is checked.