### PR TITLE
Add params to toggle LH and Loco measurements into the estimator

### DIFF
--- a/src/deck/drivers/interface/locodeck.h
+++ b/src/deck/drivers/interface/locodeck.h
@@ -120,6 +120,8 @@ bool lpsGetLppShort(lpsLppShortPacket_t* shortPacket);
 uint16_t locoDeckGetRangingState();
 void locoDeckSetRangingState(const uint16_t newState);
 
+extern uint8_t locoEnableEstimator;
+
 // LPP Packet types and format
 #define LPP_HEADER_SHORT_PACKET 0xF0
 

--- a/src/deck/drivers/src/locodeck.c
+++ b/src/deck/drivers/src/locodeck.c
@@ -126,6 +126,9 @@ static uwbAlgorithm_t *algorithm = &uwbTwrTagAlgorithm;
 #endif
 
 static bool isInit = false;
+
+uint8_t locoEnableEstimator = 1;
+
 static TaskHandle_t uwbTaskHandle = 0;
 static SemaphoreHandle_t algoSemaphore;
 
@@ -740,5 +743,14 @@ PARAM_GROUP_START(loco)
  * |   3   | TDoA 3 |\n
  */
 PARAM_ADD_CORE(PARAM_UINT8, mode, &algoOptions.userRequestedMode)
+
+/**
+ * @brief Feed loco measurements into the state estimator (default: 1)
+ *
+ * Set to 0 to stop pushing loco (TWR/TDoA distance, TDoA and absolute height)
+ * measurements into the Kalman filter, while keeping the loco system otherwise
+ * running.
+ */
+PARAM_ADD_CORE(PARAM_UINT8 | PARAM_PERSISTENT, enableEst, &locoEnableEstimator)
 
 PARAM_GROUP_STOP(loco)

--- a/src/deck/drivers/src/locodeck.c
+++ b/src/deck/drivers/src/locodeck.c
@@ -751,6 +751,6 @@ PARAM_ADD_CORE(PARAM_UINT8, mode, &algoOptions.userRequestedMode)
  * measurements into the Kalman filter, while keeping the loco system otherwise
  * running.
  */
-PARAM_ADD_CORE(PARAM_UINT8 | PARAM_PERSISTENT, enableEst, &locoEnableEstimator)
+PARAM_ADD_CORE(PARAM_UINT8, fwdToEstimator, &locoEnableEstimator)
 
 PARAM_GROUP_STOP(loco)

--- a/src/deck/drivers/src/lpsTdoa2Tag.c
+++ b/src/deck/drivers/src/lpsTdoa2Tag.c
@@ -288,15 +288,17 @@ static void sendTdoaToEstimatorCallback(tdoaMeasurement_t* tdoaMeasurement) {
   // Override the default standard deviation set by the TDoA engine.
   tdoaMeasurement->stdDev = stdDev;
 
-  estimatorEnqueueTDOA(tdoaMeasurement);
+  if (locoEnableEstimator) {
+    estimatorEnqueueTDOA(tdoaMeasurement);
 
-  #ifdef CONFIG_DECK_LOCO_2D_POSITION
-  heightMeasurement_t heightData;
-  heightData.timestamp = xTaskGetTickCount();
-  heightData.height = DECK_LOCO_2D_POSITION_HEIGHT;
-  heightData.stdDev = 0.0001;
-  estimatorEnqueueAbsoluteHeight(&heightData);
-  #endif
+    #ifdef CONFIG_DECK_LOCO_2D_POSITION
+    heightMeasurement_t heightData;
+    heightData.timestamp = xTaskGetTickCount();
+    heightData.height = DECK_LOCO_2D_POSITION_HEIGHT;
+    heightData.stdDev = 0.0001;
+    estimatorEnqueueAbsoluteHeight(&heightData);
+    #endif
+  }
 
   const uint8_t idA = tdoaMeasurement->anchorIds[0];
   const uint8_t idB = tdoaMeasurement->anchorIds[1];

--- a/src/deck/drivers/src/lpsTdoa3Tag.c
+++ b/src/deck/drivers/src/lpsTdoa3Tag.c
@@ -362,7 +362,7 @@ static void processTwoWayRanging(tdoaAnchorContext_t* anchorCtx, const uint32_t 
             .z = position.z,
           };
 
-          if (ctx.useTwrForPositionEstimation) {
+          if (ctx.useTwrForPositionEstimation && locoEnableEstimator) {
             estimatorEnqueueDistance(&measurement);
             STATS_CNT_RATE_EVENT(&ctx.cntTwrToEstimator);
           }
@@ -616,7 +616,7 @@ static uint32_t onEvent(dwDevice_t *dev, uwbEvent_t event) {
 }
 
 static void sendTdoaToEstimatorCallback(tdoaMeasurement_t* tdoaMeasurement) {
-  if (ctx.isTdoaActive) {
+  if (ctx.isTdoaActive && locoEnableEstimator) {
     // Override the default standard deviation set by the TDoA engine.
     tdoaMeasurement->stdDev = ctx.tdoaStdDev;
 

--- a/src/deck/drivers/src/lpsTwrTag.c
+++ b/src/deck/drivers/src/lpsTwrTag.c
@@ -260,7 +260,9 @@ static uint32_t rxcallback(dwDevice_t *dev) {
         dist.z = options->anchorPosition[current_anchor].z;
         dist.anchorId = current_anchor;
         dist.stdDev = 0.25;
-        estimatorEnqueueDistance(&dist);
+        if (locoEnableEstimator) {
+          estimatorEnqueueDistance(&dist);
+        }
       }
 
       if (options->useTdma && current_anchor == 0) {

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -221,6 +221,8 @@ static positionMeasurement_t ext_pos;
 static float sweepStd = 0.0004;
 static float sweepStdLh2 = 0.001;
 
+static uint8_t enableEstimator = 1;
+
 static vec3d position;
 static vec3d positionLog;
 static float deltaLog;
@@ -270,7 +272,7 @@ static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulsePr
     positionLog[2] = ext_pos.z;
 
     // Make sure we feed sane data into the estimator
-    if (isfinite(ext_pos.pos[0]) && isfinite(ext_pos.pos[1]) && isfinite(ext_pos.pos[2])) {
+    if (enableEstimator && isfinite(ext_pos.pos[0]) && isfinite(ext_pos.pos[1]) && isfinite(ext_pos.pos[2])) {
       ext_pos.stdDev = 0.01;
       ext_pos.source = MeasurementSourceLighthouse;
       #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
@@ -305,7 +307,9 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
         sweepInfo.sweepId = 0;
 
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
-          estimatorEnqueueSweepAngles(&sweepInfo);
+          if (enableEstimator) {
+            estimatorEnqueueSweepAngles(&sweepInfo);
+          }
 
           STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
           STATS_CNT_RATE_EVENT(&positionRate);
@@ -320,7 +324,9 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
         sweepInfo.sweepId = 1;
 
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
-          estimatorEnqueueSweepAngles(&sweepInfo);
+          if (enableEstimator) {
+            estimatorEnqueueSweepAngles(&sweepInfo);
+          }
 
           STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
           STATS_CNT_RATE_EVENT(&positionRate);
@@ -352,7 +358,9 @@ static void estimatePositionSweepsLh2(const pulseProcessor_t* appState, pulsePro
         sweepInfo.calib = &bsCalib->sweep[0];
         sweepInfo.sweepId = 0;
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
-          estimatorEnqueueSweepAngles(&sweepInfo);
+          if (enableEstimator) {
+            estimatorEnqueueSweepAngles(&sweepInfo);
+          }
 
           STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
           STATS_CNT_RATE_EVENT(&positionRate);
@@ -365,7 +373,9 @@ static void estimatePositionSweepsLh2(const pulseProcessor_t* appState, pulsePro
         sweepInfo.calib = &bsCalib->sweep[1];
         sweepInfo.sweepId = 1;
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
-          estimatorEnqueueSweepAngles(&sweepInfo);
+          if (enableEstimator) {
+            estimatorEnqueueSweepAngles(&sweepInfo);
+          }
 
           STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
           STATS_CNT_RATE_EVENT(&positionRate);
@@ -453,7 +463,7 @@ static void estimateYaw(const pulseProcessor_t *state, pulseProcessorResult_t* a
 
   // Calculate yaw delta using only one base station for now
   float yawDelta;
-  if (estimateYawDeltaOneBaseStation(baseStation, angles, state->bsGeometry, cfPos, n, &RR, &yawDelta)) {
+  if (enableEstimator && estimateYawDeltaOneBaseStation(baseStation, angles, state->bsGeometry, cfPos, n, &RR, &yawDelta)) {
     #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
       yawErrorMeasurement_t yawDeltaMeasurement = {.yawError = yawDelta, .stdDev = 0.01};
       estimatorEnqueueYawError(&yawDeltaMeasurement);
@@ -503,4 +513,11 @@ PARAM_ADD_CORE(PARAM_FLOAT, sweepStd, &sweepStd)
  * @brief Standard deviation Sweep angles Lighthouse V2
  */
 PARAM_ADD_CORE(PARAM_FLOAT, sweepStd2, &sweepStdLh2)
+/**
+ * @brief Feed lighthouse measurements into the state estimator (default: 1)
+ *
+ * Set to 0 to stop pushing lighthouse position/sweep measurements into the
+ * Kalman filter, while keeping the lighthouse system otherwise running.
+ */
+PARAM_ADD_CORE(PARAM_UINT8 | PARAM_PERSISTENT, enableEst, &enableEstimator)
 PARAM_GROUP_STOP(lighthouse)

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -521,5 +521,5 @@ PARAM_ADD_CORE(PARAM_FLOAT, sweepStd2, &sweepStdLh2)
  * Set to 0 to stop pushing lighthouse position/sweep measurements into the
  * Kalman filter, while keeping the lighthouse system otherwise running.
  */
-PARAM_ADD_CORE(PARAM_UINT8 | PARAM_PERSISTENT, enableEst, &enableEstimator)
+PARAM_ADD_CORE(PARAM_UINT8, fwdToEstimator, &enableEstimator)
 PARAM_GROUP_STOP(lighthouse)

--- a/src/modules/src/lighthouse/lighthouse_position_est.c
+++ b/src/modules/src/lighthouse/lighthouse_position_est.c
@@ -252,7 +252,9 @@ static void estimatePositionCrossingBeams(const pulseProcessor_t *state, pulsePr
         ext_pos.z += position[2];
         sensorsUsed++;
 
-        STATS_CNT_RATE_EVENT(&positionRate);
+        if (enableEstimator) {
+          STATS_CNT_RATE_EVENT(&positionRate);
+        }
       }
     }
   }
@@ -309,10 +311,10 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           if (enableEstimator) {
             estimatorEnqueueSweepAngles(&sweepInfo);
-          }
 
-          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-          STATS_CNT_RATE_EVENT(&positionRate);
+            STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+            STATS_CNT_RATE_EVENT(&positionRate);
+          }
         #endif
       }
 
@@ -326,10 +328,10 @@ static void estimatePositionSweepsLh1(const pulseProcessor_t* appState, pulsePro
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           if (enableEstimator) {
             estimatorEnqueueSweepAngles(&sweepInfo);
-          }
 
-          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-          STATS_CNT_RATE_EVENT(&positionRate);
+            STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+            STATS_CNT_RATE_EVENT(&positionRate);
+          }
         #endif
       }
     }
@@ -360,10 +362,10 @@ static void estimatePositionSweepsLh2(const pulseProcessor_t* appState, pulsePro
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           if (enableEstimator) {
             estimatorEnqueueSweepAngles(&sweepInfo);
-          }
 
-          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-          STATS_CNT_RATE_EVENT(&positionRate);
+            STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+            STATS_CNT_RATE_EVENT(&positionRate);
+          }
         #endif
       }
 
@@ -375,10 +377,10 @@ static void estimatePositionSweepsLh2(const pulseProcessor_t* appState, pulsePro
         #ifndef CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH
           if (enableEstimator) {
             estimatorEnqueueSweepAngles(&sweepInfo);
-          }
 
-          STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
-          STATS_CNT_RATE_EVENT(&positionRate);
+            STATS_CNT_RATE_EVENT(bsEstRates[baseStation]);
+            STATS_CNT_RATE_EVENT(&positionRate);
+          }
         #endif
       }
     }

--- a/test/deck/drivers/src/test_lps_twr_tag.c
+++ b/test/deck/drivers/src/test_lps_twr_tag.c
@@ -25,6 +25,10 @@ void arm_mean_f32(const float32_t * pSrc, uint32_t blockSize, float32_t * pResul
 
 #include "freertosMocks.h"
 
+// locoEnableEstimator is a global defined in locodeck.c, but that module is
+// mocked here. CMock only mocks functions, so provide the variable manually.
+uint8_t locoEnableEstimator = 1;
+
 static dwDevice_t dev;
 static lpsTwrAlgoOptions_t options;
 


### PR DESCRIPTION
## Summary

Adds two runtime parameters to enable/disable feeding lighthouse and Loco
positioning measurements into the state estimator (Kalman filter), without
otherwise shutting down those subsystems.

- `lighthouse.enableEst` — gates lighthouse crossing-beam position, sweep-angle, and yaw-error measurements
- `loco.enableEst` — gates Loco TWR/TDoA distance, TDoA, and absolute-height measurements

Both default to `1` (enabled, so behavior is unchanged out of the box) and are
`PARAM_PERSISTENT`, so a chosen setting survives reboot.

## Motivation

Allows comparing/combining positioning sources at runtime — e.g. fly on
lighthouse while keeping the Loco deck powered for logging, or temporarily cut
one source to diagnose estimator behavior — without reflashing or unplugging
hardware.

## Implementation

The measurements are gated at the source, right before each
`estimatorEnqueue*()` call, mirroring the existing compile-time
`CONFIG_DECK_LIGHTHOUSE_AS_GROUNDTRUTH` pattern:

- **Lighthouse** (`lighthouse_position_est.c`): new file-static `enableEstimator`
  guards the position, sweep-angle (×4) and yaw-error enqueues.
- **Loco** (`locodeck.c` + `locodeck.h`): new global `locoEnableEstimator`,
  declared `extern` in the header and checked by the three ranging algorithms
  (`lpsTwrTag`, `lpsTdoa2Tag`, `lpsTdoa3Tag`).