### PR TITLE
Made configUSE_TRACE_FACILITY kbuild configurable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -24,6 +24,14 @@ config DEBUG_QUEUE_MONITOR
     help
         Enable the queue monitoring functionality.
 
+config FREERTOS_USE_TRACE_FACILITY
+    bool "Enable sysload stats (FreeRTOS trace facility)"
+    default y
+    help
+        Enable FreeRTOS trace hooks and APIs such as uxTaskGetSystemState().
+        Disable to reduce cpu load if runtime task statistics are not
+        needed.
+
 config DEBUG_ENABLE_LED_MORSE
     bool "Enable blinking morse sequence with LEDs"
     default n

--- a/Kconfig
+++ b/Kconfig
@@ -17,20 +17,21 @@ config DEBUG
     help
         Enable debug symbols and extra output from firmware.
 
-config DEBUG_QUEUE_MONITOR
-    bool "Enable debug queue monitoring"
-    depends on DEBUG
-    default n
-    help
-        Enable the queue monitoring functionality.
-
 config FREERTOS_USE_TRACE_FACILITY
     bool "Enable sysload stats (FreeRTOS trace facility)"
     default y
     help
         Enable FreeRTOS trace hooks and APIs such as uxTaskGetSystemState().
-        Disable to reduce cpu load if runtime task statistics are not
+        Disable to reduce CPU load if runtime task statistics are not
         needed.
+
+config DEBUG_QUEUE_MONITOR
+    bool "Enable debug queue monitoring"
+    depends on DEBUG 
+    depends on FREERTOS_USE_TRACE_FACILITY
+    default n
+    help
+        Enable the queue monitoring functionality.
 
 config DEBUG_ENABLE_LED_MORSE
     bool "Enable blinking morse sequence with LEDs"

--- a/src/config/FreeRTOSConfig.h
+++ b/src/config/FreeRTOSConfig.h
@@ -90,6 +90,12 @@
 #define configUSE_MALLOC_FAILED_HOOK 1
 #define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 4)
 
+#ifdef CONFIG_FREERTOS_USE_TRACE_FACILITY
+  #define configUSE_TRACE_FACILITY 1
+#else
+  #define configUSE_TRACE_FACILITY 0
+#endif
+
 #define configMAX_PRIORITIES		( 6 )
 #define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
 

--- a/src/config/trace.h
+++ b/src/config/trace.h
@@ -27,7 +27,7 @@
 #ifndef __TRACE_H__
 #define __TRACE_H__
 
-#define configUSE_TRACE_FACILITY	1
+#include "autoconf.h"
 
 // ITM useful macros
 #ifndef ITM_NO_OVERFLOW
@@ -49,9 +49,11 @@
 #define ITM_BLOCKING_ON_QUEUE_RECEIVE 0x0300
 #define ITM_BLOCKING_ON_QUEUE_SEND 0x0400
 
+#ifdef CONFIG_FREERTOS_USE_TRACE_FACILITY
 #define traceQUEUE_SEND(xQueue) ITM_SEND(3, ITM_QUEUE_SEND | ((xQUEUE *) xQueue)->uxQueueNumber)
 #define traceQUEUE_SEND_FAILED(xQueue) ITM_SEND(3, ITM_QUEUE_FAILED | ((xQUEUE *) xQueue)->uxQueueNumber)
 #define traceBLOCKING_ON_QUEUE_RECEIVE(xQueue) ITM_SEND(3, ITM_BLOCKING_ON_QUEUE_RECEIVE | ((xQUEUE *) xQueue)->uxQueueNumber)
 #define traceBLOCKING_ON_QUEUE_SEND(xQueue) ITM_SEND(3, ITM_BLOCKING_ON_QUEUE_SEND | ((xQUEUE *) xQueue)->uxQueueNumber)
+#endif
 
 #endif

--- a/src/modules/interface/queuemonitor.h
+++ b/src/modules/interface/queuemonitor.h
@@ -39,7 +39,7 @@
 
   void qm_traceQUEUE_SEND(void* xQueue);
   void qm_traceQUEUE_SEND_FAILED(void* xQueue);
-  void qmRegisterQueue(xQueueHandle* xQueue, char* fileName, char* queueName);
+  void qmRegisterQueue(xQueueHandle xQueue, char* fileName, char* queueName);
 #else
   #define DEBUG_QUEUE_MONITOR_REGISTER(queue)
 #endif // CONFIG_DEBUG_QUEUE_MONITOR

--- a/src/modules/src/queuemonitor.c
+++ b/src/modules/src/queuemonitor.c
@@ -61,8 +61,8 @@ static void timerHandler(xTimerHandle timer);
 static void debugPrint();
 static bool filter(Data* queueData);
 static void debugPrintQueue(Data* queueData);
-static Data* getQueueData(xQueueHandle* xQueue);
-static int getMaxWaiting(xQueueHandle* xQueue, int prevPeak);
+static Data* getQueueData(xQueueHandle xQueue);
+static int getMaxWaiting(xQueueHandle xQueue, int prevPeak);
 static void resetCounters();
 
 unsigned char ucQueueGetQueueNumber( xQueueHandle xQueue );
@@ -97,7 +97,7 @@ void qm_traceQUEUE_SEND_FAILED(void* xQueue) {
   }
 }
 
-void qmRegisterQueue(xQueueHandle* xQueue, char* fileName, char* queueName) {
+void qmRegisterQueue(xQueueHandle xQueue, char* fileName, char* queueName) {
   ASSERT(initialized);
   ASSERT(nrOfQueues < MAX_NR_OF_QUEUES);
   Data* queueData = &data[nrOfQueues];
@@ -109,13 +109,13 @@ void qmRegisterQueue(xQueueHandle* xQueue, char* fileName, char* queueName) {
   nrOfQueues++;
 }
 
-static Data* getQueueData(xQueueHandle* xQueue) {
+static Data* getQueueData(xQueueHandle xQueue) {
   unsigned char number = uxQueueGetQueueNumber(xQueue);
   ASSERT(number < MAX_NR_OF_QUEUES);
   return &data[number];
 }
 
-static int getMaxWaiting(xQueueHandle* xQueue, int prevPeak) {
+static int getMaxWaiting(xQueueHandle xQueue, int prevPeak) {
   // We get here before the current item is added to the queue.
   // Must add 1 to get the peak value.
   unsigned portBASE_TYPE waiting = uxQueueMessagesWaitingFromISR(xQueue) + 1;

--- a/src/modules/src/sysload.c
+++ b/src/modules/src/sysload.c
@@ -43,6 +43,10 @@ static void timerHandler(xTimerHandle timer);
 static bool initialized = false;
 static uint8_t triggerDump = 0;
 
+static StaticTimer_t timerBuffer;
+
+#if (configUSE_TRACE_FACILITY == 1)
+
 typedef struct {
   uint32_t ulRunTimeCounter;
   uint32_t xTaskNumber;
@@ -52,8 +56,7 @@ typedef struct {
 NO_DMA_CCM_SAFE_ZERO_INIT static taskData_t previousSnapshot[TASK_MAX_COUNT];
 static int taskTopIndex = 0;
 static uint32_t previousTotalRunTime = 0;
-
-static StaticTimer_t timerBuffer;
+#endif
 
 void sysLoadInit() {
   ASSERT(!initialized);
@@ -64,7 +67,7 @@ void sysLoadInit() {
   initialized = true;
 }
 
-
+#if (configUSE_TRACE_FACILITY == 1)
 static taskData_t* getPreviousTaskData(uint32_t xTaskNumber) {
   // Try to find the task in the list of tasks
   for (int i = 0; i < taskTopIndex; i++) {
@@ -82,9 +85,11 @@ static taskData_t* getPreviousTaskData(uint32_t xTaskNumber) {
 
   return result;
 }
+#endif
 
 static void timerHandler(xTimerHandle timer) {
   if (triggerDump != 0) {
+#if (configUSE_TRACE_FACILITY == 1)
     uint32_t totalRunTime;
 
     TaskStatus_t taskStats[TASK_MAX_COUNT];
@@ -112,6 +117,9 @@ static void timerHandler(xTimerHandle timer) {
     }
 
     previousTotalRunTime = totalRunTime;
+#else
+    DEBUG_PRINT("Task dump unavailable, CONFIG_FREERTOS_USE_TRACE_FACILITY is disabled\n");
+#endif
 
     triggerDump = 0;
   }


### PR DESCRIPTION
This pull request introduces a new configuration option to enable or disable FreeRTOS trace facility support, improving flexibility and reducing CPU load when runtime task statistics are not needed. It refactors the codebase to conditionally include trace-related code and APIs based on this configuration, ensuring that sysload statistics and queue tracing are only enabled when required.

**Configuration and Build System:**
* Added a new `FREERTOS_USE_TRACE_FACILITY` option to `Kconfig` to control enabling of FreeRTOS trace hooks and APIs, such as `uxTaskGetSystemState()`. This allows users to disable runtime task statistics for reduced CPU load.
* Updated `FreeRTOSConfig.h` to define `configUSE_TRACE_FACILITY` based on the new configuration option, ensuring consistent usage throughout the codebase.
* Removed the hardcoded definition of `configUSE_TRACE_FACILITY` from `trace.h` and included `autoconf.h` for configuration management.

**Conditional Compilation and Code Refactoring:**
* Wrapped trace macro definitions in `trace.h` and sysload statistics code in `sysload.c` with checks for `CONFIG_FREERTOS_USE_TRACE_FACILITY` and `configUSE_TRACE_FACILITY`, so trace features are only compiled when enabled. [[1]](diffhunk://#diff-763380cfc16d33f9fe20a6b7868f619884e1c8dd1b20f40742fa3042a1c5e05cR52-R57) [[2]](diffhunk://#diff-1857e3eb2c018a0576276e7c5b4374bfe2e7b196cdd3a12fa682688cb5d662e4R46-R49) [[3]](diffhunk://#diff-1857e3eb2c018a0576276e7c5b4374bfe2e7b196cdd3a12fa682688cb5d662e4L55-R59) [[4]](diffhunk://#diff-1857e3eb2c018a0576276e7c5b4374bfe2e7b196cdd3a12fa682688cb5d662e4L67-R70) [[5]](diffhunk://#diff-1857e3eb2c018a0576276e7c5b4374bfe2e7b196cdd3a12fa682688cb5d662e4R88-R92)
* Updated the sysload timer handler to print a debug message when trace facility is disabled, instead of attempting to dump task statistics.