### PR TITLE
Add a parameter to turn the radio off while charging

### DIFF
--- a/src/hal/interface/radiolink.h
+++ b/src/hal/interface/radiolink.h
@@ -54,6 +54,7 @@ void radiolinkSetChannel(uint8_t channel);
 void radiolinkSetDatarate(uint8_t datarate);
 void radiolinkSetAddress(uint64_t address);
 void radiolinkSetPowerDbm(int8_t powerDbm);
+void radiolinkSendDisableOnUsb(void);
 void radiolinkSyslinkDispatch(SyslinkPacket *slp);
 struct crtpLinkOperations * radiolinkGetLink();
 bool radiolinkSendP2PPacketBroadcast(P2PPacket *p2pp);

--- a/src/hal/interface/syslink.h
+++ b/src/hal/interface/syslink.h
@@ -51,6 +51,7 @@
 #define SYSLINK_RADIO_P2P_ACK       0x09
 #define SYSLINK_RADIO_P2P_BROADCAST 0x0A
 #define SYSLINK_RADIO_READY         0x0B
+#define SYSLINK_RADIO_DISABLE_ON_USB 0x0C
 
 #define SYSLINK_PM_GROUP              0x10
 #define SYSLINK_PM_SOURCE             0x10

--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -44,6 +44,7 @@
 #include "queuemonitor.h"
 #include "static_mem.h"
 #include "cfassert.h"
+#include "param.h"
 
 #define RADIOLINK_TX_QUEUE_SIZE (1)
 #define RADIOLINK_CRTP_QUEUE_SIZE (5)
@@ -58,6 +59,8 @@ static xQueueHandle crtpPacketDelivery;
 STATIC_MEM_QUEUE_ALLOC(crtpPacketDelivery, RADIOLINK_CRTP_QUEUE_SIZE, sizeof(CRTPPacket));
 
 static bool isInit;
+
+static uint8_t disableRadioOnUsb = 0;
 
 static int radiolinkSendCRTPPacket(CRTPPacket *p);
 static int radiolinkSetEnable(bool enable);
@@ -147,6 +150,16 @@ void radiolinkSetPowerDbm(int8_t powerDbm)
   slp.type = SYSLINK_RADIO_POWER;
   slp.length = 1;
   slp.data[0] = powerDbm;
+  syslinkSendPacket(&slp);
+}
+
+void radiolinkSendDisableOnUsb(void)
+{
+  SyslinkPacket slp;
+
+  slp.type = SYSLINK_RADIO_DISABLE_ON_USB;
+  slp.length = 1;
+  slp.data[0] = disableRadioOnUsb ? 1 : 0;
   syslinkSendPacket(&slp);
 }
 
@@ -298,3 +311,17 @@ LOG_ADD_CORE(LOG_UINT16, numRxBc, &count_rx_broadcast)
  */
 LOG_ADD_CORE(LOG_UINT16, numRxUc, &count_rx_unicast)
 LOG_GROUP_STOP(radio)
+
+/**
+ * Radio link parameters.
+ */
+PARAM_GROUP_START(radio)
+/**
+ * @brief Turn the radio off while the Crazyflie is plugged in (default: 0)
+ *
+ * When different than 0, the nRF51 turns the radio off as long as a USB cable is connected.
+ * This keeps charging drones from showing up in radio scans and from being
+ * connected to. Unplugging the cable turns the radio back on without a reboot.
+ */
+PARAM_ADD_WITH_CALLBACK(PARAM_UINT8 | PARAM_PERSISTENT, disableRadioOnUsb, &disableRadioOnUsb, radiolinkSendDisableOnUsb)
+PARAM_GROUP_STOP(radio)

--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -868,6 +868,7 @@ static bool persistentParamFromStorage(const char *key, void *buffer, size_t len
 
   if (PARAM_VARID_IS_VALID(varId)) {
     paramSet(varId.index, buffer);
+    paramNotifyChanged(varId.index);
   }
 
   return true;


### PR DESCRIPTION
**Paired with: bitcraze/crazyflie2-nrf-firmware#123**

Crazyflie drones have to be powered on to charge, so drones sitting on a charging rack answer radio scans exactly like flight-ready ones. This costs time, and a charging drone can unintentionally be sent flight commands. I believe this can't be filtered client-side since the ACK that makes a drone appear in a scan is generated by the nRF51 radio itself, so a charging drone and a flight-ready one are indistinguishable at scan time.

**Fix:**
Add the parameter `disableRadioOnUsb` (persistent, default `0`, set to `1` to enable). The rule is applied by the nRF51, which owns both the radio and the USB detection. This PR only sends the preference, over a new `SYSLINK_RADIO_DISABLE_ON_USB` (`0x0C`), from the param callback.

Before the fix:
charging drone -> detected in a scan and answers like a flight-ready drone

After the fix (with both the STM32 and the nRF51 flashed):
charging drone -> same as a powered-off drone, and radio back on unplug without a reboot

Inert on its own: nothing acts on `SYSLINK_RADIO_DISABLE_ON_USB` until the nRF51 PR lands, so the two can be merged in any order.

**Also in this PR:**
The first commit fixes `persistentParamFromStorage()` calling `paramSet()` without `paramNotifyChanged()`, so a param declared with `PARAM_ADD_WITH_CALLBACK` was only notified on a client write, never when its value was restored at boot. Without it, a Crazyflie rebooting while plugged in keeps the value but never tells the nRF51.