### PR TITLE
docs: document emergency stop watchdog

### DIFF
--- a/docs/functional-areas/crtp/crtp_supervisor.md
+++ b/docs/functional-areas/crtp/crtp_supervisor.md
@@ -78,7 +78,7 @@ No response is sent.
 
 ### Emergency stop watchdog
 
-Keepalive packet that must be sent at least once per second after the first packet is received. If the timeout expires, all motors are stopped. The watchdog is disabled at startup and activates on the first received packet.
+Keepalive packet that must be sent at least once per second after the first packet is received. If the timeout expires, all motors are stopped. The watchdog is disabled at startup and activates on the first received packet. For the supervisor-level safety behavior, see the [supervisor documentation](/docs/functional-areas/supervisor/).
 
 Command:
 

--- a/docs/functional-areas/supervisor/index.md
+++ b/docs/functional-areas/supervisor/index.md
@@ -32,11 +32,13 @@ landing when possible, instead of free falling, but that is currently not implem
 
 ## Emergency stops
 
-The supervisor supports an emergency stop watchdog that can be used to implement an emergency stop command with a periodic keepalive.
+The supervisor supports two emergency stop mechanisms: an immediate emergency stop command and an emergency stop watchdog.
 
-The emergency stop watchdog is disabled at startup. It becomes active when the first watchdog keepalive packet is received. After that, a new keepalive must be received at least once every 1000 ms. If the source stops sending keepalive packets and the timeout expires, the Crazyflie enters emergency stop and the motors are stopped.
+The immediate emergency stop command stops the motors as soon as the command is handled by the supervisor. It puts the supervisor in the locked state, which is latching and requires a reboot to recover.
 
-This mechanism can be used by external control or safety integrations that want the Crazyflie to default to emergency stop if communication is lost. For packet-level details, see the [Supervisor CRTP port](/docs/functional-areas/crtp/crtp_supervisor/).
+The emergency stop watchdog can be used to implement an emergency stop command with a periodic keepalive. It is disabled at startup and becomes active when the first watchdog keepalive packet is received. After that, a new keepalive must be received at least once every 1000 ms. If the source stops sending keepalive packets and the timeout expires, the Crazyflie enters emergency stop, stops the motors and enters the locked state.
+
+The watchdog mechanism can be used by external control or safety integrations that want the Crazyflie to default to emergency stop if communication is lost. For packet-level details, see the [Supervisor CRTP port](/docs/functional-areas/crtp/crtp_supervisor.md).
 
 ## Sub pages
 

--- a/docs/functional-areas/supervisor/index.md
+++ b/docs/functional-areas/supervisor/index.md
@@ -30,6 +30,14 @@ motors and free falling.
 The supervisor framework provides the possibility to handle situations in a more "clever" way, such as doing a controlled
 landing when possible, instead of free falling, but that is currently not implemented.
 
+## Emergency stops
+
+The supervisor supports an emergency stop watchdog that can be used to implement an emergency stop command with a periodic keepalive.
+
+The emergency stop watchdog is disabled at startup. It becomes active when the first watchdog keepalive packet is received. After that, a new keepalive must be received at least once every 1000 ms. If the source stops sending keepalive packets and the timeout expires, the Crazyflie enters emergency stop and the motors are stopped.
+
+This mechanism can be used by external control or safety integrations that want the Crazyflie to default to emergency stop if communication is lost. For packet-level details, see the [Supervisor CRTP port](/docs/functional-areas/crtp/crtp_supervisor/).
+
 ## Sub pages
 
 {% sub_page_menu %}


### PR DESCRIPTION
Issue #1549 pointed out that the emergency stop watchdog behavior was implemented but not documented in the supervisor documentation. This change implements this documentation.

Fixes #1549.