### PR TITLE
Fix persistent param callbacks not called at boot

### DIFF
--- a/src/modules/src/param_logic.c
+++ b/src/modules/src/param_logic.c
@@ -882,6 +882,7 @@ static bool persistentParamFromStorage(const char *key, void *buffer, size_t len
 
   if (PARAM_VARID_IS_VALID(varId) && paramIsPersistent(varId.index)) {
     paramSet(varId.index, buffer);
+    paramNotifyChanged(varId.index);
   }
 
   return true;


### PR DESCRIPTION
**Split out from #1658 at @gemenerik's request.**

When a param is written from the client, the param system does `paramSet()` then `paramNotifyChanged()`, so the callback runs. When a persistent value is restored at boot, `persistentParamFromStorage()` only calls `paramSet()`, the callback is never run.

So a param declared with `PARAM_ADD_WITH_CALLBACK` is notified on a client write, but not when its stored value is loaded at startup.

**Fix:**
Call `paramNotifyChanged()` after restoring the value, matching the client-write path.

No param is currently both persistent and has a callback, so this is a no-op on the current firmware, it just makes the two paths consistent. #1658 adds the first such param and relies on it.