### PR TITLE
docs: mention required Python packages for bindings

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -125,7 +125,7 @@ Please go to [these instructions](/docs/development/kbuild.md) to learn how to u
 
 There are certain functions, like the high level commander and controllers, that have been wrapped to python bindings. These can be used to easily test these functions on a computer or use it in a simulation.
 
-First make sure that you have [SWIG](https://swig.org/) installed on your system. Then execute the following commands in the terminal
+First make sure that you have [SWIG](https://swig.org/) installed on your system and that the required Python packages are available: `numpy`, `pytest`, and `pyyaml`. Then execute the following commands in the terminal
 
 ```
 $ make cf2_defconfig


### PR DESCRIPTION
Update Python bindings docs to mention SWIG and required Python packages (numpy, pytest, pyyaml).