### PR TITLE
Update CI versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,9 @@ permissions:
 
 jobs:
   read_targets_from_file:
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@cc82f0e5999c39eff964dd73ce9363e94d5b5b76
+    # TODO: temporarily pinned to the bitcraze/workflows PR branch HEAD for
+    # verification; update to the real commit SHA once that PR merges to main.
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@2284e0bfa7ceefcf85bc28eff99b19cd0a7ff0d7
     with:
       target_file: './build_targets.json'
 
@@ -34,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 
@@ -42,7 +44,7 @@ jobs:
       run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build UNIT_TEST_STYLE=min"
 
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.platform }}-${{ github.sha }}
         path: |
@@ -78,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 
@@ -107,7 +109,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 
@@ -131,7 +133,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,9 +19,7 @@ permissions:
 
 jobs:
   read_targets_from_file:
-    # TODO: temporarily pinned to the bitcraze/workflows PR branch HEAD for
-    # verification; update to the real commit SHA once that PR merges to main.
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@2284e0bfa7ceefcf85bc28eff99b19cd0a7ff0d7
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@41b8cc3c616fd6fad685c3411f21f72646333b19
     with:
       target_file: './build_targets.json'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   read_targets_from_file:
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@cc82f0e5999c39eff964dd73ce9363e94d5b5b76
+    # TODO: temporarily pinned to the bitcraze/workflows PR branch HEAD for
+    # verification; update to the real commit SHA once that PR merges to main.
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@2284e0bfa7ceefcf85bc28eff99b19cd0a7ff0d7
     with:
       target_file: './build_targets.json'
 
@@ -33,7 +35,7 @@ jobs:
     - name: Release URL on file
       run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
     - name: Save Release URL File For Uploading Files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release_url
         path: release_url.txt
@@ -51,7 +53,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 
@@ -59,7 +61,7 @@ jobs:
       run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build PLATFORM=${{ matrix.platform }} UNIT_TEST_STYLE=min"
 
     - name: Load Release URL File from release job
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: release_url
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,7 @@ permissions:
 
 jobs:
   read_targets_from_file:
-    # TODO: temporarily pinned to the bitcraze/workflows PR branch HEAD for
-    # verification; update to the real commit SHA once that PR merges to main.
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@2284e0bfa7ceefcf85bc28eff99b19cd0a7ff0d7
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@41b8cc3c616fd6fad685c3411f21f72646333b19
     with:
       target_file: './build_targets.json'
 


### PR DESCRIPTION
- Update actions versions
- Update workflows versions to branch versions.

Analysis shows that breaking changes for updated versions have no effect in this repository.

NOTE: Workflows versions currently point to branch versions. Should be updated to `main` version when https://github.com/bitcraze/workflows/pull/3 has been merged.

## Verification plan
- Run CI.yml
- Run release.yml
  - Delete release candidate and tag when verification is done

## Verification table

| # | Item | Expected | Result | Notes |
|---|------|----------|--------|-------|
| 1 | `CI.yml` → `read_targets_from_file` | no Node 20 warning | Pass | run `30981424835`, job passed, no match in full run log grep |
| 2 | `CI.yml` → `basic_build` | no Node 20 warning | Pass | all 5 variants (tag, cf21bl, cf2, flapper, bolt) passed, no match |
| 3 | `CI.yml` → `features` | no Node 20 warning | Pass | all 7 configs passed, no match |
| 4 | `CI.yml` → `apps` | no Node 20 warning | Pass | all 9 apps passed, no match |
| 5 | `CI.yml` → `kbuild-targets` | no Node 20 warning | Pass | randconfig/allnoconfig passed; allyesconfig failed at `build` step (CCMRAM overflow, pre-existing/expected, unrelated to this fix) — no Node warning in any of the three |
| 6 | `CI.yml` → `kbuild-targets-random` | no Node 20 warning | Pass | covered by row 5 (`randconfig`) |
| 7 | `CI.yml` run overall | green: build succeeds, artifacts upload | Pass* | *one pre-existing/expected failure (`allyesconfig` CCMRAM overflow), unrelated to version bump; all other jobs green, `upload-artifact@v7` uploaded successfully with unchanged default (zipped) behavior |
| 8 | `release.yml` → `read_targets_from_file` | no Node 20 warning | Pass | run `31682270984` (2026-08-13), job passed, no match in full run log grep |
| 9 | `release.yml` → `release` | no Node 20 warning | Pass | job "Create Release on Github", no match |
| 10 | `release.yml` → `upload` | no Node 20 warning | Pass | all 5 "Upload Binaries to release" jobs (cf2, flapper, cf21bl, bolt, tag) passed, no match |
| 11 | `release.yml` run overall | draft release created, asset uploaded | Pass | draft release created at tag `refs/heads/stefan/bump-ci-versions`, all 5 binaries uploaded, `isDraft: true` confirmed — user deferred deletion, draft/tag still present in repo, cleanup not yet done. Note: draft has no "Source code (zip/tar.gz)" links, unlike published releases — expected, since GitHub only creates the underlying git tag at publish time |
| 12 | `create-release@v1` / `upload-release-asset@v1` | Node 20 warning still present | Pass | both actions show the warning on every job that uses them, nowhere else — confirms scope wasn't widened or narrowed |