### PR TITLE
Mellinger controller angle limitation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ build/
 *.elf
 
 tools/dependency/web/data.js
+
+# Clangd
+compile_commands.json
+.cache/**

--- a/src/modules/src/controller/controller_mellinger.c
+++ b/src/modules/src/controller/controller_mellinger.c
@@ -122,7 +122,7 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
   struct vec v_error;
   struct vec target_thrust;
   struct vec z_axis;
-  float current_thrust;
+  float current_thrust = 0;
   struct vec x_axis_desired;
   struct vec y_axis_desired;
   struct vec x_c_des;
@@ -173,9 +173,8 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
   struct quat q = mkquat(state->attitudeQuaternion.x, state->attitudeQuaternion.y, state->attitudeQuaternion.z, state->attitudeQuaternion.w);
   struct mat33 R = quat2rotmat(q);
   z_axis = mcolumn(R, 2);
-
-  current_thrust = 0.0f;
   
+  // Calculate desired axes and current thrust
   if (setpoint->mode.x == modeAbs) {
     // Desired thrust [F_des]
     target_thrust.x = self->mass * setpoint->acceleration.x                       + self->kp_xy * r_error.x + self->kd_xy * v_error.x + self->ki_xy * self->i_error_x;
@@ -197,8 +196,11 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
     y_axis_desired = vnormalize(vcross(self->z_axis_desired, x_c_des));
     // [xB_des]
     x_axis_desired = vcross(y_axis_desired, self->z_axis_desired);
-  } else {
+  } else if (setpoint->mode.pitch == modeAbs &&
+             setpoint->mode.roll  == modeAbs &&
+             setpoint->mode.z == modeDisable) { // Manual mode, no assist
     // Directly compute desired rotation for attitude-only control
+    // No need to calculate current_thrust as it is not used in this mode
     float cmd_roll  = radians(setpoint->attitude.roll);
     float cmd_pitch = -radians(setpoint->attitude.pitch);
     float cmd_yaw   = radians(desiredYaw);
@@ -208,6 +210,27 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
     x_axis_desired = mcolumn(R_cmd, 0);
     y_axis_desired = mcolumn(R_cmd, 1);
     self->z_axis_desired = mcolumn(R_cmd, 2);
+  } else { // Unknown combination of modes
+    // Hover using the previous z setting
+    // Safe behaviour for unknown combination of modes
+    target_thrust.x = 0;
+    target_thrust.y = 0;
+    target_thrust.z = self->mass * GRAVITY_MAGNITUDE + self->kp_z  * r_error.z + self->kd_z  * v_error.z + self->ki_z  * self->i_error_z;
+
+    // Calculate axis [zB_des]
+    self->z_axis_desired = vnormalize(target_thrust);
+    
+    // [xC_des]
+    // x_axis_desired = z_axis_desired x [sin(yaw), cos(yaw), 0]^T
+    x_c_des.x = cosf(radians(state->attitude.yaw));
+    x_c_des.y = sinf(radians(state->attitude.yaw));
+    x_c_des.z = 0;
+    // [yB_des]
+    y_axis_desired = vnormalize(vcross(self->z_axis_desired, x_c_des));
+    // [xB_des]
+    x_axis_desired = vcross(y_axis_desired, self->z_axis_desired);
+
+    current_thrust = vdot(target_thrust, z_axis);
   }
 
 

--- a/src/modules/src/controller/controller_mellinger.c
+++ b/src/modules/src/controller/controller_mellinger.c
@@ -173,7 +173,7 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
   struct quat q = mkquat(state->attitudeQuaternion.x, state->attitudeQuaternion.y, state->attitudeQuaternion.z, state->attitudeQuaternion.w);
   struct mat33 R = quat2rotmat(q);
   z_axis = mcolumn(R, 2);
-  
+
   // Calculate desired axes and current thrust
   if (setpoint->mode.x == modeAbs) {
     // Desired thrust [F_des]
@@ -220,7 +220,7 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
 
     // Calculate axis [zB_des]
     self->z_axis_desired = vnormalize(target_thrust);
-    
+
     // [xC_des]
     // x_axis_desired = z_axis_desired x [sin(yaw), cos(yaw), 0]^T
     x_c_des.x = cosf(radians(state->attitude.yaw));

--- a/src/modules/src/controller/controller_mellinger.c
+++ b/src/modules/src/controller/controller_mellinger.c
@@ -198,21 +198,22 @@ void controllerMellinger(controllerMellinger_t* self, control_t *control, const 
     x_axis_desired = vcross(y_axis_desired, self->z_axis_desired);
   } else if (setpoint->mode.pitch == modeAbs &&
              setpoint->mode.roll  == modeAbs &&
-             setpoint->mode.z == modeDisable) { // Manual mode, no assist
+             setpoint->mode.z     == modeDisable) { // Manual mode, no assist
     // Directly compute desired rotation for attitude-only control
     // No need to calculate current_thrust as it is not used in this mode
-    float cmd_roll  = radians(setpoint->attitude.roll);
+    float cmd_roll  =  radians(setpoint->attitude.roll);
     float cmd_pitch = -radians(setpoint->attitude.pitch);
-    float cmd_yaw   = radians(desiredYaw);
+    float cmd_yaw   =  radians(desiredYaw);
+
     struct vec cmd_rpy = mkvec(cmd_roll, cmd_pitch, cmd_yaw);
     struct quat q_cmd = rpy2quat(cmd_rpy);
     struct mat33 R_cmd = quat2rotmat(q_cmd);
-    x_axis_desired = mcolumn(R_cmd, 0);
-    y_axis_desired = mcolumn(R_cmd, 1);
+
+    x_axis_desired       = mcolumn(R_cmd, 0);
+    y_axis_desired       = mcolumn(R_cmd, 1);
     self->z_axis_desired = mcolumn(R_cmd, 2);
   } else { // Unknown combination of modes
-    // Hover using the previous z setting
-    // Safe behaviour for unknown combination of modes
+    // Hover using the received z setpoint (safe behaviour)
     target_thrust.x = 0;
     target_thrust.y = 0;
     target_thrust.z = self->mass * GRAVITY_MAGNITUDE + self->kp_z  * r_error.z + self->kd_z  * v_error.z + self->ki_z  * self->i_error_z;

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -468,6 +468,11 @@ LOG_ADD_CORE(LOG_FLOAT, pitch, &setpoint.attitude.pitch)
 LOG_ADD_CORE(LOG_FLOAT, yaw, &setpoint.attitudeRate.yaw)
 
 /**
+ * @brief Desired thrust
+ */
+LOG_ADD_CORE(LOG_FLOAT, thrust, &setpoint.thrust)
+
+/**
  * @brief Controller setpoint.mode.x (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
  */
 LOG_ADD(LOG_UINT8, mode_x, &setpoint.mode.x)

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -466,6 +466,41 @@ LOG_ADD_CORE(LOG_FLOAT, pitch, &setpoint.attitude.pitch)
  * @brief Desired attitude rate, yaw rate [deg/s]
  */
 LOG_ADD_CORE(LOG_FLOAT, yaw, &setpoint.attitudeRate.yaw)
+
+/**
+ * @brief Controller setpoint.mode.x (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_x, &setpoint.mode.x)
+
+/**
+ * @brief Controller setpoint.mode.y (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_y, &setpoint.mode.y)
+
+/**
+ * @brief Controller setpoint.mode.z (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_z, &setpoint.mode.z)
+
+/**
+ * @brief Controller setpoint.mode.roll (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_roll, &setpoint.mode.roll)
+
+/**
+ * @brief Controller setpoint.mode.pitch (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_pitch, &setpoint.mode.pitch)
+
+/**
+ * @brief Controller setpoint.mode.yaw (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_yaw, &setpoint.mode.yaw)
+
+/**
+ * @brief Controller setpoint.mode.quat (modeDisable = 0, modeAbs = 1, modeVelocity = 2)
+ */
+LOG_ADD(LOG_UINT8, mode_quat, &setpoint.mode.quat)
 LOG_GROUP_STOP(ctrltarget)
 
 /**


### PR DESCRIPTION
The other day we have observed that the Mellinger controller behaves different from our implementation in [Crazyflow](https://github.com/utiasDSL/crazyflow). We expected that when sending the attitude command via rpy angles, the desired orientation matrix gets constructed from that. After some investigation, however, we noticed that it is not correctly converted back into a rotation matrix onboard, but rather the target_thrust vector with a fixed z length of 1, effectively limiting the maximum achievable angle, since the x and y length are computed from the sin of pitch and roll. 

Here is a plot of the simulation (first plot) vs reality (second plot) for the brushless drone, where we can observe a flattening of the angle at around 45 deg (as expected from the argument above). Look for the roll and pitch command vs observed angles:
<img width="1808" height="1211" alt="sim_correct" src="https://github.com/user-attachments/assets/347e9585-30c8-403a-ad8b-b54128832303" /> 
<img width="1808" height="1211" alt="real_bug" src="https://github.com/user-attachments/assets/76713596-f06c-41f4-aa3f-bb57b8085716" />


To test if line 167, 168, and 174 actually cause this, we implemented this in our sim too and now sim and real look very similar:
<img width="1808" height="1211" alt="sim_bug" src="https://github.com/user-attachments/assets/189e5f45-7ae3-4286-a98b-fd126c1d1577" />


The fix simply includes computing the rotation matrix from the RPY angles. With the fix applied in the firmware, we observe the following results in real, which now look very similar to the first plot in sim. We can see that this implementation enables way more aggressive angles:
<img width="1808" height="1211" alt="real_correct" src="https://github.com/user-attachments/assets/142775ed-150b-4464-bab9-8442a7ccb32b" />

We stumbled across #832 and could imagine that this bug causes this limitation, but are not entirely sure what the observed behavior is. Maybe @whoenig still remembers what exactly was the issue. Either way, we have flown the brushless and the legacy drone with full state commands and RPYT interface and it appears to be stable in both cases. 