### PR TITLE
Increase bcCam firmware reset timing

### DIFF
--- a/src/deck/drivers/src/bccam_deck.c
+++ b/src/deck/drivers/src/bccam_deck.c
@@ -45,6 +45,11 @@
 #define BCCAM_UART_BAUDRATE       2000000
 #define BCCAM_ISP_BAUDRATE        500000
 
+#define BCCAM_FW_RESET_HOLD_MS    50
+#define BCCAM_FW_BOOT_SETUP_MS    50
+#define BCCAM_FW_BOOT_WAIT_MS     500
+#define BCCAM_FW_RX_DRAIN_MS      100
+
 // Deck controller GPIO pin mapping (STM32 deck-ctrl MCU)
 #define GPIO_UART1_EN   DECKCTRL_GPIO_PIN_0   // PA0 - UART1 enable
 #define GPIO_UART2_EN   DECKCTRL_GPIO_PIN_1   // PA1 - UART2 enable
@@ -434,20 +439,20 @@ static void bcCamResetToBootloader(void) {
 static void bcCamEnterFw(void) {
   // Disable QCC748
   deckctrl_gpio_write(deckInfoG, GPIO_QCC_EN, LOW);
-  vTaskDelay(M2T(10));
+  vTaskDelay(M2T(BCCAM_FW_RESET_HOLD_MS));
 
   // Set boot select LOW for normal boot
   deckctrl_gpio_write(deckInfoG, GPIO_QCC_BOOT, LOW);
-  vTaskDelay(M2T(10));
+  vTaskDelay(M2T(BCCAM_FW_BOOT_SETUP_MS));
 
   // Switch back to firmware baudrate
   uart1SetBaudrate(BCCAM_UART_BAUDRATE);
 
   // Re-enable QCC748 - it will boot firmware
   deckctrl_gpio_write(deckInfoG, GPIO_QCC_EN, HIGH);
-  vTaskDelay(M2T(100));
+  vTaskDelay(M2T(BCCAM_FW_BOOT_WAIT_MS));
 
-  ispDrainRx(50);
+  ispDrainRx(BCCAM_FW_RX_DRAIN_MS);
 
   isInFirmware = true;
   DEBUG_PRINT("QCC748 in firmware mode\n");


### PR DESCRIPTION
## Summary

The QCC748 firmware boot path needs a little more time after reset before the UART link is used. This PR replaces the short inline waits with named timing constants and increases the firmware boot wait to make reset-to-firmware more reliable.

## Changes

- Add named timing constants for the bcCam firmware reset sequence
- Increase QCC reset hold/setup waits from 10 ms to 50 ms
- Increase firmware boot wait from 100 ms to 500 ms
- Increase RX drain after firmware boot from 50 ms to 100 ms

## Test Plan

- Verified with git diff --check against origin/master
- Hardware validation: reset bcCam/QCC748 back to firmware mode and confirm it reliably boots/responds