### PR TITLE
Fixed STORED_ANGLE_SCALE in compressed trajectories

### DIFF
--- a/src/modules/src/pptraj_compressed.c
+++ b/src/modules/src/pptraj_compressed.c
@@ -36,7 +36,7 @@
 #define STORED_DISTANCE_SCALE 1000.0
 
 // In the stored version, we store angles in 1/10th degrees, hence this factor
-#define STORED_ANGLE_SCALE 0.1
+#define STORED_ANGLE_SCALE (1800.0f / M_PI_F)
 
 // Numbers of control points that we store for each storage method. Note that
 // we always store one less than the degree because the first control point of


### PR DESCRIPTION
This fix comes straight from #1659.