### PR TITLE
Use GNU commands for out-of-tree builds on MacOS

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -28,7 +28,7 @@ $ sudo apt-get install make gcc-arm-none-eabi
 The required toolchain on macOS can be installed using [homebrew](https://brew.sh/)
 
 ```
-$ brew install gcc-arm-embedded
+$ brew install gcc-arm-embedded coreutils gnu-sed
 ```
 
 ##### Windows

--- a/docs/development/oot.md
+++ b/docs/development/oot.md
@@ -52,6 +52,17 @@ EXTRA_CFLAGS += -I$(PWD)/src/inc
 
 OOT builds can be configured with [Kbuild](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/development/kbuild/) using terminal interfaces like `make menuconfig` or by loading a default configuration, such as with `make cf2_defconfig`. Any definitions in $(OOT_CONFIG) will override conflicting settings.
 
+> **Note:** If you are using **macOS** you may encounter errors when trying to build your app, such as: 
+> ```
+> readlink: illegal option -- m
+> sed: invalid command code .
+> cp: illegal option -- T
+> ```
+> This happens because the app-layer build expects the GNU versions of `readlink`, `sed` and `cp`. To fix the errors, install and use the GNU utilities:
+> ```
+> brew install coreutils gnu-sed
+> ```
+
 ## OOT estimators
 The `config` file needs to enable ESTIMATOR_OOT, and can also set other config options:
 

--- a/docs/userguides/app_layer.md
+++ b/docs/userguides/app_layer.md
@@ -93,16 +93,6 @@ Then flash the resulting bin on your crazyflie according to [the flashing instru
 > ```
 > brew install coreutils gnu-sed
 > ```
-> Then replace `readlink`, `sed` and `cp` with `greadlink`, `gsed` and `gcp`, either with temporary aliases:
-> ```
-> alias readlink=greadlink
-> alias sed=gsed
-> alias cp=gcp
-> ```
-> Or by permanently adding them to your path:
-> ```
-> export PATH="/usr/local/opt/coreutils/libexec/gnubin:/usr/local/opt/gnu-sed/libexec gnubin:$PATH"
-> ```
 
 
 ## Internal log and param system

--- a/scripts/kconfig/merge_config.sh
+++ b/scripts/kconfig/merge_config.sh
@@ -82,6 +82,12 @@ if [ "$#" -lt 1 ] ; then
 	exit
 fi
 
+# use GNU commands rather than BSD commands on macOS, requires coreutils and gnu-sed to be installed
+if [ "$(uname -s)" = "Darwin" ]; then
+	HOMEBREW_PREFIX="$(brew --prefix)"
+	export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$PATH"
+fi
+
 if [ -z "$KCONFIG_CONFIG" ]; then
 	if [ "$OUTPUT" != . ]; then
 		KCONFIG_CONFIG=$(readlink -m -- "$OUTPUT/.config")


### PR DESCRIPTION
When building OOT controllers on macOS, the system's PATH defaults to using the BSD versions of `sed`, `readlink`, etc. even though the `merge_config.sh` script requires the GNU version of the commands.

This PR adjusts the script to use the GNU versions of the commands which have been installed using Homebrew, and also updates the documentation to suggest that users on macOS install these alongside the ARM toolkit. 

fix #1590