### PR TITLE
Add zsh and bash tab completion scripts for make

### DIFF
--- a/docs/development/kbuild.md
+++ b/docs/development/kbuild.md
@@ -57,3 +57,19 @@ To get an idea of how `menuconfig` will look, please see the images below.
 
 Read more about platforms in the [platform section.](/docs/userguides/platform.md)
 
+### Shell tab completion
+
+Tab-completion scripts for `make` are available for bash and zsh in `tools/completion/`. They complete build targets (e.g. `menuconfig`, `clean`) as well as the `configs/*_defconfig` files, and only take effect inside a checkout of this repository.
+
+To enable it, add one of the following lines to your shell's rc file:
+
+```bash
+# ~/.bashrc
+source /path/to/crazyflie-firmware/tools/completion/make-completion.bash
+```
+
+```bash
+# ~/.zshrc
+source /path/to/crazyflie-firmware/tools/completion/make-completion.zsh
+```
+

--- a/tools/completion/make-completion.bash
+++ b/tools/completion/make-completion.bash
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Bash tab-completion for `make` in crazyflie-firmware.
+#
+# Completes:
+#   - every target listed by `make help` (config targets, clean, all, etc.)
+#   - every configs/*_defconfig file, as `make <name>_defconfig`
+#
+# Only takes effect inside a checkout of this repo (detected via
+# tools/kbuild/Makefile.kbuild); everywhere else, `make` completion falls
+# back to bash's normal behaviour.
+#
+# Usage: add this line to your ~/.bashrc:
+#   source /path/to/crazyflie-firmware/tools/completion/make-completion.bash
+
+_cf_kbuild_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/tools/kbuild/Makefile.kbuild" ]]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    return 1
+}
+
+_cf_make() {
+    local root
+    root=$(_cf_kbuild_root)
+
+    if [[ -z "$root" ]]; then
+        if declare -F _make >/dev/null; then
+            _make
+        elif declare -F _filedir >/dev/null; then
+            _filedir
+        fi
+        return
+    fi
+
+    local cur targets
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    targets=$(
+        {
+            command make -s -C "$root" help 2>/dev/null \
+                | sed -n -E 's/^\*?[[:space:]]+([A-Za-z0-9_.-]+)[[:space:]]+-[[:space:]]+.*$/\1/p'
+            for f in "$root"/configs/*_defconfig; do
+                [[ -e "$f" ]] && basename "$f"
+            done
+        } | sort -u
+    )
+
+    COMPREPLY=($(compgen -W "$targets" -- "$cur"))
+}
+
+complete -F _cf_make -o default make

--- a/tools/completion/make-completion.zsh
+++ b/tools/completion/make-completion.zsh
@@ -47,7 +47,7 @@ _cf_make() {
 
 	defconfig_targets=(${(f)"$(
 		for f in "$root"/configs/*_defconfig(N); do
-			print -r -- "${f:t}:defconfig (${f:t:r})"
+			print -r -- "${f:t}:defconfig (${${f:t}%_defconfig})"
 		done
 	)"})
 

--- a/tools/completion/make-completion.zsh
+++ b/tools/completion/make-completion.zsh
@@ -1,0 +1,58 @@
+#!/usr/bin/env zsh
+#
+# Zsh tab-completion for `make` in crazyflie-firmware.
+#
+# Completes:
+#   - every target listed by `make help` (config targets, clean, all, etc.)
+#   - every configs/*_defconfig file, as `make <name>_defconfig`
+#
+# Only takes effect inside a checkout of this repo (detected via
+# tools/kbuild/Makefile.kbuild); everywhere else, `make` completion falls
+# back to zsh's normal behaviour.
+#
+# Usage: add this line to your ~/.zshrc:
+#   source /path/to/crazyflie-firmware/tools/completion/make-completion.zsh
+
+_cf_kbuild_root() {
+	local dir=$PWD
+	while [[ $dir != / ]]; do
+		if [[ -f $dir/tools/kbuild/Makefile.kbuild ]]; then
+			print -r -- "$dir"
+			return 0
+		fi
+		dir=${dir:h}
+	done
+	return 1
+}
+
+_cf_make() {
+	local root
+	root=$(_cf_kbuild_root)
+
+	if [[ -z $root ]]; then
+		if (( $+functions[_make] )); then
+			_make
+		else
+			_default
+		fi
+		return
+	fi
+
+	local -a help_targets defconfig_targets
+
+	help_targets=(${(f)"$(
+		command make -s -C "$root" help 2>/dev/null \
+			| sed -n -E 's/^\*?[[:space:]]+([A-Za-z0-9_.-]+)[[:space:]]+-[[:space:]]+(.*)$/\1:\2/p'
+	)"})
+
+	defconfig_targets=(${(f)"$(
+		for f in "$root"/configs/*_defconfig(N); do
+			print -r -- "${f:t}:defconfig (${f:t:r})"
+		done
+	)"})
+
+	_describe -t make-help-targets 'make target' help_targets
+	_describe -t make-defconfig-targets 'defconfig target' defconfig_targets
+}
+
+compdef _cf_make make


### PR DESCRIPTION
Add tab completion for make targets for zsh and bash. 

Tab-completion scripts for `make` are available for bash and zsh in `tools/completion/`. They complete build targets (e.g. `menuconfig`, `clean`) as well as the `configs/*_defconfig` files, and only take effect inside a checkout of this repository.

<img width="778" height="762" alt="image" src="https://github.com/user-attachments/assets/7d300422-0757-4187-a7a1-da258bbc708d" />

<img width="443" height="119" alt="image" src="https://github.com/user-attachments/assets/f6cc1301-6d05-499e-96b4-2961b62d3c4c" />

It has to be manually enabled by sourcing the file in respective rc file. See documentation in `kbuild.md` for details.