### PR TITLE
Added simple crash detection to supervisor

### DIFF
--- a/src/modules/src/Kconfig
+++ b/src/modules/src/Kconfig
@@ -293,6 +293,18 @@ config LOG_MOTOR_CAP_WARNING
 
 endmenu
 
+menu "Supervisor configuration"
+
+config SUPERVISOR_CRASH_DETECTION_G
+    int "Crash detection (Gs)"
+    range 0 20
+    default 0
+    help
+        Maximum allowed deviation from 1 G when evaluating tumble/crash
+        detection. A value of 0 disables the detection.
+
+endmenu
+
 menu "Parameter subsystem"
 
 config PARAM_SILENT_UPDATES

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -67,6 +67,8 @@
 static uint16_t preflightTimeoutDuration = PREFLIGHT_TIMEOUT_MS;
 static uint16_t landingTimeoutDuration = LANDING_TIMEOUT_MS;
 static uint16_t armingSpinupTimeoutDuration = ARMING_SPINUP_TIMEOUT_MS;
+static float crashDetectionGs = CONFIG_SUPERVISOR_CRASH_DETECTION_G;
+static float crashDetectionAccNorm;
 
 #ifdef CONFIG_MOTORS_ESC_PROTOCOL_DSHOT_BIDIRECTIONAL
 static uint16_t rpmCheckMin = CONFIG_MOTORS_ARMING_RPM_MIN;
@@ -308,12 +310,22 @@ static bool isFlyingCheck(SupervisorMem_t* this, const uint32_t tick) {
 //
 static bool isTumbledCheck(SupervisorMem_t* this, const sensorData_t *data, const uint32_t tick) {
   const float freeFallThreshold = 0.1;
+  const float oneG = 1.0f;
 
   const float acceptedTiltAccZ = SUPERVISOR_TUMBLE_CHECK_ACCEPTED_TILT_ACCZ;  // 60 degrees tilt (when stationary)
   const uint32_t maxTiltTime = M2T(SUPERVISOR_TUMBLE_CHECK_ACCEPTED_TILT_TIME);
 
   const float acceptedUpsideDownAccZ = SUPERVISOR_TUMBLE_CHECK_ACCEPTED_UPSIDEDOWN_ACCZ;
   const uint32_t maxUpsideDownTime = M2T(SUPERVISOR_TUMBLE_CHECK_ACCEPTED_UPSIDEDOWN_TIME);
+
+  crashDetectionAccNorm = sqrtf((data->acc.x * data->acc.x) + (data->acc.y * data->acc.y) + (data->acc.z * data->acc.z));
+
+  if (crashDetectionGs > 0.0f) {
+    if (fabsf(crashDetectionAccNorm - oneG) > crashDetectionGs) {
+      DEBUG_PRINT("Crash detected @ %.2f Gs (max %.2f)\n", (double)crashDetectionAccNorm, (double)crashDetectionGs);
+      return true;
+    }
+  }
 
   const bool isFreeFalling = (fabsf(data->acc.z) < freeFallThreshold && fabsf(data->acc.y) < freeFallThreshold && fabsf(data->acc.x) < freeFallThreshold);
   if (isFreeFalling) {
@@ -709,6 +721,10 @@ LOG_GROUP_START(supervisor)
  * Bit 11 = deck fault - a deck has reported a hardware fault
  */
 LOG_ADD(LOG_UINT16, info, &supervisorMem.infoBitfield)
+/**
+ * @brief Acceleration norm in Gs used by crash/tumble detection.
+ */
+LOG_ADD(LOG_FLOAT, accNorm, &crashDetectionAccNorm)
 LOG_GROUP_STOP(supervisor)
 
 
@@ -742,5 +758,11 @@ PARAM_ADD(PARAM_UINT8 | PARAM_PERSISTENT, tmblChckEn, &tumbleCheckEnabled)
  * @brief Motor spin-up wait timeout (ms) before arming is aborted
  */
 PARAM_ADD(PARAM_UINT16 | PARAM_PERSISTENT, spinupTimeout, &armingSpinupTimeoutDuration)
+
+/**
+ * @brief Crash detection threshold (Gs)
+ * Maximum allowed | |acc| - 1G | for tumble/crash detection. Set to 0 to disable.
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, crashDetectGs, &crashDetectionGs)
 
 PARAM_GROUP_STOP(supervisor)


### PR DESCRIPTION
This pull request introduces a configurable crash detection mechanism based on acceleration measurements to the supervisor module. The main changes add a new configuration option for crash detection sensitivity, update the supervisor logic to use this setting, and expose relevant parameters and logging for monitoring and tuning.

**Crash Detection Feature:**

* Added a new configuration option `SUPERVISOR_CRASH_DETECTION_G` in `Kconfig` to set the maximum allowed deviation from 1 G for crash/tumble detection. Setting this to 0 disables the feature.
* Implemented crash detection logic in `isTumbledCheck` in `supervisor.c`, which calculates the acceleration norm and triggers a crash if the deviation from 1 G exceeds the configured threshold.

**Parameter and Logging Integration:**

* Exposed the crash detection threshold as a persistent parameter `crashDetectGs` for runtime tuning.
* Added logging for the current acceleration norm (`accNorm`) used in crash/tumble detection, enabling monitoring via the logging subsystem.
* Declared and initialized variables for the crash detection threshold and acceleration norm in `supervisor.c`.