### PR TITLE
Disable prop and battery tests (Flapper platform)

### DIFF
--- a/src/modules/src/health.c
+++ b/src/modules/src/health.c
@@ -149,15 +149,23 @@ static bool evaluatePropTest(float low, float high, float value, uint8_t motor)
 
 bool healthShallWeRunTest(void)
 {
-
   if (startPropTest != false) {
+#ifndef HEALTH_DISABLE_PROP_TEST
     testState = configureAcc;
+#else
+  DEBUG_PRINT("Propeller test disabled for this platform.\n");
+#endif
     startPropTest = false;
   } else if (startBatTest != false) {
+#ifndef HEALTH_DISABLE_BAT_TEST
     testState = testBattery;
+#else
+  DEBUG_PRINT("Battery test disabled for this platform.\n");
+#endif
     startBatTest = false;
     tick = 0;
   }
+
 
   return (testState != testDone);
 }

--- a/src/platform/interface/platform_defaults_flapper.h
+++ b/src/platform/interface/platform_defaults_flapper.h
@@ -42,6 +42,9 @@
 // Requires kbuild config ENABLE_AUTO_SHUTDOWN to be activated.
 #define DEFAULT_SYSTEM_SHUTDOWN_TIMEOUT_MIN       5
 
+#define HEALTH_DISABLE_PROP_TEST true
+#define HEALTH_DISABLE_BAT_TEST true
+
 // Default PID gains
 #define PID_ROLL_RATE_KP  50.0
 #define PID_ROLL_RATE_KI  0.0


### PR DESCRIPTION
This PR adds 2 defines allowing to disable the prop and battery tests for platforms, where this functionality is not implemented.

The defines are added to the Flapper platform defaults, no other platforms should be affected.