### PR TITLE
Made lighthouse rate kbuild configurable.

### DIFF
--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -278,11 +278,11 @@ config DECK_LIGHTHOUSE_MAX_N_BS
       valid for Lighthouse V2.
 
 config DECK_LIGHTHOUSE_MAX_RATE
-  int "Max sweeps used per second"
+  int "Max measurement sampels used per second"
   depends on DECK_LIGHTHOUSE
   default 50
   help
-      Set the max number of lighthouse sweeps used (Hz).
+      Set the max number of lighthouse measurements sent to the estimator (Hz).
 
 config DECK_LOCO
     bool "Support the Loco positioning deck"

--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -277,6 +277,13 @@ config DECK_LIGHTHOUSE_MAX_N_BS
       Set the max number of base stations supported. NOTE: This is only
       valid for Lighthouse V2.
 
+config DECK_LIGHTHOUSE_MAX_RATE
+  int "Max sweeps used per second"
+  depends on DECK_LIGHTHOUSE
+  default 50
+  help
+      Set the max number of lighthouse sweeps used (Hz).
+
 config DECK_LOCO
     bool "Support the Loco positioning deck"
     default y

--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -281,6 +281,7 @@ config DECK_LIGHTHOUSE_MAX_RATE
   int "Max measurement samples used per second"
   depends on DECK_LIGHTHOUSE
   default 50
+  range 0 65535
   help
       Set the max number of lighthouse measurements sent to the estimator (Hz).
 

--- a/src/deck/drivers/src/Kconfig
+++ b/src/deck/drivers/src/Kconfig
@@ -278,7 +278,7 @@ config DECK_LIGHTHOUSE_MAX_N_BS
       valid for Lighthouse V2.
 
 config DECK_LIGHTHOUSE_MAX_RATE
-  int "Max measurement sampels used per second"
+  int "Max measurement samples used per second"
   depends on DECK_LIGHTHOUSE
   default 50
   help

--- a/src/modules/src/lighthouse/lighthouse_throttle.c
+++ b/src/modules/src/lighthouse/lighthouse_throttle.c
@@ -27,13 +27,14 @@
 #include <stdlib.h>
 #include "lighthouse_throttle.h"
 #include "param.h"
+#include "autoconf.h"
 
 // Uncomment next line to add extra debug log variables
 // #define CONFIG_DEBUG_LOG_ENABLE 1
 #include "log.h"
 
 static const uint32_t evaluationIntervalMs = 100;
-static uint16_t maxRate = 50;  // Samples / second
+static uint16_t maxRate = CONFIG_DECK_LIGHTHOUSE_MAX_RATE;  // Samples / second
 static float discardProbability = 0.0f;
 
 bool throttleLh2Samples(const uint32_t nowMs) {


### PR DESCRIPTION
This pull request adds configurability to the maximum rate at which Lighthouse measurements are sent to the estimator, making the system more flexible and easier to tune for different setups. The main changes introduce a new configuration option and ensure it is used in the relevant module.

Configuration improvements:

* Added a new Kconfig option `DECK_LIGHTHOUSE_MAX_RATE` to allow setting the maximum number of Lighthouse measurements sent to the estimator per second.

Code updates to use the new configuration:

* Updated `lighthouse_throttle.c` to use the configurable `CONFIG_DECK_LIGHTHOUSE_MAX_RATE` instead of a hardcoded value for the maximum sample rate.