### PR TITLE
Added possitity to disable asserts on radio communication problems.

### DIFF
--- a/src/drivers/src/uart_syslink.c
+++ b/src/drivers/src/uart_syslink.c
@@ -445,23 +445,23 @@ static void uartslkDmaRXIsr(void)
         xQueueSendFromISR(syslinkPacketDelivery, (void *)&slp, &xHigherPriorityTaskWoken);
       }
     }
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
     else if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
     {
-#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       // Only assert if debugger is not connected
       ASSERT(0); // Queue overflow
-#endif
     }
+#endif
   }
   else
   { // Checksum error
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
     if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
     {
-#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       // Only assert if debugger is not connected
       ASSERT(0);
-#endif
     }
+#endif
   }
 
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
@@ -529,13 +529,13 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
     else
     {
       rxState = waitForFirstStart; //Checksum error
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
       {
-#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
         // Only assert if debugger is not connected
         ASSERT(0);
-#endif
       }
+#endif
     }
     break;
   case waitForChksum2:
@@ -549,13 +549,13 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
           xQueueSendFromISR(syslinkPacketDelivery, (void *)&slp, pxHigherPriorityTaskWoken);
         }
       }
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       else if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
       {
-#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
         // Only assert if debugger is not connected
         ASSERT(0); // Queue overflow
-#endif
       }
+#endif
     }
     else
     {

--- a/src/drivers/src/uart_syslink.c
+++ b/src/drivers/src/uart_syslink.c
@@ -447,16 +447,20 @@ static void uartslkDmaRXIsr(void)
     }
     else if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
     {
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       // Only assert if debugger is not connected
       ASSERT(0); // Queue overflow
+#endif
     }
   }
   else
   { // Checksum error
     if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
     {
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       // Only assert if debugger is not connected
       ASSERT(0);
+#endif
     }
   }
 
@@ -527,8 +531,10 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
       rxState = waitForFirstStart; //Checksum error
       if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
       {
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
         // Only assert if debugger is not connected
         ASSERT(0);
+#endif
       }
     }
     break;
@@ -545,14 +551,18 @@ void uartslkHandleDataFromISR(uint8_t c, BaseType_t * const pxHigherPriorityTask
       }
       else if(!(CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk))
       {
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
         // Only assert if debugger is not connected
         ASSERT(0); // Queue overflow
+#endif
       }
     }
     else
     {
       rxState = waitForFirstStart; //Checksum error
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
       ASSERT(0);
+#endif
     }
     rxState = waitForFirstStart;
     break;

--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -55,7 +55,9 @@ config RADIO_ASSERT_ON_COM_PROBLEM
   default y
   help
       In case of any radio communication problem, such as queue overflow 
-      or checksum error, assert. This will make the Crazyflie cut the motor
-      power so it might not be always wanted.
+      or checksum error, assert. This is often a sign of a overloaded system.
+      Since the assert will make the Crazyflie cut power to the motors, 
+      this might not always be wanted and it might be better to
+      sactifice communcation.
 
 endmenu

--- a/src/hal/src/Kconfig
+++ b/src/hal/src/Kconfig
@@ -50,4 +50,12 @@ config RADIO_ACTIVITY_TIMEOUT_MS
       Timeout in milliseconds since the last radio packet was received
       before the radio is considered inactive.
 
+config RADIO_ASSERT_ON_COM_PROBLEM
+  bool "Assert on radio communication problem"
+  default y
+  help
+      In case of any radio communication problem, such as queue overflow 
+      or checksum error, assert. This will make the Crazyflie cut the motor
+      power so it might not be always wanted.
+
 endmenu

--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -167,9 +167,11 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
   else if (slp->type == SYSLINK_RADIO_RAW)
   {
     slp->length--; // Decrease to get CRTP size.
-#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
+#ifdef CONFIG_RADIO_ASSERT_ON_QUEUE_FULL
     // Assert that we are not dropping any packets
     ASSERT(xQueueSend(crtpPacketDelivery, &slp->length, 0) == pdPASS);
+#else
+    xQueueSend(crtpPacketDelivery, &slp->length, 0);
 #endif
     ++count_rx_unicast;
     ledseqRun(&seq_linkUp);

--- a/src/hal/src/radiolink.c
+++ b/src/hal/src/radiolink.c
@@ -167,8 +167,10 @@ void radiolinkSyslinkDispatch(SyslinkPacket *slp)
   else if (slp->type == SYSLINK_RADIO_RAW)
   {
     slp->length--; // Decrease to get CRTP size.
+#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM
     // Assert that we are not dropping any packets
     ASSERT(xQueueSend(crtpPacketDelivery, &slp->length, 0) == pdPASS);
+#endif
     ++count_rx_unicast;
     ledseqRun(&seq_linkUp);
     // If a radio packet is received, one can be sent


### PR DESCRIPTION
This pull request introduces a new configuration option to control assertion behavior on radio communication problems. By default, assertions will now be triggered on errors like queue overflows and checksum failures, but this can be disabled if desired. The main changes are the addition of the `RADIO_ASSERT_ON_COM_PROBLEM` config option and wrapping several `ASSERT` statements with this conditional.

Configuration:

* Added new `RADIO_ASSERT_ON_COM_PROBLEM` boolean config option in `Kconfig` to control whether the system asserts on radio communication problems. This is enabled by default and will cut motor power on assertion.

Error handling improvements:

* Wrapped `ASSERT(0)` statements for queue overflows and checksum errors in `uart_syslink.c` with `#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM` to make assertion behavior configurable. [[1]](diffhunk://#diff-10337b89fed4b234b1b46651544eb7957b6237e0feb62eec8ab96b89cb496777R450-R463) [[2]](diffhunk://#diff-10337b89fed4b234b1b46651544eb7957b6237e0feb62eec8ab96b89cb496777R534-R537) [[3]](diffhunk://#diff-10337b89fed4b234b1b46651544eb7957b6237e0feb62eec8ab96b89cb496777R554-R565)
* Wrapped the assertion on packet drops in `radiolink.c` with `#ifdef CONFIG_RADIO_ASSERT_ON_COM_PROBLEM` to ensure consistent behavior with the new config option.