### PR TITLE
Release unused AI-deck GPIO pins

### DIFF
--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -314,9 +314,6 @@ static void aideckInit(DeckInfo *info)
   if (isInit)
     return;
 
-  pinMode(DECK_GPIO_IO2, OUTPUT);
-  pinMode(DECK_GPIO_IO3, OUTPUT);
-
   bootloaderSync = xEventGroupCreate();
 
   // Pull reset for GAP8/ESP32


### PR DESCRIPTION
## Summary

- stop the AI-deck driver from configuring IO2 and IO3 as outputs
- leave those GPIOs available to other decks, including the Loco deck alternate-pin configuration

## Root cause

The AI-deck initialization configured IO2 and IO3 as outputs even though the driver neither declares nor uses those pins. This can interfere with another deck depending on initialization order; the Loco deck uses IO2 for IRQ and IO3 for reset when `CONFIG_DECK_LOCODECK_USE_ALT_PINS` is enabled.

The AI-deck still configures IO4 for the GAP8/ESP32 reset sequence and retains its declared `IO1 | IO4` GPIO ownership.

Fixes #1655

## Validation

- `git diff --check`
- `make cf2_defconfig`
- reviewed AI-deck and Loco deck GPIO ownership and initialization paths

A complete local firmware build was attempted, but the available Homebrew split ARM toolchain does not include the C library headers (`stdint.h`, `string.h`, etc.); repository CI should run the build with the supported toolchain image.
