### PR TITLE
fix: gate DeckCtrl unit tests on CONFIG_DECK_BACKEND_DECKCTRL

### DIFF
--- a/test/deck/api/test_deckctrl_gpio.c
+++ b/test/deck/api/test_deckctrl_gpio.c
@@ -1,3 +1,5 @@
+// @IGNORE_IF_NOT CONFIG_DECK_BACKEND_DECKCTRL
+
 #include <stdint.h>
 #include <string.h>
 

--- a/test/deck/backends/test_deck_backend_deckctrl.c
+++ b/test/deck/backends/test_deck_backend_deckctrl.c
@@ -1,3 +1,5 @@
+// @IGNORE_IF_NOT CONFIG_DECK_BACKEND_DECKCTRL
+
 #include <stdint.h>
 #include <string.h>
 


### PR DESCRIPTION
Both tests compile modules that Kbuild gates on
CONFIG_DECK_BACKEND_DECKCTRL, but neither declared that dependency, so the harness built them in configs where the backend is off.

test_deck_backend_deckctrl.c broke the allnoconfig CI job: deck_backend_deckctrl.c sizes its arrays with
CONFIG_DECK_BACKEND_DECKCTRL_MAX_DECKS, which Kconfig only defines when the backend is enabled. test_deckctrl_gpio.c has the same undeclared dependency and only builds today because deckctrl_gpio.c happens to use no CONFIG_ symbols.

Add @IGNORE_IF_NOT so both are skipped when the backend is disabled, matching the existing lighthouse and loco tests.