### PR TITLE
Replaced depricated distutils with setuptools in bindings/setup.py

### DIFF
--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -1,7 +1,7 @@
 """Compiles the cffirmware C extension."""
 
-import distutils.command.build
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
+from setuptools.command.build import build
 import os
 
 include = [
@@ -71,9 +71,9 @@ cffirmware = Extension(
 )
 
 # Override build command to specify custom "build" directory
-class BuildCommand(distutils.command.build.build):
+class BuildCommand(build):
     def initialize_options(self):
-        distutils.command.build.build.initialize_options(self)
+        build.initialize_options(self)
         self.build_base = "build"
 
 setup(


### PR DESCRIPTION
This PR updates `bindigs/setup.py` to use `setuptools` instead of `distutils`, which was removed from the standard python library in python 3.12.

This means that setuptools is now a dependency for the bindings to run, which is described in #1677.