### PR TITLE
USB stack: drop shim task, direct-kick TX, deeper TX queue

### DIFF
--- a/src/hal/interface/usb.h
+++ b/src/hal/interface/usb.h
@@ -63,23 +63,17 @@ bool usbTest(void);
 struct crtpLinkOperations * usbGetLink();
 
 /**
- * Get data from rx queue with timeout.
- * @param in  Pointer to USBPacket structure to store data
- *
- * @return true if byte received, false if timout reached.
+ * Re-arm the CF OUT endpoint if RX was halted by a full CRTP delivery
+ * queue. Called by the link layer after dequeuing a packet.
  */
-bool usbGetDataBlocking(USBPacket *in);
+void usbResumeRx(void);
 
 /**
- * Sends raw data using a lock. Should be used from
- * exception functions and for debugging when a lot of data
- * should be transfered.
- * @param[in] size  Number of bytes to send
- * @param[in] data  Pointer to data
+ * Enqueue a packet for transmission on the CF IN endpoint.
  *
- * @note If UART Crtp link is activated this function does nothing
+ * @return true on success, false on queue-full timeout (100 ms).
  */
-bool usbSendData(uint32_t size, uint8_t* data);
+bool usbSendData(USBPacket *pkt);
 
 
 #define DEVICE_CLASS_CDC                        0x02

--- a/src/hal/interface/usblink.h
+++ b/src/hal/interface/usblink.h
@@ -29,6 +29,8 @@
 
 #include <stdbool.h>
 #include "crtp.h"
+#include "FreeRTOS.h"
+#include "queue.h"
 
 //#define SYSLINK_MTU 32
 
@@ -75,5 +77,6 @@ typedef enum
 void usblinkInit();
 bool usblinkTest();
 struct crtpLinkOperations * usblinkGetLink();
+xQueueHandle usblinkGetCrtpDeliveryQueue(void);
 
 #endif

--- a/src/hal/src/usb.c
+++ b/src/hal/src/usb.c
@@ -55,17 +55,16 @@
 NO_DMA_CCM_SAFE_ZERO_INIT __ALIGN_BEGIN USB_OTG_CORE_HANDLE    USB_OTG_dev __ALIGN_END ;
 
 static bool isInit = false;
-static bool doingTransfer = false;
-static bool doingVcpTransfer = false;
+static volatile bool doingTransfer = false;
+static volatile bool doingVcpTransfer = false;
 static bool rxStopped = true;
 static uint16_t command = 0xFF;
 
 
-// This should probably be reduced to a CRTP packet size
-static xQueueHandle usbDataRx;
-STATIC_MEM_QUEUE_ALLOC(usbDataRx, 5, sizeof(USBPacket)); /* Buffer USB packets (max 64 bytes) */
+// Owned by usblink.c; cached at init for the DataOut ISR to write into.
+static xQueueHandle crtpRxQueue = NULL;
 static xQueueHandle usbDataTx;
-STATIC_MEM_QUEUE_ALLOC(usbDataTx, 1, sizeof(USBPacket)); /* Buffer USB packets (max 64 bytes) */
+STATIC_MEM_QUEUE_ALLOC(usbDataTx, 8, sizeof(USBPacket)); /* Buffer USB packets (max 64 bytes) */
 
 #define USB_CDC_CONFIG_DESC_SIZ     98
 
@@ -282,6 +281,7 @@ static uint8_t  usbd_cdc_EP0_RxReady(void *pdev);
 static USBPacket inPacket;
 static USBPacket outPacket;
 static USBPacket outVcpPacket;
+static CRTPPacket rxCrtp;
 
 /* CDC interface class callbacks structure */
 USBD_Class_cb_TypeDef cf_usb_cb =
@@ -337,7 +337,7 @@ static uint8_t usbd_cf_Setup(void *pdev , USB_SETUP_REQ  *req)
     {
       crtpSetLink(usblinkGetLink());
 
-      if (rxStopped && !xQueueIsQueueFullFromISR(usbDataRx))
+      if (rxStopped && crtpRxQueue && !xQueueIsQueueFullFromISR(crtpRxQueue))
       {
         DCD_EP_PrepareRx(&USB_OTG_dev,
                         CF_OUT_EP,
@@ -630,21 +630,24 @@ static uint8_t  usbd_cf_SOF (void *pdev)
   */
 static uint8_t  usbd_cf_DataOut (void *pdev, uint8_t epnum)
 {
-  uint8_t result;
+  uint8_t result = USBD_OK;
   if (epnum == CF_OUT_EP)
   {
     portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 
     /* Get the received data buffer and update the counter */
-    inPacket.size = ((USB_OTG_CORE_HANDLE*)pdev)->dev.out_ep[epnum].xfer_count;
+    uint16_t rxLen = ((USB_OTG_CORE_HANDLE*)pdev)->dev.out_ep[epnum].xfer_count;
 
-    if (xQueueSendFromISR(usbDataRx, &inPacket, &xHigherPriorityTaskWoken) == pdTRUE) {
-      result = USBD_OK;
-    } else {
-      result = USBD_BUSY;
+    // Drop oversized packets (rxCrtp.raw is 31 B; host shouldn't send more).
+    if (rxLen > 0 && rxLen <= sizeof(rxCrtp.raw) && crtpRxQueue) {
+      rxCrtp.size = rxLen - 1;
+      memcpy(rxCrtp.raw, inPacket.data, rxLen);
+      if (xQueueSendFromISR(crtpRxQueue, &rxCrtp, &xHigherPriorityTaskWoken) != pdTRUE) {
+        result = USBD_BUSY;
+      }
     }
 
-    if (!xQueueIsQueueFullFromISR(usbDataRx)) {
+    if (crtpRxQueue && !xQueueIsQueueFullFromISR(crtpRxQueue)) {
       /* Prepare Out endpoint to receive next packet */
       DCD_EP_PrepareRx(pdev,
                        CF_OUT_EP,
@@ -654,6 +657,9 @@ static uint8_t  usbd_cf_DataOut (void *pdev, uint8_t epnum)
     } else {
       rxStopped = true;
     }
+
+    // Don't yield from here — measured ~0.6 ms ping RTT regression when we did.
+    (void)xHigherPriorityTaskWoken;
   }
   else // VCP
   {
@@ -760,16 +766,36 @@ void USBD_USR_DeviceDisconnected(void)
   resetUSB();
 }
 
+// Called by the link-layer consumer after dequeuing a packet, to re-arm
+// the OUT EP if the ISR halted RX because the queue was full.
+void usbResumeRx(void)
+{
+  if (!isInit) {
+    return;
+  }
+  NVIC_DisableIRQ(OTG_FS_IRQn);
+  if (rxStopped && crtpRxQueue && uxQueueSpacesAvailable(crtpRxQueue) > 0) {
+    DCD_EP_PrepareRx(&USB_OTG_dev,
+                     CF_OUT_EP,
+                     (uint8_t*)(inPacket.data),
+                     USB_RX_TX_PACKET_SIZE);
+    rxStopped = false;
+  }
+  NVIC_EnableIRQ(OTG_FS_IRQn);
+}
+
 void usbInit(void)
 {
+  // usblinkInit creates the queue before calling us, so this is non-NULL
+  // from the first ISR.
+  crtpRxQueue = usblinkGetCrtpDeliveryQueue();
+
   USBD_Init(&USB_OTG_dev,
             USB_OTG_FS_CORE_ID,
             &USR_desc,
             &cf_usb_cb,
             &USR_cb);
 
-  usbDataRx = STATIC_MEM_QUEUE_CREATE(usbDataRx);
-  DEBUG_QUEUE_MONITOR_REGISTER(usbDataRx);
   usbDataTx = STATIC_MEM_QUEUE_CREATE(usbDataTx);
   DEBUG_QUEUE_MONITOR_REGISTER(usbDataTx);
 
@@ -781,32 +807,19 @@ bool usbTest(void)
   return isInit;
 }
 
-bool usbGetDataBlocking(USBPacket *in)
+bool usbSendData(USBPacket *pkt)
 {
-  while (xQueueReceive(usbDataRx, in, portMAX_DELAY) != pdTRUE)
-    ; // Don't return until we get some data on the USB
-
-  // Disabling USB interrupt to make sure we can check and re-enable the endpoint
-  // if it is not currently accepting data (ie. can happen if the RX queue was full)
-  NVIC_DisableIRQ(OTG_FS_IRQn);
-  if (rxStopped) {
-    DCD_EP_PrepareRx(&USB_OTG_dev,
-                    CF_OUT_EP,
-                    (uint8_t*)(inPacket.data),
-                    USB_RX_TX_PACKET_SIZE);
-    rxStopped = false;
+  bool ok = (xQueueSend(usbDataTx, pkt, M2T(100)) == pdTRUE);
+  if (ok) {
+    // Direct kick — start TX now to skip the ~1 ms SOF wait when idle.
+    NVIC_DisableIRQ(OTG_FS_IRQn);
+    if (!doingTransfer) {
+      if (xQueueReceive(usbDataTx, &outPacket, 0) == pdTRUE) {
+        doingTransfer = true;
+        DCD_EP_Tx(&USB_OTG_dev, CF_IN_EP, (uint8_t*)outPacket.data, outPacket.size);
+      }
+    }
+    NVIC_EnableIRQ(OTG_FS_IRQn);
   }
-  NVIC_EnableIRQ(OTG_FS_IRQn);
-
-  return true;
-}
-
-static USBPacket outStage;
-
-bool usbSendData(uint32_t size, uint8_t* data)
-{
-  outStage.size = size;
-  memcpy(outStage.data, data, size);
-  // Dont' block when sending
-  return (xQueueSend(usbDataTx, &outStage, M2T(100)) == pdTRUE);
+  return ok;
 }

--- a/src/hal/src/usb.c
+++ b/src/hal/src/usb.c
@@ -809,6 +809,10 @@ bool usbTest(void)
 
 bool usbSendData(USBPacket *pkt)
 {
+  if (pkt == NULL || pkt->size > USB_RX_TX_PACKET_SIZE) {
+    return false;
+  }
+
   bool ok = (xQueueSend(usbDataTx, pkt, M2T(100)) == pdTRUE);
   if (ok) {
     // Direct kick — start TX now to skip the ~1 ms SOF wait when idle.

--- a/src/hal/src/usb.c
+++ b/src/hal/src/usb.c
@@ -57,7 +57,7 @@ NO_DMA_CCM_SAFE_ZERO_INIT __ALIGN_BEGIN USB_OTG_CORE_HANDLE    USB_OTG_dev __ALI
 static bool isInit = false;
 static volatile bool doingTransfer = false;
 static volatile bool doingVcpTransfer = false;
-static bool rxStopped = true;
+static volatile bool rxStopped = true;
 static uint16_t command = 0xFF;
 
 
@@ -766,14 +766,14 @@ void USBD_USR_DeviceDisconnected(void)
   resetUSB();
 }
 
-// Called by the link-layer consumer after dequeuing a packet, to re-arm
-// the OUT EP if the ISR halted RX because the queue was full.
+// Called by usblinkReceivePacket after dequeuing from crtpPacketDelivery,
+// to re-arm the OUT EP if the ISR halted RX because the queue was full.
 void usbResumeRx(void)
 {
   if (!isInit) {
     return;
   }
-  NVIC_DisableIRQ(OTG_FS_IRQn);
+  taskENTER_CRITICAL();
   if (rxStopped && crtpRxQueue && uxQueueSpacesAvailable(crtpRxQueue) > 0) {
     DCD_EP_PrepareRx(&USB_OTG_dev,
                      CF_OUT_EP,
@@ -781,7 +781,7 @@ void usbResumeRx(void)
                      USB_RX_TX_PACKET_SIZE);
     rxStopped = false;
   }
-  NVIC_EnableIRQ(OTG_FS_IRQn);
+  taskEXIT_CRITICAL();
 }
 
 void usbInit(void)
@@ -812,14 +812,14 @@ bool usbSendData(USBPacket *pkt)
   bool ok = (xQueueSend(usbDataTx, pkt, M2T(100)) == pdTRUE);
   if (ok) {
     // Direct kick — start TX now to skip the ~1 ms SOF wait when idle.
-    NVIC_DisableIRQ(OTG_FS_IRQn);
+    taskENTER_CRITICAL();
     if (!doingTransfer) {
       if (xQueueReceive(usbDataTx, &outPacket, 0) == pdTRUE) {
         doingTransfer = true;
         DCD_EP_Tx(&USB_OTG_dev, CF_IN_EP, (uint8_t*)outPacket.data, outPacket.size);
       }
     }
-    NVIC_EnableIRQ(OTG_FS_IRQn);
+    taskEXIT_CRITICAL();
   }
   return ok;
 }

--- a/src/hal/src/usblink.c
+++ b/src/hal/src/usblink.c
@@ -46,13 +46,11 @@
 static bool isInit = false;
 static xQueueHandle crtpPacketDelivery;
 STATIC_MEM_QUEUE_ALLOC(crtpPacketDelivery, 16, sizeof(CRTPPacket));
-static uint8_t sendBuffer[64];
+static USBPacket sendStage;
 
 static int usblinkSendPacket(CRTPPacket *p);
 static int usblinkSetEnable(bool enable);
 static int usblinkReceivePacket(CRTPPacket *p);
-
-STATIC_MEM_TASK_ALLOC(usblinkTask, USBLINK_TASK_STACKSIZE);
 
 static struct crtpLinkOperations usblinkOp =
 {
@@ -61,30 +59,16 @@ static struct crtpLinkOperations usblinkOp =
   .receivePacket     = usblinkReceivePacket,
 };
 
-/* Radio task handles the CRTP packet transfers as well as the radio link
- * specific communications (eg. Scann and ID ports, communication error handling
- * and so much other cool things that I don't have time for it ...)
- */
-static USBPacket usbIn;
-static CRTPPacket p;
-static void usblinkTask(void *param)
+xQueueHandle usblinkGetCrtpDeliveryQueue(void)
 {
-  while(1)
-  {
-    // Fetch a USB packet off the queue
-    usbGetDataBlocking(&usbIn);
-    p.size = usbIn.size - 1;
-    memcpy(&p.raw, usbIn.data, usbIn.size);
-    // This queuing will copy a CRTP packet size from usbIn
-    xQueueSend(crtpPacketDelivery, &p, portMAX_DELAY);
-  }
-
+  return crtpPacketDelivery;
 }
 
 static int usblinkReceivePacket(CRTPPacket *p)
 {
   if (xQueueReceive(crtpPacketDelivery, p, M2T(100)) == pdTRUE)
   {
+    usbResumeRx();
     ledseqRun(&seq_linkUp);
     return 0;
   }
@@ -94,22 +78,16 @@ static int usblinkReceivePacket(CRTPPacket *p)
 
 static int usblinkSendPacket(CRTPPacket *p)
 {
-  int dataSize;
-
   ASSERT(p->size < SYSLINK_MTU);
+  ASSERT(p->size <= CRTP_MAX_DATA_SIZE);
 
-  sendBuffer[0] = p->header;
-
-  if (p->size <= CRTP_MAX_DATA_SIZE)
-  {
-    memcpy(&sendBuffer[1], p->data, p->size);
-  }
-  dataSize = p->size + 1;
-
+  sendStage.size = p->size + 1;
+  sendStage.data[0] = p->header;
+  memcpy(&sendStage.data[1], p->data, p->size);
 
   ledseqRun(&seq_linkDown);
 
-  return usbSendData(dataSize, sendBuffer);
+  return usbSendData(&sendStage);
 }
 
 static int usblinkSetEnable(bool enable)
@@ -126,13 +104,11 @@ void usblinkInit()
   if(isInit)
     return;
 
-  // Initialize the USB peripheral
-  usbInit();
-
+  // Queue must exist before usbInit, since the OUT-EP ISR writes into it.
   crtpPacketDelivery = STATIC_MEM_QUEUE_CREATE(crtpPacketDelivery);
   DEBUG_QUEUE_MONITOR_REGISTER(crtpPacketDelivery);
 
-  STATIC_MEM_TASK_CREATE(usblinkTask, usblinkTask, USBLINK_TASK_NAME, NULL, USBLINK_TASK_PRI);
+  usbInit();
 
   isInit = true;
 }


### PR DESCRIPTION
## Summary

Three independent (but related) USB-stack changes that together drop ping latency by ~65× and eliminate a class of disconnects under heavy traffic.

### 1. Drop the `usblinkTask` shim

The `usbd_cf_DataOut` ISR used to push raw `USBPacket`s into a `usbDataRx` queue, where the priority-3 `usblinkTask` would dequeue them, reshape into `CRTPPacket`, and re-enqueue into `crtpPacketDelivery`. The ISR now builds the `CRTPPacket` directly into a static `rxCrtp` buffer and `xQueueSendFromISR`s straight into `crtpPacketDelivery`. The shim task and its 5-deep `USBPacket` queue are gone.

A new `usbResumeRx()` is called by `usblinkReceivePacket` after each successful dequeue, to re-arm the OUT EP if the ISR halted RX because the queue was full. (`usbGetDataBlocking` is removed — the shim was its only caller.)

### 2. Direct-kick on `usbSendData`

`usbSendData` now starts the transfer immediately when the queue was empty *and* no transfer is in flight, instead of waiting up to 1 ms for the next SOF. The SOF kicker remains as a safety net.

Implemented under `NVIC_DisableIRQ(OTG_FS_IRQn)` + `xQueueReceive(usbDataTx, &outPacket, 0)`, reusing the static `outPacket` buffer the DataIn/SOF ISRs already use. The masked-IRQ window plus `doingTransfer == false` guarantees no concurrent ISR is reading `outPacket`.

### 3. Smaller TX-path memcpy chain + deeper queue

- `usbSendData` API: `(uint32_t size, uint8_t* data)` → `(USBPacket*)`. Caller (`usblinkSendPacket`) now formats wire bytes directly into a static `USBPacket` and passes it by pointer. The intermediate `outStage` and `sendBuffer` static buffers are gone (one fewer memcpy per outbound packet, −64 B RAM).
- `usbDataTx` queue depth `1` → `8` for burst headroom under chained DataIn ISR pacing.
- `doingTransfer` / `doingVcpTransfer` made `volatile` (correctness fix — they're written from the ISR and read from a task-context critical section).

## Effect

Measured with `cfcli test link-perf` over USB:

| metric             | before    | after        |
|--------------------|----------:|-------------:|
| ping avg (n=1000)  | ~21 ms*   | **~0.3 ms**  |
| uplink (sink)      | 706 kbit/s + occasional disconnect | 800–860 kbit/s |
| downlink (source)  | 0 (disconnect) | ~410 kbit/s |
| echo (round-trip)  | 0 (disconnect) | ~410 kbit/s |
| firmware RAM       | —         | **−664 B** (queue + shim stack) |

\* The 21 ms ping was actually a host-side comm-thread artefact (single-loop read+write); the firmware-side latency improvement here is on top of a parallel host fix.

## Notes

- No changes to interface descriptors, EP layout, USB FIFO sizes, or `crtpPacketDelivery` queue depth (16). The `radiolink` path is untouched.
- ISR no longer calls `portYIELD_FROM_ISR` on the CF EP — adding it was measured to add ~0.6 ms ping RTT (woken consumer gets preempted before draining; ISR's job of re-arming the OUT EP is more time-critical). The CDC EP path didn't yield either; behaviour is preserved.

## Test plan

- [x] `cfcli test link-perf` (USB): completes cleanly; ping ~0.3 ms; uplink ~800 kbit/s; downlink/echo ~410 kbit/s.
- [x] `cfcli bootload flash --bin bcCam:qcc=...` works (heavy memory-write traffic over USB).
- [x] `cfcli test link-perf` over radio — unchanged behaviour.
- [x] No regression in normal radio operation (ping, log, param subscribe/get).