### PR TITLE
Make uSD log completeness checkable over the log TOC

### DIFF
--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -120,7 +120,8 @@ typedef struct usdLogConfig_s {
 
 typedef struct usdLogStats_s {
   uint32_t eventsRequested;
-  uint32_t eventsWritten;
+  // Events that fit in the log buffer; the rest were dropped.
+  uint32_t eventsAccepted;
   // FRESULT of the first failed write or close of the run, 0 if none.
   uint8_t writeError;
 } usdLogStats_t;
@@ -528,7 +529,7 @@ static void usddeckWriteEventData(const usdLogEventConfig_t* cfg, const uint8_t*
         break;
       }
     }
-    ++usdLogStats.eventsWritten;
+    ++usdLogStats.eventsAccepted;
   }
   xSemaphoreGive(logBufferMutex);
 }
@@ -849,7 +850,7 @@ static void usdWriteTask(void* prm)
       xSemaphoreTake(logBufferMutex, portMAX_DELAY);
       ringBuffer_reset(&logBuffer);
       usdLogStats.eventsRequested = 0;
-      usdLogStats.eventsWritten = 0;
+      usdLogStats.eventsAccepted = 0;
       usdLogStats.writeError = 0;
       xSemaphoreGive(logBufferMutex);
 
@@ -1043,7 +1044,7 @@ static void usdWriteTask(void* prm)
         DEBUG_PRINT("Wrote %ld B to: %s (%ld of %ld events)\n",
           lastFileSize,
           usdLogConfig.filename,
-          usdLogStats.eventsWritten,
+          usdLogStats.eventsAccepted,
           usdLogStats.eventsRequested);
 
         xSemaphoreGive(logFileMutex);
@@ -1144,22 +1145,21 @@ STATS_CNT_RATE_LOG_ADD(spiReBps, &spiReadRate)
  */
 STATS_CNT_RATE_LOG_ADD(fatWrBps, &fatWriteRate)
 /**
- * @brief Number of events requested to be written to the uSD card during the current/last log run
+ * @brief Number of events offered to the uSD log during the current/last run
  */
 LOG_ADD(LOG_UINT32, eventsRequested, &usdLogStats.eventsRequested)
 /**
- * @brief Number of events actually written to the uSD card during the current/last log run.
+ * @brief Number of events accepted into the uSD log buffer during the current/last run
  *
- * If lower than eventsRequested, events were dropped and the log is
- * incomplete; do not trust lossless replay of that log.
+ * Counted on entry into the buffer, not on the card. Fewer than eventsRequested
+ * means events were dropped and the log is incomplete.
  */
-LOG_ADD(LOG_UINT32, eventsWritten, &usdLogStats.eventsWritten)
+LOG_ADD(LOG_UINT32, eventsAccepted, &usdLogStats.eventsAccepted)
 /**
- * @brief FatFS error (FRESULT) of the first failed SD write or file close of
- *        the current/last log run, 0 if none.
+ * @brief FRESULT of the first failed SD write or file close of the current/last run, 0 if none
  *
- * A failure stops the log; a run with a non-zero writeError is
- * incomplete and must not be used for replay.
+ * Non-zero means the log is truncated. Only final once the writer has closed
+ * the file, some time after usd.logging reads 0.
  */
 LOG_ADD(LOG_UINT8, writeError, &usdLogStats.writeError)
 LOG_GROUP_STOP(usd)

--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -1126,4 +1126,15 @@ STATS_CNT_RATE_LOG_ADD(spiReBps, &spiReadRate)
  * @brief Data write rate to the SD card [bytes/s]
  */
 STATS_CNT_RATE_LOG_ADD(fatWrBps, &fatWriteRate)
+/**
+ * @brief Number of events requested to be written to the uSD card during the current/last log run
+ */
+LOG_ADD(LOG_UINT32, eventsRequested, &usdLogStats.eventsRequested)
+/**
+ * @brief Number of events actually written to the uSD card during the current/last log run.
+ *
+ * If lower than eventsRequested, events were dropped and the log is
+ * incomplete; do not trust lossless replay of that log.
+ */
+LOG_ADD(LOG_UINT32, eventsWritten, &usdLogStats.eventsWritten)
 LOG_GROUP_STOP(usd)

--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -842,14 +842,12 @@ static void usdWriteTask(void* prm)
   while (!in_shutdown) {
     vTaskSuspend(NULL);
     if (enableLogging) {
-      // reset stats
+      // Reset under the mutex; producers update the counters under it too.
+      xSemaphoreTake(logBufferMutex, portMAX_DELAY);
+      ringBuffer_reset(&logBuffer);
       usdLogStats.eventsRequested = 0;
       usdLogStats.eventsWritten = 0;
       usdLogStats.writeError = 0;
-
-      // reset the buffer
-      xSemaphoreTake(logBufferMutex, portMAX_DELAY);
-      ringBuffer_reset(&logBuffer);
       xSemaphoreGive(logBufferMutex);
 
       xSemaphoreTake(logFileMutex, portMAX_DELAY);

--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -121,8 +121,7 @@ typedef struct usdLogConfig_s {
 typedef struct usdLogStats_s {
   uint32_t eventsRequested;
   uint32_t eventsWritten;
-  // FatFS FRESULT of the first failed write of the current/last log run,
-  // 0 if none. Lets a run be checked for completeness on the drone.
+  // FRESULT of the first failed write or close of the run, 0 if none.
   uint8_t writeError;
 } usdLogStats_t;
 
@@ -810,6 +809,14 @@ static bool handleMemRead(const uint8_t internal_id, const uint32_t memAddr, con
   return result;
 }
 
+// Keep the first error of the run; it is the one that says what went wrong.
+static void usdRecordWriteError(FRESULT status)
+{
+  if (usdLogStats.writeError == 0) {
+    usdLogStats.writeError = (uint8_t)status;
+  }
+}
+
 static void usdWriteData(const void *data, size_t size)
 {
   UINT bytesWritten;
@@ -817,12 +824,8 @@ static void usdWriteData(const void *data, size_t size)
   if (status != FR_OK || bytesWritten < size) {
     DEBUG_PRINT("usd deck write failure %d (%u of %u B)\n",
                 status, (unsigned)bytesWritten, (unsigned)size);
-    // Keep the first error of the run; later writes of the same burst can
-    // report follow-up errors. A short write with FR_OK means a full volume,
-    // which f_write itself reports as FR_DENIED.
-    if (usdLogStats.writeError == 0) {
-      usdLogStats.writeError = (status != FR_OK) ? (uint8_t)status : (uint8_t)FR_DENIED;
-    }
+    // A short write with FR_OK means a full volume.
+    usdRecordWriteError((status != FR_OK) ? status : FR_DENIED);
     enableLogging = false;
   } else {
     crc32Update(&crcContext, data, size);
@@ -1024,8 +1027,12 @@ static void usdWriteTask(void* prm)
         uint32_t crcValue = crc32Out(&crcContext);
         usdWriteData(&crcValue, sizeof(crcValue));
 
-        // close file
-        f_close(&logFile);
+        // f_close syncs the FIL buffer, so it can fail like a write does.
+        FRESULT closeStatus = f_close(&logFile);
+        if (closeStatus != FR_OK) {
+          DEBUG_PRINT("usd deck close failure %d\n", closeStatus);
+          usdRecordWriteError(closeStatus);
+        }
 
         // Update file size for fast query
         FILINFO info;
@@ -1148,10 +1155,10 @@ LOG_ADD(LOG_UINT32, eventsRequested, &usdLogStats.eventsRequested)
  */
 LOG_ADD(LOG_UINT32, eventsWritten, &usdLogStats.eventsWritten)
 /**
- * @brief FatFS error (FRESULT) of the first failed SD write of the current/last
- *        log run, 0 if none.
+ * @brief FatFS error (FRESULT) of the first failed SD write or file close of
+ *        the current/last log run, 0 if none.
  *
- * A write failure stops the log; a run with a non-zero writeError is
+ * A failure stops the log; a run with a non-zero writeError is
  * incomplete and must not be used for replay.
  */
 LOG_ADD(LOG_UINT8, writeError, &usdLogStats.writeError)

--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -121,6 +121,9 @@ typedef struct usdLogConfig_s {
 typedef struct usdLogStats_s {
   uint32_t eventsRequested;
   uint32_t eventsWritten;
+  // FatFS FRESULT of the first failed write of the current/last log run,
+  // 0 if none. Lets a run be checked for completeness on the drone.
+  uint8_t writeError;
 } usdLogStats_t;
 
 // Ring buffer
@@ -811,8 +814,15 @@ static void usdWriteData(const void *data, size_t size)
 {
   UINT bytesWritten;
   FRESULT status = f_write(&logFile, data, size, &bytesWritten);
-  if (status != FR_OK) {
-    DEBUG_PRINT("usd deck write failure %d\n", status);
+  if (status != FR_OK || bytesWritten < size) {
+    DEBUG_PRINT("usd deck write failure %d (%u of %u B)\n",
+                status, (unsigned)bytesWritten, (unsigned)size);
+    // Keep the first error of the run; later writes of the same burst can
+    // report follow-up errors. A short write with FR_OK means a full volume,
+    // which f_write itself reports as FR_DENIED.
+    if (usdLogStats.writeError == 0) {
+      usdLogStats.writeError = (status != FR_OK) ? (uint8_t)status : (uint8_t)FR_DENIED;
+    }
     enableLogging = false;
   } else {
     crc32Update(&crcContext, data, size);
@@ -835,6 +845,7 @@ static void usdWriteTask(void* prm)
       // reset stats
       usdLogStats.eventsRequested = 0;
       usdLogStats.eventsWritten = 0;
+      usdLogStats.writeError = 0;
 
       // reset the buffer
       xSemaphoreTake(logBufferMutex, portMAX_DELAY);
@@ -1138,4 +1149,12 @@ LOG_ADD(LOG_UINT32, eventsRequested, &usdLogStats.eventsRequested)
  * incomplete; do not trust lossless replay of that log.
  */
 LOG_ADD(LOG_UINT32, eventsWritten, &usdLogStats.eventsWritten)
+/**
+ * @brief FatFS error (FRESULT) of the first failed SD write of the current/last
+ *        log run, 0 if none.
+ *
+ * A write failure stops the log; a run with a non-zero writeError is
+ * incomplete and must not be used for replay.
+ */
+LOG_ADD(LOG_UINT8, writeError, &usdLogStats.writeError)
 LOG_GROUP_STOP(usd)

--- a/src/deck/drivers/src/usddeck.c
+++ b/src/deck/drivers/src/usddeck.c
@@ -483,9 +483,10 @@ static void usddeckWriteEventData(const usdLogEventConfig_t* cfg, const uint8_t*
     return;
   }
 
-  ++usdLogStats.eventsRequested;
-
   xSemaphoreTake(logBufferMutex, portMAX_DELAY);
+
+  // Incremented from several task contexts, so keep it under the mutex.
+  ++usdLogStats.eventsRequested;
 
   // trigger writing once there is some data
   if (logBuffer.size > 0 && xHandleWriteTask) {


### PR DESCRIPTION
Adds three `usd` log variables so a user/script can tell whether a log run is usable, without reading the file off the card first:
- `eventsRequested` / `eventsAccepted` - already counted, but previously only reachable as a console print at log stop. `eventsAccepted` counts events on entry into the log buffer, not on the card; if it is lower than `eventsRequested`, events were dropped and the log is incomplete.
- `writeError` - FatFS result of the first failed write or file close of a run, 0 if none. A failure stops logging, so a non-zero value means the log is truncated, and the FRESULT says why.

The counters and `writeError` are only final once the writer has closed the file, which happens some time after `usd.logging` reads 0.

Four fixes came out of this:
- `eventsRequested` was incremented outside the log buffer mutex while the accepted counter was incremented inside it, so the unprotected counter lost updates. This appeared on a real CF as the accepted count exceeding
`eventsRequested` by 41 after 1.25M events, which made a drop check report a negative number of drops.
- The counters were also reset outside that mutex at the start of a run, which could recreate the same skew for a whole run. They are now reset in the same critical section as the ring buffer.
- `f_write` returns `FR_OK` with a short write when the volume fills up. That was treated as success, so the CRC was updated with bytes that never reached the card and logging carried on past the gap. It is now treated as a failure and reported as `FR_DENIED`. Has not been reproduced on a real full card.
- `f_close` was called without checking its result. With `FF_FS_TINY == 0` the last partial sector is only synced by `f_close`, so a failure there could truncate the log while `writeError` stayed 0. It is now recorded as the first error of the run.