### PR TITLE
Add printout to CI job kbuild-targets-random

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -168,9 +168,9 @@ jobs:
               fi
             done
             if [ "$FAIL_COUNT" -eq 0 ]; then
-              echo "All $RANDOM_BUILD_COUNT random builds passed!"
+              echo "SUCCESS! All $RANDOM_BUILD_COUNT random builds passed!"
             else
-              echo "ERROR: $FAIL_COUNT/$RANDOM_BUILD_COUNT random builds failed!"
+              echo "FAIL! $FAIL_COUNT/$RANDOM_BUILD_COUNT random builds failed!"
             fi
             exit $FAIL_COUNT
           '

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,8 +167,10 @@ jobs:
                 FAIL_COUNT=$((FAIL_COUNT + 1))
               fi
             done
-            if [ "$FAIL_COUNT" -ne 0 ]; then
-              echo "ERROR: $FAIL_COUNT/$RANDOM_BUILD_COUNT random builds failed"
+            if [ "$FAIL_COUNT" -eq 0 ]; then
+              echo "All $RANDOM_BUILD_COUNT random builds passed!"
+            else
+              echo "ERROR: $FAIL_COUNT/$RANDOM_BUILD_COUNT random builds failed!"
             fi
             exit $FAIL_COUNT
           '


### PR DESCRIPTION
See [kbuild-targets-random job in workflow run](https://github.com/bitcraze/crazyflie-firmware/actions/runs/32709795145/job/97379676575) for verification. Manually triggered as the job only runs on workflow dispatch and schedule.