### PR TITLE
docs: update Python bindings test instructions

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -129,12 +129,18 @@ First make sure that you have [SWIG](https://swig.org/) installed on your system
 
 ```
 $ make cf2_defconfig
-$ make bindings_python
-$ cd build
-$ python3 setup.py install --user
+$ make test_python
 ```
 
+The `test_python` target builds the bindings and runs the Python tests with the
+build directory on `PYTHONPATH`. If you want to import the generated bindings
+manually without installing them, use:
+
+```
+$ PYTHONPATH=build python3 -c "import cffirmware"
+```
 ## Make targets
+
 
 ### General targets
 ```


### PR DESCRIPTION
This updates the Python bindings documentation to recommend `make test_python`
instead of installing the generated bindings with `python3 setup.py install --user`.

The `test_python` target already builds the bindings and runs the tests with
`PYTHONPATH=build`, which matches the intended test workflow.

Tested:
- Documentation-only change; checked the edited section in the GitHub editor.