### PR TITLE
Geofence

### DIFF
--- a/src/modules/interface/supervisor.h
+++ b/src/modules/interface/supervisor.h
@@ -39,9 +39,10 @@ uint16_t supervisorGetInfoBitfield(void);
  *
  * @param sensors        Latest sensor data
  * @param setpoint       Current setpoint
+ * @param state          Latest state estimate
  * @param stabilizerStep Stabilizer step for rate control
  */
-void supervisorUpdate(const sensorData_t *sensors, const setpoint_t* setpoint, stabilizerStep_t stabilizerStep);
+void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, const state_t *state, stabilizerStep_t stabilizerStep);
 
 /**
  * @brief Replace the values in the current setpoint, if required.

--- a/src/modules/interface/supervisor.h
+++ b/src/modules/interface/supervisor.h
@@ -51,8 +51,9 @@ void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, c
  * if may replace values in the current setpoint.
  *
  * @param setpoint The current setpoint
+ * @param state    Latest state estimate
  */
-void supervisorOverrideSetpoint(setpoint_t* setpoint);
+void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state);
 
 /**
  * @brief Check if it is OK to spin the motors

--- a/src/modules/interface/supervisor_state_machine.h
+++ b/src/modules/interface/supervisor_state_machine.h
@@ -48,8 +48,6 @@ typedef enum {
   supervisorConditionArmed = 0,
   supervisorConditionIsFlying,
   supervisorConditionIsTumbled,
-  supervisorConditionGeofenceWarning,
-  supervisorConditionGeofenceStop,
   supervisorConditionCommanderWdtWarning,
   supervisorConditionCommanderWdtTimeout,
   supervisorConditionEmergencyStop,
@@ -60,6 +58,8 @@ typedef enum {
   supervisorConditionRPMatArmingValid,
   supervisorConditionSpinupTimeout,
   supervisorConditionMotorsNotResponding,
+  supervisorConditionGeofenceWarning,
+  supervisorConditionGeofenceStop,
   supervisorCondition_NrOfConditions,
 } supervisorConditions_t;
 
@@ -70,8 +70,6 @@ typedef uint32_t supervisorConditionBits_t;
 #define SUPERVISOR_CB_ARMED (1 << supervisorConditionArmed)
 #define SUPERVISOR_CB_IS_FLYING (1 << supervisorConditionIsFlying)
 #define SUPERVISOR_CB_IS_TUMBLED (1 << supervisorConditionIsTumbled)
-#define SUPERVISOR_CB_GEOFENCE_WARNING (1 << supervisorConditionGeofenceWarning)
-#define SUPERVISOR_CB_GEOFENCE_STOP (1 << supervisorConditionGeofenceStop)
 #define SUPERVISOR_CB_COMMANDER_WDT_WARNING (1 << supervisorConditionCommanderWdtWarning)
 #define SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT (1 << supervisorConditionCommanderWdtTimeout)
 #define SUPERVISOR_CB_EMERGENCY_STOP (1 << supervisorConditionEmergencyStop)
@@ -82,6 +80,8 @@ typedef uint32_t supervisorConditionBits_t;
 #define SUPERVISOR_CB_RPM_AT_ARMING_VALID (1 << supervisorConditionRPMatArmingValid)
 #define SUPERVISOR_CB_SPINUP_TIMEOUT (1 << supervisorConditionSpinupTimeout)
 #define SUPERVISOR_CB_MOTORS_NOT_RESPONDING (1 << supervisorConditionMotorsNotResponding)
+#define SUPERVISOR_CB_GEOFENCE_WARNING (1 << supervisorConditionGeofenceWarning)
+#define SUPERVISOR_CB_GEOFENCE_STOP (1 << supervisorConditionGeofenceStop)
 
 
 // Enum that is used to describe how to combine the bits in the required field

--- a/src/modules/interface/supervisor_state_machine.h
+++ b/src/modules/interface/supervisor_state_machine.h
@@ -35,6 +35,7 @@ typedef enum {
     supervisorStateFlying,
     supervisorStateLanded,
     supervisorStateReset,
+    supervisorStateWarningReturnToGeofence,
     supervisorStateWarningLevelOut,
     supervisorStateExceptFreeFall,
     supervisorStateLocked,
@@ -47,6 +48,8 @@ typedef enum {
   supervisorConditionArmed = 0,
   supervisorConditionIsFlying,
   supervisorConditionIsTumbled,
+  supervisorConditionGeofenceWarning,
+  supervisorConditionGeofenceStop,
   supervisorConditionCommanderWdtWarning,
   supervisorConditionCommanderWdtTimeout,
   supervisorConditionEmergencyStop,
@@ -67,6 +70,8 @@ typedef uint32_t supervisorConditionBits_t;
 #define SUPERVISOR_CB_ARMED (1 << supervisorConditionArmed)
 #define SUPERVISOR_CB_IS_FLYING (1 << supervisorConditionIsFlying)
 #define SUPERVISOR_CB_IS_TUMBLED (1 << supervisorConditionIsTumbled)
+#define SUPERVISOR_CB_GEOFENCE_WARNING (1 << supervisorConditionGeofenceWarning)
+#define SUPERVISOR_CB_GEOFENCE_STOP (1 << supervisorConditionGeofenceStop)
 #define SUPERVISOR_CB_COMMANDER_WDT_WARNING (1 << supervisorConditionCommanderWdtWarning)
 #define SUPERVISOR_CB_COMMANDER_WDT_TIMEOUT (1 << supervisorConditionCommanderWdtTimeout)
 #define SUPERVISOR_CB_EMERGENCY_STOP (1 << supervisorConditionEmergencyStop)

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -344,7 +344,7 @@ static void stabilizerTask(void* param)
 
       // Critical for safety, be careful if you modify this code!
       // Let the supervisor update it's view of the current situation
-      supervisorUpdate(&sensorData, &setpoint, stabilizerStep);
+      supervisorUpdate(&sensorData, &setpoint, &state, stabilizerStep);
 
       // Let the collision avoidance module modify the setpoint, if needed
       collisionAvoidanceUpdateSetpoint(&setpoint, &sensorData, &state, stabilizerStep);

--- a/src/modules/src/stabilizer.c
+++ b/src/modules/src/stabilizer.c
@@ -351,7 +351,7 @@ static void stabilizerTask(void* param)
 
       // Critical for safety, be careful if you modify this code!
       // Let the supervisor modify the setpoint to handle exceptional conditions
-      supervisorOverrideSetpoint(&setpoint);
+      supervisorOverrideSetpoint(&setpoint, &state);
 
       controller(&control, &setpoint, &sensorData, &state, stabilizerStep);
 

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -77,7 +77,7 @@ static uint16_t rpmCheckDurationMs = CONFIG_MOTORS_ARMING_RPM_DURATION_MS;
 static uint16_t motorsNotRespondingRpmThreshold = CONFIG_MOTORS_RPM_NOT_RESPONDING_THRESHOLD;
 #endif
 
-static float geofenceWarningZone = 1.0f;
+static float geofenceWarningZone = 0.5f;
 static float geofenceXmin = -10.0f;
 static float geofenceXmax = 10.0f;
 static float geofenceYmin = -10.0f;
@@ -745,12 +745,12 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       if (setpoint->mode.x == modeVelocity) {
         if (state->position.x < geofenceXmin) {
           setpoint->mode.x = modeAbs;
-          setpoint->position.x = geofenceXmin;
+          setpoint->position.x = geofenceXmin+geofenceWarningZone/2;
           setpoint->velocity.x = 0;
           geofenceActivated = true;
         } else if (state->position.x > geofenceXmax) {
           setpoint->mode.x = modeAbs;
-          setpoint->position.x = geofenceXmax;
+          setpoint->position.x = geofenceXmax-geofenceWarningZone/2;
           setpoint->velocity.x = 0;
           geofenceActivated = true;
         }
@@ -758,12 +758,12 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       if (setpoint->mode.y == modeVelocity) {
         if (state->position.y < geofenceYmin) {
           setpoint->mode.y = modeAbs;
-          setpoint->position.y = geofenceYmin;
+          setpoint->position.y = geofenceYmin+geofenceWarningZone/2;
           setpoint->velocity.y = 0;
           geofenceActivated = true;
         } else if (state->position.y > geofenceYmax) {
           setpoint->mode.y = modeAbs;
-          setpoint->position.y = geofenceYmax;
+          setpoint->position.y = geofenceYmax-geofenceWarningZone/2;
           setpoint->velocity.y = 0;
           geofenceActivated = true;
         }
@@ -771,12 +771,12 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       if (setpoint->mode.z == modeVelocity) {
         if (state->position.z < geofenceZmin) {
           setpoint->mode.z = modeAbs;
-          setpoint->position.z = geofenceZmin;
+          setpoint->position.z = geofenceZmin+geofenceWarningZone/2;
           setpoint->velocity.z = 0;
           geofenceActivated = true;
         } else if (state->position.z > geofenceZmax) {
           setpoint->mode.z = modeAbs;
-          setpoint->position.z = geofenceZmax;
+          setpoint->position.z = geofenceZmax-geofenceWarningZone;
           setpoint->velocity.z = 0;
           geofenceActivated = true;
         }

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -141,6 +141,7 @@ bool supervisorCanFly() {
   supervisorMem.canFly = 
     (supervisorMem.state == supervisorStateReadyToFly) ||
     (supervisorMem.state == supervisorStateFlying) ||
+    (supervisorMem.state == supervisorStateWarningReturnToGeofence) ||
     (supervisorMem.state == supervisorStateWarningLevelOut) ||
     (supervisorMem.state == supervisorStateLanded);
 
@@ -470,6 +471,10 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
     supervisorRequestCrashRecovery(false);
   }
 
+  if (newState == supervisorStateWarningReturnToGeofence) {
+    DEBUG_PRINT("Warning: Outside of geofence, trying to return\n");
+  }
+
   if (newState != supervisorStateArming &&
       newState != supervisorStateReadyToFly &&
       newState != supervisorStateFlying &&
@@ -631,6 +636,12 @@ static void updateLogData(SupervisorMem_t* this, const supervisorConditionBits_t
   if (conditions & SUPERVISOR_CB_DECK_FAULT) {
       this->infoBitfield |= 0x0800;  // a deck has reported a hardware fault
   }
+  if (conditions & SUPERVISOR_CB_GEOFENCE_WARNING) {
+      this->infoBitfield |= 0x1000;  // geofence warning zone triggered
+  }
+  if (conditions & SUPERVISOR_CB_GEOFENCE_STOP) {
+      this->infoBitfield |= 0x2000;  // geofence stop triggered
+  }
 }
 
 void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, const state_t *state, stabilizerStep_t stabilizerStep) {
@@ -657,20 +668,8 @@ void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, c
   }
 }
 
-bool geofenceTriggered = false;
-
-extern void geofenceTriggeredUpdate(bool status) {
-  if (status) {
-    geofenceTriggered = true;
-  } else {
-    geofenceTriggered = false;
-  }
-}
-
-bool geofenceActivated = false;
 void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
   SupervisorMem_t* this = &supervisorMem;
-  geofenceActivated = false;
   switch(this->state){
     case supervisorStateArming:
       // Fall through
@@ -684,28 +683,22 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
         if (setpoint->mode.x == modeAbs) {
           if (setpoint->position.x < geofenceXmin) {
             setpoint->position.x = geofenceXmin;
-            geofenceActivated = true;
           } else if (setpoint->position.x > geofenceXmax) {
             setpoint->position.x = geofenceXmax;
-            geofenceActivated = true;
           }
         }
         if (setpoint->mode.y == modeAbs) {
           if (setpoint->position.y < geofenceYmin) {
             setpoint->position.y = geofenceYmin;
-            geofenceActivated = true;
           } else if (setpoint->position.y > geofenceYmax) {
             setpoint->position.y = geofenceYmax;
-            geofenceActivated = true;
           }
         }
         if (setpoint->mode.z == modeAbs) {
           if (setpoint->position.z < geofenceZmin) {
             setpoint->position.z = geofenceZmin;
-            geofenceActivated = true;
           } else if (setpoint->position.z > geofenceZmax) {
             setpoint->position.z = geofenceZmax;
-            geofenceActivated = true;
           }
         }
       }
@@ -716,28 +709,22 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       if (setpoint->mode.x == modeAbs) {
         if (setpoint->position.x < geofenceXmin) {
           setpoint->position.x = geofenceXmin;
-          geofenceActivated = true;
         } else if (setpoint->position.x > geofenceXmax) {
           setpoint->position.x = geofenceXmax;
-          geofenceActivated = true;
         }
       }
       if (setpoint->mode.y == modeAbs) {
         if (setpoint->position.y < geofenceYmin) {
           setpoint->position.y = geofenceYmin;
-          geofenceActivated = true;
         } else if (setpoint->position.y > geofenceYmax) {
           setpoint->position.y = geofenceYmax;
-          geofenceActivated = true;
         }
       }
       if (setpoint->mode.z == modeAbs) {
         if (setpoint->position.z < geofenceZmin) {
           setpoint->position.z = geofenceZmin;
-          geofenceActivated = true;
         } else if (setpoint->position.z > geofenceZmax) {
           setpoint->position.z = geofenceZmax;
-          geofenceActivated = true;
         }
       }
 
@@ -747,12 +734,10 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
           setpoint->mode.x = modeAbs;
           setpoint->position.x = geofenceXmin+geofenceWarningZone/2;
           setpoint->velocity.x = 0;
-          geofenceActivated = true;
         } else if (state->position.x > geofenceXmax) {
           setpoint->mode.x = modeAbs;
           setpoint->position.x = geofenceXmax-geofenceWarningZone/2;
           setpoint->velocity.x = 0;
-          geofenceActivated = true;
         }
       }
       if (setpoint->mode.y == modeVelocity) {
@@ -760,12 +745,10 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
           setpoint->mode.y = modeAbs;
           setpoint->position.y = geofenceYmin+geofenceWarningZone/2;
           setpoint->velocity.y = 0;
-          geofenceActivated = true;
         } else if (state->position.y > geofenceYmax) {
           setpoint->mode.y = modeAbs;
           setpoint->position.y = geofenceYmax-geofenceWarningZone/2;
           setpoint->velocity.y = 0;
-          geofenceActivated = true;
         }
       }
       if (setpoint->mode.z == modeVelocity) {
@@ -773,12 +756,10 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
           setpoint->mode.z = modeAbs;
           setpoint->position.z = geofenceZmin+geofenceWarningZone/2;
           setpoint->velocity.z = 0;
-          geofenceActivated = true;
         } else if (state->position.z > geofenceZmax) {
           setpoint->mode.z = modeAbs;
           setpoint->position.z = geofenceZmax-geofenceWarningZone;
           setpoint->velocity.z = 0;
-          geofenceActivated = true;
         }
       }
 
@@ -801,7 +782,6 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       memcpy(setpoint, &nullSetpoint, sizeof(nullSetpoint));
       break;
   }
-  geofenceTriggeredUpdate(geofenceActivated);
 }
 
 bool supervisorAreMotorsAllowedToRun() {
@@ -883,16 +863,14 @@ LOG_GROUP_START(supervisor)
  * Bit 9 = high level trajectory has finished
  * Bit 10 = high level control is disabled and not producing setpoints
  * Bit 11 = deck fault - a deck has reported a hardware fault
+ * Bit 12 = geofence warning - the Crazyflie is outside of the geofence but within the warning zone
+ * Bit 13 = geofence stop - the Crazyflie got outside of the geofence warning zone and has triggered the stop condition
  */
 LOG_ADD(LOG_UINT16, info, &supervisorMem.infoBitfield)
 /**
  * @brief Acceleration norm in Gs used by crash/tumble detection.
  */
 LOG_ADD(LOG_FLOAT, accNorm, &crashDetectionAccNorm)
-/**
- * @brief Indicates if the geofence has been triggered. 1=triggered, 0=not triggered
- */
-LOG_ADD(LOG_UINT8, geofTrig, &geofenceTriggered)
 LOG_GROUP_STOP(supervisor)
 
 

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -657,8 +657,20 @@ void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, c
   }
 }
 
+bool geofenceTriggered = false;
+
+extern void geofenceTriggeredUpdate(bool status) {
+  if (status) {
+    geofenceTriggered = true;
+  } else {
+    geofenceTriggered = false;
+  }
+}
+
+bool geofenceActivated = false;
 void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
   SupervisorMem_t* this = &supervisorMem;
+  geofenceActivated = false;
   switch(this->state){
     case supervisorStateArming:
       // Fall through
@@ -672,22 +684,28 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
         if (setpoint->mode.x == modeAbs) {
           if (setpoint->position.x < geofenceXmin) {
             setpoint->position.x = geofenceXmin;
+            geofenceActivated = true;
           } else if (setpoint->position.x > geofenceXmax) {
             setpoint->position.x = geofenceXmax;
+            geofenceActivated = true;
           }
         }
         if (setpoint->mode.y == modeAbs) {
           if (setpoint->position.y < geofenceYmin) {
             setpoint->position.y = geofenceYmin;
+            geofenceActivated = true;
           } else if (setpoint->position.y > geofenceYmax) {
             setpoint->position.y = geofenceYmax;
+            geofenceActivated = true;
           }
         }
         if (setpoint->mode.z == modeAbs) {
           if (setpoint->position.z < geofenceZmin) {
             setpoint->position.z = geofenceZmin;
+            geofenceActivated = true;
           } else if (setpoint->position.z > geofenceZmax) {
             setpoint->position.z = geofenceZmax;
+            geofenceActivated = true;
           }
         }
       }
@@ -698,22 +716,28 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       if (setpoint->mode.x == modeAbs) {
         if (setpoint->position.x < geofenceXmin) {
           setpoint->position.x = geofenceXmin;
+          geofenceActivated = true;
         } else if (setpoint->position.x > geofenceXmax) {
           setpoint->position.x = geofenceXmax;
+          geofenceActivated = true;
         }
       }
       if (setpoint->mode.y == modeAbs) {
         if (setpoint->position.y < geofenceYmin) {
           setpoint->position.y = geofenceYmin;
+          geofenceActivated = true;
         } else if (setpoint->position.y > geofenceYmax) {
           setpoint->position.y = geofenceYmax;
+          geofenceActivated = true;
         }
       }
       if (setpoint->mode.z == modeAbs) {
         if (setpoint->position.z < geofenceZmin) {
           setpoint->position.z = geofenceZmin;
+          geofenceActivated = true;
         } else if (setpoint->position.z > geofenceZmax) {
           setpoint->position.z = geofenceZmax;
+          geofenceActivated = true;
         }
       }
 
@@ -721,22 +745,28 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       if (setpoint->mode.x == modeVelocity) {
         if (state->position.x < geofenceXmin) {
           setpoint->velocity.x = fabs(setpoint->velocity.x);
+          geofenceActivated = true;
         } else if (state->position.x > geofenceXmax) {
           setpoint->velocity.x = -fabs(setpoint->velocity.x);
+          geofenceActivated = true;
         }
       }
       if (setpoint->mode.y == modeVelocity) {
         if (state->position.y < geofenceYmin) {
           setpoint->velocity.y = fabs(setpoint->velocity.y);
+          geofenceActivated = true;
         } else if (state->position.y > geofenceYmax) {
           setpoint->velocity.y = -fabs(setpoint->velocity.y);
+          geofenceActivated = true;
         }
       }
       if (setpoint->mode.z == modeVelocity) {
         if (state->position.z < geofenceZmin) {
           setpoint->velocity.z = fabs(setpoint->velocity.z);
+          geofenceActivated = true;
         } else if (state->position.z > geofenceZmax) {
           setpoint->velocity.z = -fabs(setpoint->velocity.z);
+          geofenceActivated = true;
         }
       }
 
@@ -759,6 +789,7 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       memcpy(setpoint, &nullSetpoint, sizeof(nullSetpoint));
       break;
   }
+  geofenceTriggeredUpdate(geofenceActivated);
 }
 
 bool supervisorAreMotorsAllowedToRun() {
@@ -846,6 +877,10 @@ LOG_ADD(LOG_UINT16, info, &supervisorMem.infoBitfield)
  * @brief Acceleration norm in Gs used by crash/tumble detection.
  */
 LOG_ADD(LOG_FLOAT, accNorm, &crashDetectionAccNorm)
+/**
+ * @brief Indicates if the geofence has been triggered. 1=triggered, 0=not triggered
+ */
+LOG_ADD(LOG_UINT8, geofTrig, &geofenceTriggered)
 LOG_GROUP_STOP(supervisor)
 
 

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -744,28 +744,40 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
       // If setpoint is velocity, return to geofence by overiding velocity setpoints
       if (setpoint->mode.x == modeVelocity) {
         if (state->position.x < geofenceXmin) {
-          setpoint->velocity.x = fabs(setpoint->velocity.x);
+          setpoint->mode.x = modeAbs;
+          setpoint->position.x = geofenceXmin;
+          setpoint->velocity.x = 0;
           geofenceActivated = true;
         } else if (state->position.x > geofenceXmax) {
-          setpoint->velocity.x = -fabs(setpoint->velocity.x);
+          setpoint->mode.x = modeAbs;
+          setpoint->position.x = geofenceXmax;
+          setpoint->velocity.x = 0;
           geofenceActivated = true;
         }
       }
       if (setpoint->mode.y == modeVelocity) {
         if (state->position.y < geofenceYmin) {
-          setpoint->velocity.y = fabs(setpoint->velocity.y);
+          setpoint->mode.y = modeAbs;
+          setpoint->position.y = geofenceYmin;
+          setpoint->velocity.y = 0;
           geofenceActivated = true;
         } else if (state->position.y > geofenceYmax) {
-          setpoint->velocity.y = -fabs(setpoint->velocity.y);
+          setpoint->mode.y = modeAbs;
+          setpoint->position.y = geofenceYmax;
+          setpoint->velocity.y = 0;
           geofenceActivated = true;
         }
       }
       if (setpoint->mode.z == modeVelocity) {
         if (state->position.z < geofenceZmin) {
-          setpoint->velocity.z = fabs(setpoint->velocity.z);
+          setpoint->mode.z = modeAbs;
+          setpoint->position.z = geofenceZmin;
+          setpoint->velocity.z = 0;
           geofenceActivated = true;
         } else if (state->position.z > geofenceZmax) {
-          setpoint->velocity.z = -fabs(setpoint->velocity.z);
+          setpoint->mode.z = modeAbs;
+          setpoint->position.z = geofenceZmax;
+          setpoint->velocity.z = 0;
           geofenceActivated = true;
         }
       }

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -77,6 +77,14 @@ static uint16_t rpmCheckDurationMs = CONFIG_MOTORS_ARMING_RPM_DURATION_MS;
 static uint16_t motorsNotRespondingRpmThreshold = CONFIG_MOTORS_RPM_NOT_RESPONDING_THRESHOLD;
 #endif
 
+static float geofenceWarningZone = 1.0f;
+static float geofenceXmin = -10.0f;
+static float geofenceXmax = 10.0f;
+static float geofenceYmin = -10.0f;
+static float geofenceYmax = 10.0f;
+static float geofenceZmin = -0.5f;
+static float geofenceZmax = 10.0f;
+
 typedef struct {
   bool canFly;
   bool isFlying;
@@ -358,6 +366,28 @@ static bool isTumbledCheck(SupervisorMem_t* this, const sensorData_t *data, cons
   return false;
 }
 
+//
+// Checks if we are outside of allowed geofence limits
+//
+
+static bool isOutsideGeofenceCheck(const state_t *state, const float margin) {
+  const bool isOutsideX = (state->position.x < geofenceXmin - margin) || (state->position.x > geofenceXmax + margin);
+  const bool isOutsideY = (state->position.y < geofenceYmin - margin) || (state->position.y > geofenceYmax + margin);
+  const bool isOutsideZ = (state->position.z < geofenceZmin - margin) || (state->position.z > geofenceZmax + margin);
+
+  bool result = isOutsideX || isOutsideY || isOutsideZ;
+  
+  return result;
+}
+
+static bool isOutsideGeofenceWarningCheck(const state_t *state) {
+  return isOutsideGeofenceCheck(state, 0.0f);
+}
+
+static bool isOutsideGeofenceStopCheck(const state_t *state) {
+  return isOutsideGeofenceCheck(state, geofenceWarningZone);
+}
+
 static bool checkEmergencyStopWatchdog(const uint32_t tick) {
   bool isOk = true;
 
@@ -443,6 +473,7 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
   if (newState != supervisorStateArming &&
       newState != supervisorStateReadyToFly &&
       newState != supervisorStateFlying &&
+      newState != supervisorStateWarningReturnToGeofence &&
       newState != supervisorStateWarningLevelOut &&
       newState != supervisorStateLanded) {
     supervisorRequestArming(false);
@@ -457,8 +488,9 @@ static void postTransitionActions(SupervisorMem_t* this, const supervisorState_t
 }
 
 uint8_t tumbleCheckEnabled = SUPERVISOR_TUMBLE_CHECK_ENABLE;
+uint8_t geofenceCheckEnabled = SUPERVISOR_GEOFENCE_CHECK_ENABLE;
 
-static supervisorConditionBits_t updateAndPopulateConditions(SupervisorMem_t* this, const sensorData_t *sensors, const setpoint_t* setpoint, const uint32_t currentTick) {
+static supervisorConditionBits_t updateAndPopulateConditions(SupervisorMem_t* this, const sensorData_t *sensors, const setpoint_t* setpoint, const state_t* state, const uint32_t currentTick) {
   supervisorConditionBits_t conditions = 0;
 
   if (supervisorIsArmed()) {
@@ -475,6 +507,23 @@ static supervisorConditionBits_t updateAndPopulateConditions(SupervisorMem_t* th
     if (tumbleCheckEnabled)
     {
       conditions |= SUPERVISOR_CB_IS_TUMBLED;
+    }
+  }
+
+  
+  const bool isOutsideGeofenceWarning = isOutsideGeofenceWarningCheck(state);
+  if (isOutsideGeofenceWarning) {
+    if (geofenceCheckEnabled)
+    {
+      conditions |= SUPERVISOR_CB_GEOFENCE_WARNING;
+    }
+  }
+
+  const bool isOutsideGeofenceStop = isOutsideGeofenceStopCheck(state);
+  if (isOutsideGeofenceStop) {
+    if (geofenceCheckEnabled)
+    {
+      conditions |= SUPERVISOR_CB_GEOFENCE_STOP;
     }
   }
 
@@ -539,7 +588,7 @@ static supervisorConditionBits_t updateAndPopulateConditions(SupervisorMem_t* th
 
 static void updateLogData(SupervisorMem_t* this, const supervisorConditionBits_t conditions) {
   this->canFly = supervisorCanFly();
-  this->isFlying = (this->state == supervisorStateFlying) || (this->state == supervisorStateWarningLevelOut);
+  this->isFlying = (this->state == supervisorStateFlying) || (this->state == supervisorStateWarningLevelOut) || (this->state == supervisorStateWarningReturnToGeofence);
   this->isTumbled = (conditions & SUPERVISOR_CB_IS_TUMBLED) != 0;
 
   this->infoBitfield = 0;
@@ -582,10 +631,9 @@ static void updateLogData(SupervisorMem_t* this, const supervisorConditionBits_t
   if (conditions & SUPERVISOR_CB_DECK_FAULT) {
       this->infoBitfield |= 0x0800;  // a deck has reported a hardware fault
   }
-
 }
 
-void supervisorUpdate(const sensorData_t *sensors, const setpoint_t* setpoint, stabilizerStep_t stabilizerStep) {
+void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, const state_t *state, stabilizerStep_t stabilizerStep) {
   if (!RATE_DO_EXECUTE(RATE_SUPERVISOR, stabilizerStep)) {
     return;
   }
@@ -593,7 +641,7 @@ void supervisorUpdate(const sensorData_t *sensors, const setpoint_t* setpoint, s
   SupervisorMem_t* this = &supervisorMem;
   const uint32_t currentTick = xTaskGetTickCount();
 
-  const supervisorConditionBits_t conditions = updateAndPopulateConditions(this, sensors, setpoint, currentTick);
+  const supervisorConditionBits_t conditions = updateAndPopulateConditions(this, sensors, setpoint, state, currentTick);
   const supervisorState_t newState = supervisorStateUpdate(this->state, conditions);
   if (this->state != newState) {
     const supervisorState_t previousState = this->state;
@@ -619,9 +667,57 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint) {
     case supervisorStateLanded:
       // Fall through
     case supervisorStateFlying:
-      // Do nothing
+      if (geofenceCheckEnabled){
+        // Constrain setpoint position to be inside geofence
+        if (setpoint->mode.x == modeAbs) {
+          if (setpoint->position.x < geofenceXmin) {
+            setpoint->position.x = geofenceXmin;
+          } else if (setpoint->position.x > geofenceXmax) {
+            setpoint->position.x = geofenceXmax;
+          }
+        }
+        if (setpoint->mode.y == modeAbs) {
+          if (setpoint->position.y < geofenceYmin) {
+            setpoint->position.y = geofenceYmin;
+          } else if (setpoint->position.y > geofenceYmax) {
+            setpoint->position.y = geofenceYmax;
+          }
+        }
+        if (setpoint->mode.z == modeAbs) {
+          if (setpoint->position.z < geofenceZmin) {
+            setpoint->position.z = geofenceZmin;
+          } else if (setpoint->position.z > geofenceZmax) {
+            setpoint->position.z = geofenceZmax;
+          }
+        }
+      }
       break;
 
+    case supervisorStateWarningReturnToGeofence:
+      // Constrain setpoint position to be inside geofence
+      if (setpoint->mode.x == modeAbs) {
+        if (setpoint->position.x < geofenceXmin) {
+          setpoint->position.x = geofenceXmin;
+        } else if (setpoint->position.x > geofenceXmax) {
+          setpoint->position.x = geofenceXmax;
+        }
+      }
+      if (setpoint->mode.y == modeAbs) {
+        if (setpoint->position.y < geofenceYmin) {
+          setpoint->position.y = geofenceYmin;
+        } else if (setpoint->position.y > geofenceYmax) {
+          setpoint->position.y = geofenceYmax;
+        }
+      }
+      if (setpoint->mode.z == modeAbs) {
+        if (setpoint->position.z < geofenceZmin) {
+          setpoint->position.z = geofenceZmin;
+        } else if (setpoint->position.z > geofenceZmax) {
+          setpoint->position.z = geofenceZmax;
+        }
+      }
+      break;
+      
     case supervisorStateWarningLevelOut:
       setpoint->mode.x = modeDisable;
       setpoint->mode.y = modeDisable;
@@ -646,6 +742,7 @@ bool supervisorAreMotorsAllowedToRun() {
   return (this->state == supervisorStateArming) ||
          (this->state == supervisorStateReadyToFly) ||
          (this->state == supervisorStateFlying) ||
+         (this->state == supervisorStateWarningReturnToGeofence) ||
          (this->state == supervisorStateWarningLevelOut) ||
          (this->state == supervisorStateLanded);
 }
@@ -765,4 +862,55 @@ PARAM_ADD(PARAM_UINT16 | PARAM_PERSISTENT, spinupTimeout, &armingSpinupTimeoutDu
  */
 PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, crashDetectGs, &crashDetectionGs)
 
+/**
+ * @brief Set to one to enable geofence check
+ */
+PARAM_ADD(PARAM_UINT8 | PARAM_PERSISTENT, geofChckEn, &geofenceCheckEnabled)
+
 PARAM_GROUP_STOP(supervisor)
+
+
+/**
+ * Geofence makes sure setpoints cannot be set outside of defined limits and that 
+ * flight is stopped if the limits are exceeded.
+ */
+PARAM_GROUP_START(geofence)
+
+/**
+ * @brief Geofence failsafe zone width (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofWarnZone, &geofenceWarningZone)
+
+/**
+ * @brief Geofence X min (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofXmin, &geofenceXmin)
+
+/**
+ * @brief Geofence X max (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofXmax, &geofenceXmax)
+
+/**
+ * @brief Geofence Y min (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofYmin, &geofenceYmin)
+
+/**
+ * @brief Geofence Y max (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofYmax, &geofenceYmax)
+
+/**
+ * @brief Geofence Z min (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofZmin, &geofenceZmin)
+
+/**
+ * @brief Geofence Z max (m)
+ */
+PARAM_ADD(PARAM_FLOAT | PARAM_PERSISTENT, geofZmax, &geofenceZmax)  
+
+PARAM_GROUP_STOP(geofence)
+
+

--- a/src/modules/src/supervisor.c
+++ b/src/modules/src/supervisor.c
@@ -657,7 +657,7 @@ void supervisorUpdate(const sensorData_t *sensors, const setpoint_t *setpoint, c
   }
 }
 
-void supervisorOverrideSetpoint(setpoint_t* setpoint) {
+void supervisorOverrideSetpoint(setpoint_t* setpoint, const state_t *state) {
   SupervisorMem_t* this = &supervisorMem;
   switch(this->state){
     case supervisorStateArming:
@@ -716,6 +716,30 @@ void supervisorOverrideSetpoint(setpoint_t* setpoint) {
           setpoint->position.z = geofenceZmax;
         }
       }
+
+      // If setpoint is velocity, return to geofence by overiding velocity setpoints
+      if (setpoint->mode.x == modeVelocity) {
+        if (state->position.x < geofenceXmin) {
+          setpoint->velocity.x = fabs(setpoint->velocity.x);
+        } else if (state->position.x > geofenceXmax) {
+          setpoint->velocity.x = -fabs(setpoint->velocity.x);
+        }
+      }
+      if (setpoint->mode.y == modeVelocity) {
+        if (state->position.y < geofenceYmin) {
+          setpoint->velocity.y = fabs(setpoint->velocity.y);
+        } else if (state->position.y > geofenceYmax) {
+          setpoint->velocity.y = -fabs(setpoint->velocity.y);
+        }
+      }
+      if (setpoint->mode.z == modeVelocity) {
+        if (state->position.z < geofenceZmin) {
+          setpoint->velocity.z = fabs(setpoint->velocity.z);
+        } else if (state->position.z > geofenceZmax) {
+          setpoint->velocity.z = -fabs(setpoint->velocity.z);
+        }
+      }
+
       break;
       
     case supervisorStateWarningLevelOut:

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -57,8 +57,6 @@ static const char* const conditionNames[] = {
   "armed",
   "isFlying",
   "isTumbled",
-  "geofenceWarning",
-  "geofenceStop",
   "commanderWdtWarning",
   "commanderWdtTimeout",
   "emergencyStop",
@@ -69,6 +67,8 @@ static const char* const conditionNames[] = {
   "rpmAtArmingValid",
   "spinupTimeout",
   "motorsNotResponding",
+  "geofenceWarning",
+  "geofenceStop",
 };
 static_assert(sizeof(conditionNames) / sizeof(conditionNames[0]) == supervisorCondition_NrOfConditions);
 
@@ -147,7 +147,7 @@ static SupervisorStateTransition_t transitionsMotorsSpinup[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_SPINUP_TIMEOUT,
+    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_SPINUP_TIMEOUT | SUPERVISOR_CB_GEOFENCE_WARNING | SUPERVISOR_CB_GEOFENCE_STOP,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 

--- a/src/modules/src/supervisor_state_machine.c
+++ b/src/modules/src/supervisor_state_machine.c
@@ -45,6 +45,7 @@ static const char* const stateNames[] = {
   "Flying",
   "Landed",
   "Reset",
+  "Warning, return inside geofence",
   "Warning, level out",
   "Exception, free fall",
   "Locked",
@@ -56,6 +57,8 @@ static const char* const conditionNames[] = {
   "armed",
   "isFlying",
   "isTumbled",
+  "geofenceWarning",
+  "geofenceStop",
   "commanderWdtWarning",
   "commanderWdtTimeout",
   "emergencyStop",
@@ -93,7 +96,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksNotPassed[] = {
 
     .triggerCombiner = supervisorAlways,
 
-    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_DECK_FAULT,
+    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_GEOFENCE_WARNING | SUPERVISOR_CB_GEOFENCE_STOP | SUPERVISOR_CB_DECK_FAULT,
     .negatedBlockers = SUPERVISOR_CB_NONE,
     .blockerCombiner = supervisorAny,
   }
@@ -112,7 +115,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksPassed[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_DECK_FAULT,
+    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_GEOFENCE_WARNING | SUPERVISOR_CB_GEOFENCE_STOP | SUPERVISOR_CB_DECK_FAULT,
     .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAny,
 
@@ -125,7 +128,7 @@ static SupervisorStateTransition_t transitionsPreFlChecksPassed[] = {
     .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAll,
 
-    .blockers = SUPERVISOR_CB_IS_TUMBLED,
+    .blockers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_GEOFENCE_WARNING | SUPERVISOR_CB_GEOFENCE_STOP,
     .negatedBlockers = SUPERVISOR_CB_NONE,
     .blockerCombiner = supervisorAny,
   },
@@ -175,7 +178,7 @@ static SupervisorStateTransition_t transitionsReadyToFly[] = {
   {
     .newState = supervisorStatePreFlChecksNotPassed,
 
-    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_PREFLIGHT_TIMEOUT | SUPERVISOR_CB_DECK_FAULT,
+    .triggers = SUPERVISOR_CB_IS_TUMBLED | SUPERVISOR_CB_PREFLIGHT_TIMEOUT | SUPERVISOR_CB_DECK_FAULT | SUPERVISOR_CB_GEOFENCE_WARNING | SUPERVISOR_CB_GEOFENCE_STOP,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
     .triggerCombiner = supervisorAny,
 
@@ -219,6 +222,15 @@ static SupervisorStateTransition_t transitionsFlying[] = {
 
     .triggers = SUPERVISOR_CB_NONE,
     .negatedTriggers = SUPERVISOR_CB_ARMED,
+    .triggerCombiner = supervisorAll,
+
+    .blockerCombiner = supervisorNever,
+  },
+  {
+    .newState = supervisorStateWarningReturnToGeofence,
+
+    .triggers = SUPERVISOR_CB_GEOFENCE_WARNING,
+    .negatedTriggers = SUPERVISOR_CB_NONE,
     .triggerCombiner = supervisorAll,
 
     .blockerCombiner = supervisorNever,
@@ -278,6 +290,36 @@ static SupervisorStateTransition_t transitionsReset[] = {
     .newState = supervisorStatePreFlChecksNotPassed,
 
     .triggerCombiner = supervisorAlways,
+
+    .blockerCombiner = supervisorNever,
+  },
+};
+
+static SupervisorStateTransition_t transitionsWarningGeofence[] = {
+  {
+    .newState = supervisorStateExceptFreeFall,
+
+    .triggers = SUPERVISOR_CB_GEOFENCE_STOP | SUPERVISOR_CB_EMERGENCY_STOP | SUPERVISOR_CB_DECK_FAULT,
+    .negatedTriggers = SUPERVISOR_CB_NONE,
+    .triggerCombiner = supervisorAny,
+
+    .blockerCombiner = supervisorNever,
+  },
+  {
+    .newState = supervisorStateExceptFreeFall,
+
+    .triggers = SUPERVISOR_CB_MOTORS_NOT_RESPONDING,
+    .negatedTriggers = SUPERVISOR_CB_NONE,
+    .triggerCombiner = supervisorAll,
+
+    .blockerCombiner = supervisorNever,
+  },
+  {
+    .newState = supervisorStateFlying,
+
+    .triggers = SUPERVISOR_CB_NONE,
+    .negatedTriggers = SUPERVISOR_CB_GEOFENCE_STOP | SUPERVISOR_CB_GEOFENCE_WARNING,
+    .triggerCombiner = supervisorAll,
 
     .blockerCombiner = supervisorNever,
   },
@@ -364,6 +406,7 @@ SupervisorStateTransitionList_t transitionLists[] = {
   {SUPERVISOR_TRANSITION_ENTRY(transitionsFlying)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsLanded)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsReset)},
+  {SUPERVISOR_TRANSITION_ENTRY(transitionsWarningGeofence)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsWarningLevelOut)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsExceptFreeFall)},
   {SUPERVISOR_TRANSITION_ENTRY(transitionsLocked)},

--- a/src/platform/interface/platform_defaults.h
+++ b/src/platform/interface/platform_defaults.h
@@ -152,6 +152,11 @@
     #define SUPERVISOR_TUMBLE_CHECK_ENABLE true
 #endif
 
+// Geofence settings
+#ifndef SUPERVISOR_GEOFENCE_CHECK_ENABLE
+    #define SUPERVISOR_GEOFENCE_CHECK_ENABLE false
+#endif
+
 // 60 degrees tilt (when stationary)
 #ifndef SUPERVISOR_TUMBLE_CHECK_ACCEPTED_TILT_ACCZ
     #define SUPERVISOR_TUMBLE_CHECK_ACCEPTED_TILT_ACCZ 0.5f


### PR DESCRIPTION
This PR adds geofence function to the supervisor, which ensures that:

1) Setpoints can only be set within the geofenced volume
2) If the crazyflie flies (too far) out of the geofence, it gets locked

The geofence function is disabled by default and can be turned on by SUPERVISOR_GEOFENCE_CHECK_ENABLE or via a (persistent) parameter. The geofence volume limits can be set via parameters.

A new state "WarningReturnToGeofence" is introduced when the crazyflie is outside the geofence volume but still within the "geofenceWarningZone" distance from it. This is to allow the crazyflie to overshoot e.g. due to a disturbance. And also for situations when we are in modeVelocity, here we switch to position control until we are back within the geofence.

Flight tested on the crazyflies and Flappers BEFORE the following was introduced, so some testing is still required (am currently out of office, but will test later):
- SUPERVISOR_CB_DECK_FAULT (but a pretty much identical implementation was used to detect Lighthouse deck communication timouts in the flight tests)
- SUPERVISOR_CB_MOTORS_NOT_RESPONDING