### PR TITLE
Reset pid controller when switching commander

### DIFF
--- a/src/modules/interface/stabilizer_types.h
+++ b/src/modules/interface/stabilizer_types.h
@@ -248,6 +248,16 @@ typedef enum mode_e {
   modeVelocity
 } stab_mode_t;
 
+typedef struct {
+  stab_mode_t x;
+  stab_mode_t y;
+  stab_mode_t z;
+  stab_mode_t roll;
+  stab_mode_t pitch;
+  stab_mode_t yaw;
+  stab_mode_t quat;
+} setpoint_mode_t;
+
 typedef struct setpoint_s {
   uint32_t timestamp;
 
@@ -261,15 +271,7 @@ typedef struct setpoint_s {
   jerk_t jerk;              // m/s^3
   bool velocity_body;       // true if velocity is given in body frame; false if velocity is given in world frame
 
-  struct {
-    stab_mode_t x;
-    stab_mode_t y;
-    stab_mode_t z;
-    stab_mode_t roll;
-    stab_mode_t pitch;
-    stab_mode_t yaw;
-    stab_mode_t quat;
-  } mode;
+  setpoint_mode_t mode;
 } setpoint_t;
 
 /** Estimate of position */

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -40,6 +40,15 @@ bool controllerPidTest(void)
   return pass;
 }
 
+static void controllerPidReinitialize(const state_t *state)
+{
+  positionControllerResetAllPID(state->position.x, state->position.y, state->position.z);
+  positionControllerResetAllfilters();
+  attitudeControllerResetAllPID(state->attitude.roll, state->attitude.pitch, state->attitude.yaw);
+  attitudeDesired.roll  = state->attitude.roll;
+  attitudeDesired.pitch = state->attitude.pitch;
+}
+
 static float capAngle(float angle) {
   float result = angle;
 
@@ -52,15 +61,6 @@ static float capAngle(float angle) {
   }
 
   return result;
-}
-
-static void controllerPidReinitialize(const state_t *state)
-{
-  positionControllerResetAllPID(state->position.x, state->position.y, state->position.z);
-  positionControllerResetAllfilters();
-  attitudeControllerResetAllPID(state->attitude.roll, state->attitude.pitch, state->attitude.yaw);
-  attitudeDesired.roll  = state->attitude.roll;
-  attitudeDesired.pitch = state->attitude.pitch;
 }
 
 static bool setpointModeChanged(const setpoint_t *setpoint)

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -79,7 +79,7 @@ void controllerPid(control_t *control, const setpoint_t *setpoint,
   control->controlMode = controlModeLegacy;
 
   if (setpointModeChanged(setpoint)) {
-    controllerPidReinitialize(state);
+    controllerPidReinitialize(state); // To prevent control bump
   }
 
   if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -57,6 +57,7 @@ static float capAngle(float angle) {
 static void controllerResetAllPids(const state_t *state)
 {
   positionControllerResetAllPID(state->position.x, state->position.y, state->position.z);
+  positionControllerResetAllfilters();
   attitudeControllerResetAllPID(state->attitude.roll, state->attitude.pitch, state->attitude.yaw);
   attitudeDesired.roll  = state->attitude.roll;
   attitudeDesired.pitch = state->attitude.pitch;

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -1,3 +1,4 @@
+#include <string.h>
 
 #include "stabilizer_types.h"
 
@@ -53,12 +54,32 @@ static float capAngle(float angle) {
   return result;
 }
 
+static void controllerResetAllPids(const state_t *state)
+{
+  positionControllerResetAllPID(state->position.x, state->position.y, state->position.z);
+  attitudeControllerResetAllPID(state->attitude.roll, state->attitude.pitch, state->attitude.yaw);
+  attitudeDesired.roll  = state->attitude.roll;
+  attitudeDesired.pitch = state->attitude.pitch;
+}
+
+static bool setpointModeChanged(const setpoint_t *setpoint)
+{
+  static setpoint_t prev; // only .mode is used; zero-init triggers reset on first tick
+  bool changed = (memcmp(&setpoint->mode, &prev.mode, sizeof(setpoint->mode)) != 0);
+  prev.mode = setpoint->mode;
+  return changed;
+}
+
 void controllerPid(control_t *control, const setpoint_t *setpoint,
                                          const sensorData_t *sensors,
                                          const state_t *state,
                                          const stabilizerStep_t stabilizerStep)
 {
   control->controlMode = controlModeLegacy;
+
+  if (setpointModeChanged(setpoint)) {
+    controllerResetAllPids(state);
+  }
 
   if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
     // Rate-controled YAW is moving YAW angle setpoint
@@ -108,16 +129,12 @@ void controllerPid(control_t *control, const setpoint_t *setpoint,
                                 attitudeDesired.roll, attitudeDesired.pitch, attitudeDesired.yaw,
                                 &rateDesired.roll, &rateDesired.pitch, &rateDesired.yaw);
 
-    // For roll and pitch, if velocity mode, overwrite rateDesired with the setpoint
-    // value. Also reset the PID to avoid error buildup, which can lead to unstable
-    // behavior if level mode is engaged later
+    // For roll and pitch, if velocity mode, overwrite rateDesired with the setpoint value
     if (setpoint->mode.roll == modeVelocity) {
       rateDesired.roll = setpoint->attitudeRate.roll;
-      attitudeControllerResetRollAttitudePID(state->attitude.roll);
     }
     if (setpoint->mode.pitch == modeVelocity) {
       rateDesired.pitch = setpoint->attitudeRate.pitch;
-      attitudeControllerResetPitchAttitudePID(state->attitude.pitch);
     }
 
     // TODO: Investigate possibility to subtract gyro drift.
@@ -154,8 +171,7 @@ void controllerPid(control_t *control, const setpoint_t *setpoint,
     cmd_pitch = control->pitch;
     cmd_yaw = control->yaw;
 
-    attitudeControllerResetAllPID(state->attitude.roll, state->attitude.pitch, state->attitude.yaw);
-    positionControllerResetAllPID(state->position.x, state->position.y, state->position.z);
+    controllerResetAllPids(state);
 
     // Reset the calculated YAW angle for rate control
     attitudeDesired.yaw = state->attitude.yaw;

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -65,10 +65,10 @@ static float capAngle(float angle) {
 
 static bool setpointModeChanged(const setpoint_t *setpoint)
 {
-  static setpoint_t prev; // only .mode is used; zero-init triggers reset on first tick
-  bool changed = (memcmp(&setpoint->mode, &prev.mode, sizeof(setpoint->mode)) != 0);
-  prev.mode = setpoint->mode;
-  return changed;
+  static setpoint_mode_t previous_mode; // zero-init triggers reset on first tick
+  bool is_mode_changed = (memcmp(&setpoint->mode, &previous_mode, sizeof(previous_mode)) != 0);
+  previous_mode = setpoint->mode;
+  return is_mode_changed;
 }
 
 void controllerPid(control_t *control, const setpoint_t *setpoint,

--- a/src/modules/src/controller/controller_pid.c
+++ b/src/modules/src/controller/controller_pid.c
@@ -54,7 +54,7 @@ static float capAngle(float angle) {
   return result;
 }
 
-static void controllerResetAllPids(const state_t *state)
+static void controllerPidReinitialize(const state_t *state)
 {
   positionControllerResetAllPID(state->position.x, state->position.y, state->position.z);
   positionControllerResetAllfilters();
@@ -79,7 +79,7 @@ void controllerPid(control_t *control, const setpoint_t *setpoint,
   control->controlMode = controlModeLegacy;
 
   if (setpointModeChanged(setpoint)) {
-    controllerResetAllPids(state);
+    controllerPidReinitialize(state);
   }
 
   if (RATE_DO_EXECUTE(ATTITUDE_RATE, stabilizerStep)) {
@@ -172,7 +172,7 @@ void controllerPid(control_t *control, const setpoint_t *setpoint,
     cmd_pitch = control->pitch;
     cmd_yaw = control->yaw;
 
-    controllerResetAllPids(state);
+    controllerPidReinitialize(state);
 
     // Reset the calculated YAW angle for rate control
     attitudeDesired.yaw = state->attitude.yaw;

--- a/src/modules/src/kalman_core/mm_tdoa.c
+++ b/src/modules/src/kalman_core/mm_tdoa.c
@@ -69,7 +69,7 @@ void kalmanCoreUpdateWithTdoa(kalmanCoreData_t* this, tdoaMeasurement_t *tdoa, c
     h[KC_STATE_Y] = (dy1 / d1 - dy0 / d0);
     h[KC_STATE_Z] = (dz1 / d1 - dz0 / d0);
 
-  #if CONFIG_ESTIMATOR_KALMAN_TDOA_OUTLIERFILTER_FALLBACK
+    #if CONFIG_ESTIMATOR_KALMAN_TDOA_OUTLIERFILTER_FALLBACK
     vector_t jacobian = {
       .x = h[KC_STATE_X],
       .y = h[KC_STATE_Y],


### PR DESCRIPTION
# Issue Summary: PID Integral Corruption on Commander Handover

## Background

@ShuqinZ, among others, have sometimes noticed a large transient when switching from the low-level commander (LLC) to the high-level commander (HLC). Furthermore, @ShuqinZ discovered and verified that resetting the integral parts of the PID controllers when changing to HLC solved the issue. See #1627 for more information.

## Issue Analysis

The Crazyflie PID position controller runs two cascaded loops at 100 Hz: an outer position PID producing a velocity setpoint, and an inner velocity PID producing attitude/thrust commands. When the high-level commander (HLC) is active, both loops run and their outputs are used. When the low-level commander (LLC) is active (e.g. raw RPYT packets), the velocity PID outputs are silently overridden by the raw setpoint values — but the PIDs still run and their integrals keep accumulating.

The attitude controller runs at 500 Hz.

The velocity PIDs (`pidVX`, `pidVY`, `pidVZ`) run unconditionally every tick regardless of the active setpoint mode. When LLC sends raw attitude commands, the mode flags are `modeDisable`, causing the velocity PID outputs to be discarded (`controller_pid.c:99–105`). Meanwhile the PIDs accumulate error against actual body velocity, which has no reason to match the zero velocity setpoint. With `ki_Z = 15.0`, even one second of 0.15 m/s vertical motion adds 2.25 to `VZi` immediately on resuming position control.

When the LLC stops and the HLC resumes, the corrupted integrals produce a large, sudden attitude/thrust correction — causing a visible jitter or lurch at the transition. This can happen in x, y or z direction.

A timing subtlety: if there is a pause between `notify_setpoint_stop` and the first HLC command, the stopped planner issues a `nullSetpoint` (all modes `modeDisable`, thrust = 0), which triggers the existing `thrust == 0` safety block and resets all PIDs. So the corruption is only visible when the `go_to` command arrives fast enough to prevent that reset — specifically with `--no-pause-before-hlc`.

## Proposed Solution

Reset all position and attitude PIDs whenever the setpoint mode changes. The reason for resetting all controllers on any mode change (compared to supervising each controller and its mode) is that many of the controllers are coupled. This means that a change in a mode for one controller would need to reset another controller. Resetting everything is a simple solution, and a good start. If customers experience issues due to this strategy, we can do an overhaul.

A static `prevSetpoint.mode` is compared each tick at the top of `controllerPid`. On any change, `positionControllerResetAllPID` and `attitudeControllerResetAllPID` are called, and `attitudeDesired.roll/pitch` is snapped to the current state so the attitude controller holds level during the up-to-10 ms gap before the next 100 Hz position controller tick. The existing per-tick `modeVelocity` attitude resets are removed since the mode-change reset subsumes them.

This approach is decoupled from the commander: the controller detects the transition itself from the setpoint it receives, making behaviour predictable regardless of timing between `notify_setpoint_stop` and the first HLC command.

## Results

The tests try to reproduce and demonstrate the results of the fix, using the Z axis as example. The Z has a larger coefficient for the I part, which means less time spent using the LLC to visualize the effect.

Each test runs three phases:

- **Phase 1** — HLC hover settle: the drone takes off and holds position under HLC control.
- **Phase 2** — LLC takes over: integrals build up for controllers which output is unused.
- **Phase 3** — HLC switch-back: `notify_setpoint_stop` is called and HLC resumes with a `go_to` command to the current position. The effect of the corrupted integrals is observable here.

Three scenarios have been run:

- **Scenario A** — LLC takes over at altitude 1.5 m and descends to around 0.5 m, where command is handed over to HLC. The drone is still descending at handover.
- **Scenario B** — LLC only hovers.
- **Scenario C** — LLC takes over at altitude 1.5 m and descends to around 0.5 m, and reaches hovering before command is handed over to HLC.

### Scenario A

#### Before fix — integral build up with no reset

Velocity Z integral `posCtl.VZi` builds up during the LLC in phase 2 and corrupts the first position-control thrust command, causing a visible altitude lurch and an audible thrust boost when entering phase 3 (HLC).

<img width="1367" height="937" alt="image" src="https://github.com/user-attachments/assets/fe687087-bb98-480c-bf9e-5b092e15c247" />

#### After fix — PID reset at mode switch

On mode change the integrals are reset. The transition is smooth. There is a substantial undershoot though, due to integrals being reset while the the drone is moving.

<img width="1288" height="937" alt="image" src="https://github.com/user-attachments/assets/d6a9fabf-debd-4d69-901f-5961b5b57727" />

### Scenario B — Steady-state handover

#### After fix

In this setup, the LLC is hovering, which gives the cleanest handover to HLC (phase 3).

There is a feedforward term, `thrustBase`, which should represent the thrust needed to hover. This does most of the initial compensation. This also means that a handover in hover state should be smooth. In the case of the Brushless, which this is, `thrustBase` is about 10 % lower than needed, which gives the initial dip. The dip is a lot less than in the dynamic handover case above, however.

<img width="1327" height="890" alt="image" src="https://github.com/user-attachments/assets/7da2cfac-9f9a-41ba-8966-f736667d7b6e" />

### Scenario C

In this example, integrals build up during LLC descent. The LLC then tries to reach hover (z velocity close to 0), before handing over to HLC. 

#### Before fix

<img width="809" height="754" alt="image" src="https://github.com/user-attachments/assets/447dc533-e710-4112-9634-7beca9a69bf0" />

#### After fix

<img width="809" height="754" alt="image" src="https://github.com/user-attachments/assets/f296b79a-682b-41c1-83d7-2087c8d95ce9" />

#### Comparison

The image is zoomed in; only last part of phase 2 and the first part of phase 3 are seen.

To the left: Before the fix. This creates a control bump of approximately 20 cm.

To the right: After the fix. Undershoot of about 7 cm.

<img width="1791" height="827" alt="image" src="https://github.com/user-attachments/assets/b9f47e6c-e765-47b9-b2d2-0110eac587cd" />


# Conclusions

Resetting all PID controllers is a good place to start. This should solve the problems for all axes, and for all cases when switching commander. Even though the steady-state handover in the simplest case going from HLC to LLC to HLC is probably better with the old strategy (since the I part should be exactly correct after HLC has found it after its first run), the dip seen with the new strategy is acceptable and avoids the worst cases. Also, the new strategy gives an honest and clear state of the controllers, and make it easier to improve if needed.
