### PR TITLE
Add rate limiter to Loco measurements

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -345,6 +345,14 @@ config DECK_LOCO_LONGER_RANGE
     help
         Note that anchors need to be built with support for this as well
 
+config DECK_LOCO_TDOA_RATE_LIMIT
+    bool "Support rate limiting of TDoA measurements forwarded to the estimator (experimental)"
+    depends on DECK_LOCO
+    default y
+    help
+        Compile in the rate limiter that caps how often TDoA measurements,
+        aggregated over all anchors, are forwarded to the estimator.
+
 config DECK_LOCO_TDOA3_HYBRID_MODE
     bool "Support TDoA3 hybrid mode"
     depends on DECK_LOCO

--- a/src/modules/src/tdoaEngineInstance.c
+++ b/src/modules/src/tdoaEngineInstance.c
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "param.h"
 #include "static_mem.h"
+#include "autoconf.h"
 
 NO_DMA_CCM_SAFE_ZERO_INIT tdoaEngineState_t tdoaEngineState;
 
@@ -115,9 +116,11 @@ PARAM_ADD_CORE(PARAM_UINT8, logOthrId, &tdoaEngineState.stats.newRemoteAnchorId)
 // not a frequent action, we chose to expose it anyway.
 PARAM_ADD(PARAM_UINT8, matchAlgo, &tdoaEngineState.matchingAlgorithm)
 
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
 /**
  * @brief Max rate at which TDoA measurements are forwarded to the estimator, aggregated over all
  * anchors [Hz]. 0 = unlimited.
  */
 PARAM_ADD(PARAM_FLOAT, maxRateHz, &tdoaEngineState.maxRateHz)
+#endif
 PARAM_GROUP_STOP(tdoaEngine)

--- a/src/modules/src/tdoaEngineInstance.c
+++ b/src/modules/src/tdoaEngineInstance.c
@@ -114,4 +114,10 @@ PARAM_ADD_CORE(PARAM_UINT8, logOthrId, &tdoaEngineState.stats.newRemoteAnchorId)
 // It only happens when the LPS system mode is changed to TDoA2 or TDoA3 though, and as this is
 // not a frequent action, we chose to expose it anyway.
 PARAM_ADD(PARAM_UINT8, matchAlgo, &tdoaEngineState.matchingAlgorithm)
+
+/**
+ * @brief Max rate at which TDoA measurements are forwarded to the estimator, aggregated over all
+ * anchors [Hz]. 0 (default) = unlimited.
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, maxRateHz, &tdoaEngineState.maxRateHz)
 PARAM_GROUP_STOP(tdoaEngine)

--- a/src/modules/src/tdoaEngineInstance.c
+++ b/src/modules/src/tdoaEngineInstance.c
@@ -117,7 +117,7 @@ PARAM_ADD(PARAM_UINT8, matchAlgo, &tdoaEngineState.matchingAlgorithm)
 
 /**
  * @brief Max rate at which TDoA measurements are forwarded to the estimator, aggregated over all
- * anchors [Hz]. 0 (default) = unlimited.
+ * anchors [Hz]. 0 = unlimited.
  */
-PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, maxRateHz, &tdoaEngineState.maxRateHz)
+PARAM_ADD(PARAM_FLOAT, maxRateHz, &tdoaEngineState.maxRateHz)
 PARAM_GROUP_STOP(tdoaEngine)

--- a/src/utils/interface/tdoa/tdoaEngine.h
+++ b/src/utils/interface/tdoa/tdoaEngine.h
@@ -11,8 +11,10 @@
 #define TDOA_ENGINE_MEASUREMENT_NOISE_STD 0.15f
 #endif
 
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
 // 0 = unlimited
 #define TDOA_ENGINE_DEFAULT_MAX_RATE_HZ 0.0f
+#endif
 
 typedef void (*tdoaEngineSendTdoaToEstimator)(tdoaMeasurement_t* tdoaMeasurement);
 
@@ -26,13 +28,17 @@ typedef struct {
   // State
   tdaoAnchorInfoArray_t anchorInfoArray;
   tdoaStats_t stats;
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
   uint32_t lastForwardedTime_ms;
+#endif
 
   // Configuration
   tdoaEngineSendTdoaToEstimator sendTdoaToEstimator;
   double locodeckTsFreq;
   tdoaEngineMatchingAlgorithm_t matchingAlgorithm;
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
   float maxRateHz;
+#endif
 
   // Matching algorithm data
   struct {

--- a/src/utils/interface/tdoa/tdoaEngine.h
+++ b/src/utils/interface/tdoa/tdoaEngine.h
@@ -23,11 +23,13 @@ typedef struct {
   // State
   tdaoAnchorInfoArray_t anchorInfoArray;
   tdoaStats_t stats;
+  uint32_t lastForwardedTime_ms;
 
   // Configuration
   tdoaEngineSendTdoaToEstimator sendTdoaToEstimator;
   double locodeckTsFreq;
   tdoaEngineMatchingAlgorithm_t matchingAlgorithm;
+  float maxRateHz;
 
   // Matching algorithm data
   struct {

--- a/src/utils/interface/tdoa/tdoaEngine.h
+++ b/src/utils/interface/tdoa/tdoaEngine.h
@@ -11,6 +11,9 @@
 #define TDOA_ENGINE_MEASUREMENT_NOISE_STD 0.15f
 #endif
 
+// 0 = unlimited
+#define TDOA_ENGINE_DEFAULT_MAX_RATE_HZ 0.0f
+
 typedef void (*tdoaEngineSendTdoaToEstimator)(tdoaMeasurement_t* tdoaMeasurement);
 
 typedef enum {

--- a/src/utils/src/tdoa/tdoaEngine.c
+++ b/src/utils/src/tdoa/tdoaEngine.c
@@ -61,6 +61,7 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
   engineState->matchingAlgorithm = matchingAlgorithm;
 
   engineState->matching.offset = 0;
+  engineState->lastForwardedTime_ms = 0;
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {
@@ -220,6 +221,23 @@ void tdoaEngineGetAnchorCtxForPacketProcessing(tdoaEngineState_t* engineState, c
   }
 }
 
+// Rate-limits the aggregate stream of measurements forwarded to the estimator, across all anchors.
+// maxRateHz <= 0 disables the limit. The shared timer is reset as soon as a packet is let through,
+// even if matching later fails to produce a measurement.
+static bool isForwardRateLimited(tdoaEngineState_t* engineState, const uint32_t now_ms, const float maxRateHz) {
+  if (maxRateHz <= 0.0f) {
+    return false;
+  }
+
+  const uint32_t minPeriod_ms = (uint32_t)(1000.0f / maxRateHz);
+  if (engineState->lastForwardedTime_ms != 0 && (now_ms - engineState->lastForwardedTime_ms) < minPeriod_ms) {
+    return true;
+  } else {
+    engineState->lastForwardedTime_ms = now_ms;
+    return false;
+  }
+}
+
 void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T) {
   tdoaEngineProcessPacketFiltered(engineState, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, false, 0);
 }
@@ -229,11 +247,13 @@ bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorC
   if (timeIsGood) {
     STATS_CNT_RATE_EVENT(&engineState->stats.timeIsGood);
 
-    tdoaAnchorContext_t otherAnchorCtx;
-    if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
-      STATS_CNT_RATE_EVENT(&engineState->stats.suitableDataFound);
-      double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
-      enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
+    if (!isForwardRateLimited(engineState, anchorCtx->currentTime_ms, engineState->maxRateHz)) {
+      tdoaAnchorContext_t otherAnchorCtx;
+      if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
+        STATS_CNT_RATE_EVENT(&engineState->stats.suitableDataFound);
+        double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
+        enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
+      }
     }
   }
   return timeIsGood;

--- a/src/utils/src/tdoa/tdoaEngine.c
+++ b/src/utils/src/tdoa/tdoaEngine.c
@@ -59,6 +59,7 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
   engineState->sendTdoaToEstimator = sendTdoaToEstimator;
   engineState->locodeckTsFreq = locodeckTsFreq;
   engineState->matchingAlgorithm = matchingAlgorithm;
+  engineState->maxRateHz = TDOA_ENGINE_DEFAULT_MAX_RATE_HZ;
 
   engineState->matching.offset = 0;
   engineState->lastForwardedTime_ms = 0;

--- a/src/utils/src/tdoa/tdoaEngine.c
+++ b/src/utils/src/tdoa/tdoaEngine.c
@@ -59,10 +59,12 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
   engineState->sendTdoaToEstimator = sendTdoaToEstimator;
   engineState->locodeckTsFreq = locodeckTsFreq;
   engineState->matchingAlgorithm = matchingAlgorithm;
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
   engineState->maxRateHz = TDOA_ENGINE_DEFAULT_MAX_RATE_HZ;
+  engineState->lastForwardedTime_ms = 0;
+#endif
 
   engineState->matching.offset = 0;
-  engineState->lastForwardedTime_ms = 0;
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {
@@ -222,6 +224,7 @@ void tdoaEngineGetAnchorCtxForPacketProcessing(tdoaEngineState_t* engineState, c
   }
 }
 
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
 // Rate-limits the aggregate stream of measurements forwarded to the estimator, across all anchors.
 // maxRateHz <= 0 disables the limit. The shared timer is reset as soon as a packet is let through,
 // even if matching later fails to produce a measurement.
@@ -238,6 +241,7 @@ static bool isForwardRateLimited(tdoaEngineState_t* engineState, const uint32_t 
     return false;
   }
 }
+#endif
 
 void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T) {
   tdoaEngineProcessPacketFiltered(engineState, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, false, 0);
@@ -248,14 +252,18 @@ bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorC
   if (timeIsGood) {
     STATS_CNT_RATE_EVENT(&engineState->stats.timeIsGood);
 
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
     if (!isForwardRateLimited(engineState, anchorCtx->currentTime_ms, engineState->maxRateHz)) {
+#endif
       tdoaAnchorContext_t otherAnchorCtx;
       if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
         STATS_CNT_RATE_EVENT(&engineState->stats.suitableDataFound);
         double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
         enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
       }
+#ifdef CONFIG_DECK_LOCO_TDOA_RATE_LIMIT
     }
+#endif
   }
   return timeIsGood;
 }


### PR DESCRIPTION
Loco measurements can arrive at a combined rate of up to 400 Hz. Put a limit on this rate, in order to free up CPU load on the Crazyflie.

- Add a rate limiter for queuing measurement to the Kalman filter, by not queuing measurements within a certain time period since the last queued measurement. The time period is the inverse of the frequency.
- All measurements are still used for clock correction and are put in the stack of measurements
- Add a kconfig parameter for the frequency
- Add a kconfig parameter for related code

## Notes

There is no intelligence to which measurements are discarded.

Microseconds are used for calculations, since milliseconds make for relatively large deviations from requested rate at frequencies larger than 150 Hz. E.g. 150 Hz becomes 167 Hz.

This solution was chosen due to the ease of use and that configuration is easy to understand.

## Verification

tdoaEngine.stFound gives the rate for enqueued TDOA messages.
Compare this value to tdoaEngine.maxRateHz

maxRateHz = 0 (unlimited):

<img width="754" height="644" alt="image" src="https://github.com/user-attachments/assets/f7fdd2c0-8bff-4b9b-88a0-229b2cbfb928" />

maxRateHz = 150:

<img width="1036" height="679" alt="image" src="https://github.com/user-attachments/assets/8099cc37-f971-4526-8dfc-018b94d8e230" />

maxRateHz = 75:

<img width="1033" height="693" alt="image" src="https://github.com/user-attachments/assets/975b4b77-0e90-42e2-8c98-36ea19f34a27" />

No analysis has been to see if the filtering is spread evenly across anchors.