### PR TITLE
Fix 1.18% clock skew in `usecTimestamp()`, which de-synced microSD card recordings

### DIFF
--- a/src/hal/src/usec_time.c
+++ b/src/hal/src/usec_time.c
@@ -54,7 +54,7 @@ void usecTimerInit(void)
   TIM_TimeBaseStructure.TIM_Period = 0xFFFF;
   // APB1 clock is /4, but APB clock inputs to timers are doubled when
   // the APB clock runs slower than /1, so APB1 timers see a /2 clock
-  TIM_TimeBaseStructure.TIM_Prescaler = SystemCoreClock / (1000 * 1000) / 2;
+  TIM_TimeBaseStructure.TIM_Prescaler = (SystemCoreClock / (1000 * 1000) / 2) - 1;
   TIM_TimeBaseStructure.TIM_ClockDivision = TIM_CKD_DIV1;
   TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
   TIM_TimeBaseStructure.TIM_RepetitionCounter = 0;


### PR DESCRIPTION
Hi,

This PR fixes a bug that caused micro sd card recordings to have timestamps that advance 1.18% slower than realtime. The bug was caused by an off-by-one in `usec_time.c`'s configuration of hardware TIM7, which caused the prescaler to divided by 85 instead of 84. Consequently, micro sd card timestamps advanced at 84/85 = 98.82% of realtime.

The fix affects all computations relying on `usecTimestamp()` as a time source, including the ukf estimator and other sensing related computations.

I have tested the fix on a flapper drone, but it appears that the bug affects all platforms. It has been present for [at least 10 years](https://github.com/bitcraze/crazyflie-firmware/blame/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/hal/src/usec_time.c#L57). 

**Details**
The micro sd card logger [uses `usecTimestamp()`](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/deck/drivers/src/usddeck.c#L480) function provided by `usec_time.c` to timestamp measurements. `usec_time.c` configures the [TIM7 prescaler to 84](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/hal/src/usec_time.c#L57), which is the correct divisor, however hardware applies N+1 prescaling and so divides by 85.

Wireless logging uses the less accurate, but correct, freeRTOS tick counter for timestamping ([`xTaskGetTickCount())/portTICK_RATE_MS`](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/modules/src/log.c#L568)) and so is unaffected.

**Evidence that the fix is correct**
I used normalized cross correlation and nonlinear least squares to measure the clock skew as 1.18% precisely. The wirelessly recorded data used the timestamps reported by cflib, which reports hardware timestamps. The micro sd data also uses hardware timestamps. The wirelessly recorded data's timestamps align with the recording PC's software timestamps. PC hardware timers are typically accurate to 20-50 ppm (1.18% is 11,800 ppm of error).

I used AI to search the firmware and find the prescaler misconfiguration, which predicts a 1.18% clock skew.

I recorded data without and with the prescaler fix applied and manually time aligned the beginning of the recordings. The plots below show that fixing the prescaler configuration removes the clock skew, that otherwise causes misalignment by ~0.65 seconds by the end of the approximately 1 minute recording.
<img width="1400" height="800" alt="Figure_1" src="https://github.com/user-attachments/assets/a95061d9-55ad-4e37-af24-c6157965063e" />

**Downstream effects**
At a glance the files using `usecTimestamp`, whose computations may/will be affected, are:
```
src/drivers/src/motors.c
src/drivers/src/i2c_drv.c
src/modules/src/controller/controller_lee.c
src/modules/src/crtp_commander_high_level.c
src/modules/src/estimator/estimator_ukf.c
src/modules/src/stabilizer.c
src/modules/src/serial_4way.c
src/deck/drivers/src/flowdeck_v1v2.c
src/deck/drivers/src/ledring12.c
src/deck/drivers/src/usddeck.c
src/utils/src/lighthouse/pulse_processor_v2.c
src/utils/src/sleepus.c
src/hal/src/sensors_mpu9250_lps25h.c
src/hal/src/sensors_bmi088_bmp3xx.c
```

In [`src/deck/drivers/src/rpm.c:117`](https://github.com/bitcraze/crazyflie-firmware/blob/54f31e243a0b28b67efef5ba20dbb6d9890a5478/src/deck/drivers/src/rpm.c#L117) a different timer's prescaler configuration accounts for the offset correctly. `TIM_Prescaler = (84 - 1); // 84 / 84M = 1uS`. This suggests that not all hardware timer prescalers are configured consistently, and so it might be a good idea to check all time sources throughout the firmware.