### PR TITLE
Use direct to task notification to wake up sensors task

### DIFF
--- a/src/hal/src/sensors_bmi088_bmp3xx.c
+++ b/src/hal/src/sensors_bmi088_bmp3xx.c
@@ -115,10 +115,9 @@ STATIC_MEM_QUEUE_ALLOC(magnetometerDataQueue, 1, sizeof(Axis3f));
 static xQueueHandle barometerDataQueue;
 STATIC_MEM_QUEUE_ALLOC(barometerDataQueue, 1, sizeof(baro_t));
 
-static xSemaphoreHandle sensorsDataReady;
-static StaticSemaphore_t sensorsDataReadyBuffer;
 static xSemaphoreHandle dataReady;
 static StaticSemaphore_t dataReadyBuffer;
+static TaskHandle_t sensorsTaskHandle;
 
 static bool isInit = false;
 static sensorData_t sensorData;
@@ -304,7 +303,7 @@ static void sensorsTask(void *param)
   //vTaskDelayUntil(&lastWakeTime, M2T(1500));
   while (1)
   {
-    if (pdTRUE == xSemaphoreTake(sensorsDataReady, portMAX_DELAY))
+    if (ulTaskNotifyTake(pdTRUE, portMAX_DELAY))
     {
       sensorData.interruptTimestamp = imuIntTimestamp;
 
@@ -563,7 +562,7 @@ static void sensorsTaskInit(void)
   magnetometerDataQueue = STATIC_MEM_QUEUE_CREATE(magnetometerDataQueue);
   barometerDataQueue = STATIC_MEM_QUEUE_CREATE(barometerDataQueue);
 
-  STATIC_MEM_TASK_CREATE(sensorsTask, sensorsTask, SENSORS_TASK_NAME, NULL, SENSORS_TASK_PRI);
+  sensorsTaskHandle = STATIC_MEM_TASK_CREATE(sensorsTask, sensorsTask, SENSORS_TASK_NAME, NULL, SENSORS_TASK_PRI);
 }
 
 static void sensorsInterruptInit(void)
@@ -571,7 +570,6 @@ static void sensorsInterruptInit(void)
   GPIO_InitTypeDef GPIO_InitStructure;
   EXTI_InitTypeDef EXTI_InitStructure;
 
-  sensorsDataReady = xSemaphoreCreateBinaryStatic(&sensorsDataReadyBuffer);
   dataReady = xSemaphoreCreateBinaryStatic(&dataReadyBuffer);
 
   // Enable the interrupt on PC14
@@ -997,7 +995,7 @@ void sensorsBmi088Bmp3xxDataAvailableCallback(void)
 {
   portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
   imuIntTimestamp = usecTimestamp();
-  xSemaphoreGiveFromISR(sensorsDataReady, &xHigherPriorityTaskWoken);
+  vTaskNotifyGiveFromISR(sensorsTaskHandle, &xHigherPriorityTaskWoken);
 
   if (xHigherPriorityTaskWoken)
   {

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -109,10 +109,9 @@ STATIC_MEM_QUEUE_ALLOC(magnetometerDataQueue, 1, sizeof(Axis3f));
 static xQueueHandle barometerDataQueue;
 STATIC_MEM_QUEUE_ALLOC(barometerDataQueue, 1, sizeof(baro_t));
 
-static xSemaphoreHandle sensorsDataReady;
-static StaticSemaphore_t sensorsDataReadyBuffer;
 static xSemaphoreHandle dataReady;
 static StaticSemaphore_t dataReadyBuffer;
+static TaskHandle_t sensorsTaskHandle;
 
 static bool isInit = false;
 static sensorData_t sensorData;
@@ -223,7 +222,7 @@ static void sensorsTask(void *param)
 
   while (1)
   {
-    if (pdTRUE == xSemaphoreTake(sensorsDataReady, portMAX_DELAY))
+    if (ulTaskNotifyTake(pdTRUE, portMAX_DELAY))
     {
       sensorData.interruptTimestamp = imuIntTimestamp;
       // data is ready to be read
@@ -496,7 +495,7 @@ static void sensorsTaskInit(void)
   magnetometerDataQueue = STATIC_MEM_QUEUE_CREATE(magnetometerDataQueue);
   barometerDataQueue = STATIC_MEM_QUEUE_CREATE(barometerDataQueue);
 
-  STATIC_MEM_TASK_CREATE(sensorsTask, sensorsTask, SENSORS_TASK_NAME, NULL, SENSORS_TASK_PRI);
+  sensorsTaskHandle = STATIC_MEM_TASK_CREATE(sensorsTask, sensorsTask, SENSORS_TASK_NAME, NULL, SENSORS_TASK_PRI);
 }
 
 static void sensorsInterruptInit(void)
@@ -504,7 +503,6 @@ static void sensorsInterruptInit(void)
   GPIO_InitTypeDef GPIO_InitStructure;
   EXTI_InitTypeDef EXTI_InitStructure;
 
-  sensorsDataReady = xSemaphoreCreateBinaryStatic(&sensorsDataReadyBuffer);
   dataReady = xSemaphoreCreateBinaryStatic(&dataReadyBuffer);
 
   // FSYNC "shall not be floating, must be set high or low by the MCU"
@@ -855,7 +853,7 @@ void __attribute__((used)) EXTI13_Callback(void)
 {
   portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
   imuIntTimestamp = usecTimestamp();
-  xSemaphoreGiveFromISR(sensorsDataReady, &xHigherPriorityTaskWoken);
+  vTaskNotifyGiveFromISR(sensorsTaskHandle, &xHigherPriorityTaskWoken);
 
   if (xHigherPriorityTaskWoken)
   {


### PR DESCRIPTION
This PR is a minor improvement for optimizing the sensor task. Previously a binary semaphore was used to wake up the sensor task from the IMU ISR. Based on the FreeRTOS documentation, direct to task notifications have better performance and use less RAM.

> A direct to task notification is an event sent directly to a task, rather than indirectly to a task via an intermediary object such as a queue, event group or semaphore.

> Unblocking an RTOS task with a direct notification is 35% faster and uses less RAM than unblocking a task using an intermediary object such as a binary semaphore.

https://www.freertos.org/Documentation/02-Kernel/02-Kernel-features/03-Direct-to-task-notifications/01-Task-notifications

