### PR TITLE
Add backward compat forwarding for arming/recovery on platform port

### DIFF
--- a/src/modules/src/platformservice.c
+++ b/src/modules/src/platformservice.c
@@ -42,6 +42,10 @@
 #include "static_mem.h"
 #include "ledseq.h"
 #include "worker.h"
+#include "supervisor.h"
+
+#define DEBUG_MODULE "PLAT"
+#include "debug.h"
 
 static bool isInit=false;
 STATIC_MEM_TASK_ALLOC_STACK_NO_DMA_CCM_SAFE(platformSrvTask, PLATFORM_SRV_TASK_STACKSIZE);
@@ -54,8 +58,8 @@ typedef enum {
 
 typedef enum {
   setContinuousWave    = 0x00,
-  // armSystem            = 0x01, (moved to crtp_supervisor)
-  // recoverSystem        = 0x02, (moved to crtp_supervisor)
+  armSystem            = 0x01, // Deprecated: moved to crtp_supervisor
+  recoverSystem        = 0x02, // Deprecated: moved to crtp_supervisor
   userNotification     = 0x03,
 } PlatformCommand;
 
@@ -128,6 +132,27 @@ static void platformCommandProcess(CRTPPacket *p)
       slp.length = 1;
       slp.data[0] = data[0];
       syslinkSendPacket(&slp);
+      break;
+    }
+    case armSystem:
+    {
+      // Deprecated: use CRTP_PORT_SUPERVISOR instead
+      DEBUG_PRINT("WARNING: arming via platform port is deprecated, use supervisor port\n");
+      const bool doArm = data[0];
+      const bool success = supervisorRequestArming(doArm);
+      data[0] = success;
+      data[1] = supervisorIsArmed();
+      p->size = 3;
+      break;
+    }
+    case recoverSystem:
+    {
+      // Deprecated: use CRTP_PORT_SUPERVISOR instead
+      DEBUG_PRINT("WARNING: recovery via platform port is deprecated, use supervisor port\n");
+      const bool success = supervisorRequestCrashRecovery(true);
+      data[0] = success;
+      data[1] = !supervisorIsCrashed();
+      p->size = 3;
       break;
     }
     case userNotification:

--- a/src/modules/src/platformservice.c
+++ b/src/modules/src/platformservice.c
@@ -138,6 +138,12 @@ static void platformCommandProcess(CRTPPacket *p)
     {
       // Deprecated: use CRTP_PORT_SUPERVISOR instead
       DEBUG_PRINT("WARNING: arming via platform port is deprecated, use supervisor port\n");
+      if (p->size < 2) {
+        data[0] = false;
+        data[1] = supervisorIsArmed();
+        p->size = 3;
+        break;
+      }
       const bool doArm = data[0];
       const bool success = supervisorRequestArming(doArm);
       data[0] = success;


### PR DESCRIPTION
Old libraries send arming and crash recovery commands to the platform CRTP port. After moving these to the supervisor port, these commands were silently dropped. Forward them to the supervisor and print a deprecation warning, matching the pattern used for emergency stop forwarding in crtp_localization_service.