### PR TITLE
Fix FP32 to FP16 conversion

### DIFF
--- a/src/utils/src/num.c
+++ b/src/utils/src/num.c
@@ -58,7 +58,7 @@ uint16_t single2half(float number)
     if (e<(127-15))
         return 0; //Do not handle generating subnormalised representation
 
-    return (s<<15) | ((e-127+15)<<10) + (((num>>13)&0x3FF)+((num>>12)&0x01));
+    return (s<<15) | (((e-127+15)<<10) + (((num>>13)&0x3FF)+((num>>12)&0x01)));
 }
 
 float half2single(uint16_t number)

--- a/src/utils/src/num.c
+++ b/src/utils/src/num.c
@@ -58,7 +58,7 @@ uint16_t single2half(float number)
     if (e<(127-15))
         return 0; //Do not handle generating subnormalised representation
 
-    return (s<<15) | ((e-127+15)<<10) | (((num>>13)&0x3FF)+((num>>12)&0x01));
+    return (s<<15) | ((e-127+15)<<10) + (((num>>13)&0x3FF)+((num>>12)&0x01));
 }
 
 float half2single(uint16_t number)

--- a/test/utils/src/test_num.c
+++ b/test/utils/src/test_num.c
@@ -1,6 +1,177 @@
 #include "unity.h"
 #include "num.h"
 
+#include <math.h>
+
+static float floatFromBits(uint32_t bits) {
+  union {
+    uint32_t asBits;
+    float asFloat;
+  } u;
+
+  u.asBits = bits;
+  return u.asFloat;
+}
+
+
+void testThatSingle2halfConvertsZero() {
+  // Fixture
+  float value = 0.0f;
+  uint16_t expected = 0x0000;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsOne() {
+  // Fixture
+  float value = 1.0f;
+  uint16_t expected = 0x3C00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsNegativeOne() {
+  // Fixture
+  float value = -1.0f;
+  uint16_t expected = 0xBC00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsFractionalValue() {
+  // Fixture
+  float value = 2.5f;
+  uint16_t expected = 0x4100;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfHandlesRoundingCarryIntoExponent() {
+  // Fixture
+  // Mantissa bits [22:13] are all 1 and the rounding bit [12] is 1, so
+  // rounding the 23-bit mantissa down to 10 bits overflows and must carry
+  // into the exponent field.
+  float value = floatFromBits(0x3FFFF000); // 1.99951171875f, rounds to 2.0 in fp16
+  uint16_t expected = 0x4000; // 2.0
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsMaxFiniteValue() {
+  // Fixture
+  float value = 65504.0f; // largest finite value representable in fp16
+  uint16_t expected = 0x7BFF;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfClampsPositiveOverflowToInfinity() {
+  // Fixture
+  float value = 1.0e10f; // exponent too large to fit in fp16
+  uint16_t expected = 0x7C00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfClampsNegativeOverflowToInfinity() {
+  // Fixture
+  float value = -1.0e10f; // exponent too large to fit in fp16
+  uint16_t expected = 0xFC00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsPositiveInfinity() {
+  // Fixture
+  float value = INFINITY;
+  uint16_t expected = 0x7C00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsNegativeInfinity() {
+  // Fixture
+  float value = -INFINITY;
+  uint16_t expected = 0xFC00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfConvertsNaN() {
+  // Fixture
+  float value = NAN;
+  uint16_t expected = 0x7E00;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
+
+void testThatSingle2halfFlushesTinyValueToZero() {
+  // Fixture
+  float value = 1.0e-10f; // normalized, but below fp16's minimum normal magnitude
+  uint16_t expected = 0x0000;
+
+  // Test
+  uint16_t actual = single2half(value);
+
+  // Assert
+  TEST_ASSERT_EQUAL_HEX16(expected, actual);
+}
+
 
 void testThatLimitUint16NotLimitInRange() {
   // Fixture


### PR DESCRIPTION
`single2half()` joined the exponent and rounded mantissa with `|`. However, when rounding overflows the mantissa to `0x400`, the carry bit lands on the exponent's lowest bit. If that bit is `1`, the `|` operator drops the carry bit, resulting in a value 2× too small (which showed up as position spikes in my telemetry logs). 

This only happens for values where the upper 11 bits of the mantissa of the FP32 are `1` and where the exponent is odd.

**Fix:**
Use `+` instead of `|` so the carry bit properly propagates to the exponent.

Before the fix:
`single2half(0.49999f)` -> `0.25`

After the fix:
`single2half(0.49999f)` -> `0.5`