### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot is a first-party tool from Github to keep versions up-to-date. In this case,
Github action versions.

See https://github.com/bitcraze/workflows/pull/4 for more information. This PR is independent of the referenced PR, but it makes sense to start in the workflows repo and make sure it works there.

We can only verify after merging this PR, since dependabot only acts on the default branch.

## Verification plan

- **Prerequisite**: Dependabot version updates only read `dependabot.yml` from the
  **default branch** (`master` for crazyflie-firmware, `main` for workflows). Nothing
  below is checkable until the file is merged there.
- **Syntax**: GitHub validates `dependabot.yml` on push; a malformed file shows as an error
  banner on the repo's Insights > Dependency graph > Dependabot page instead of silently
  doing nothing.
- **Registration**: after merging to the default branch, open repo Settings > Advanced
  security > Dependabot and confirm "Dependabot version updates" shows as
  configured/enabled for both repos.
- **Manual trigger**: on the Insights > Dependency graph > Dependabot page, use "Last
  checked ... Check for updates" to force an immediate run rather than waiting a week,
  and confirm it completes without error.
- **Behavior check**: since `crazyflie-firmware`'s `read_build_targets.yml` call is
  currently pinned to a raw SHA (see Findings), a successful first run should surface a
  proposed PR updating that pin — confirms Dependabot is actually parsing the `uses:`
  lines, not just accepting the config.