### PR TITLE
Updated release to use softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       id: get_release_version
       env:
         GITHUB_REF : ${{ github.ref }}
-      run: echo "release_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+      run: echo "release_version=$(echo "${GITHUB_REF/refs\/tags\//}" | tr '/' '-')" >> $GITHUB_OUTPUT
 
     - name: Rename binary for upload
       run: cp build/${{ matrix.platform }}.bin build/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,12 @@ jobs:
       run: echo "release_version=$(echo "${GITHUB_REF/refs\/tags\//}" | tr '/' '-')" >> $GITHUB_OUTPUT
 
     - name: Rename binary for upload
-      run: cp build/${{ matrix.platform }}.bin build/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
+      run: |
+        mkdir -p release_assets
+        cp build/${{ matrix.platform }}.bin release_assets/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
 
     - name: Upload ${{ matrix.platform }} bin
       uses: softprops/action-gh-release@e598afbe1493e6b1bafb1f389cabb956eab91231 # v3.0.3
       with:
         tag_name: ${{ github.ref }}
-        files: build/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
+        files: release_assets/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,6 @@ jobs:
       uses: softprops/action-gh-release@e598afbe1493e6b1bafb1f389cabb956eab91231 # v3.0.3
       with:
         tag_name: ${{ github.ref }}
+        draft: true
+        prerelease: true
         files: release_assets/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,31 +16,21 @@ jobs:
 
   release:
     permissions:
-      contents: write  # for actions/create-release to create a release
+      contents: write  # for softprops/action-gh-release to create a release
     name: Create Release on Github
     runs-on: ubuntu-latest
     steps:
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@e598afbe1493e6b1bafb1f389cabb956eab91231 # v3.0.3
       with:
         tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
+        name: ${{ github.ref }}
         draft: true
         prerelease: true
-    - name: Release URL on file
-      run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
-    - name: Save Release URL File For Uploading Files
-      uses: actions/upload-artifact@v7
-      with:
-        name: release_url
-        path: release_url.txt
 
   upload:
     permissions:
-      contents: write  # for actions/upload-release-asset to upload release asset
+      contents: write  # for softprops/action-gh-release to upload release assets
     name: Upload Binaries to release
     needs: [release, read_targets_from_file]
     runs-on: ubuntu-latest
@@ -58,29 +48,17 @@ jobs:
     - name: Build
       run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "make ${{ matrix.platform }}_defconfig && ./tools/build/build PLATFORM=${{ matrix.platform }} UNIT_TEST_STYLE=min"
 
-    - name: Load Release URL File from release job
-      uses: actions/download-artifact@v8
-      with:
-        name: release_url
-
-    - name: Get Release File Name & Upload URL
-      id: get_release_info
-      run: |
-        value=`cat release_url.txt`
-        echo "upload_url=$value" >> $GITHUB_OUTPUT
-
     - name: Get the version
       id: get_release_version
       env:
         GITHUB_REF : ${{ github.ref }}
       run: echo "release_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
+    - name: Rename binary for upload
+      run: cp build/${{ matrix.platform }}.bin build/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
+
     - name: Upload ${{ matrix.platform }} bin
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@e598afbe1493e6b1bafb1f389cabb956eab91231 # v3.0.3
       with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: build/${{ matrix.platform }}.bin
-        asset_name: ${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin
-        asset_content_type: application/octet-stream
+        tag_name: ${{ github.ref }}
+        files: build/${{ matrix.platform }}-${{ steps.get_release_version.outputs.release_version }}.bin


### PR DESCRIPTION
## Summary

Closes #1675.

`.github/workflows/release.yml` used `actions/create-release@v1` and
`actions/upload-release-asset@v1`, both archived by GitHub with no
newer major version. They run on the Node.js 20 runtime, which GitHub
Actions no longer ships, so every `release` run logged a
`Node.js 20 is deprecated` warning annotation on the `Create Release on
Github` job and on each per-platform `Upload Binaries to release`
matrix job.

This PR replaces both with
[`softprops/action-gh-release`](https://github.com/softprops/action-gh-release)
`v3.0.3` (pinned by commit SHA, matching this file's existing pinning
convention), which creates the release and uploads assets to it in one
maintained action, and removes the `release_url.txt` artifact
upload/download steps that only existed to pass `create_release`'s
`upload_url` output between jobs — `action-gh-release` doesn't need it,
since it can be invoked multiple times against the same tag (creates
on first call, adds files on later calls).

## Why a third-party action

GitHub has not published an in-house successor to `actions/create-release`/
`actions/upload-release-asset`. The alternative is scripting release
creation/upload with the first-party `gh` CLI directly in `run:` steps,
which avoids granting a third-party action `contents: write` at the
cost of more shell and manual idempotency handling.
`softprops/action-gh-release` was chosen instead, checked 2026-08-31:

- Referenced in ~267,000 workflow files on GitHub (`gh api search/code`),
  the de facto standard replacement for the archived `actions/*-release*`
  actions.
- 5,752 stars, 638 forks, not archived, latest release `v3.0.3`
  published the day before this check with a steady release cadence.

## Behavior preserved / changed

- `tag_name: ${{ github.ref }}` is passed on both jobs, matching the
  old actions exactly, so tag/release naming is unchanged.
- Asset renaming to `<platform>-<version>.bin` is preserved by copying
  the built binary to the desired filename before upload (into a new
  `release_assets/` directory — see below), since `action-gh-release`
  uploads under the basename of the given path rather than exposing a
  rename input.
- `draft: true` / `prerelease: true` are now passed explicitly on
  *both* the `release` and `upload` steps. `action-gh-release` updates
  the existing release in place and defaults `draft` to `false`, so
  without repeating it on `upload`, the release was found to go public
  the moment the first matrix job uploaded — before all platforms
  finished. This is a real behavior fix, not a no-op.
- The version-extraction step now sanitizes `/` out of
  `release_version` (`tr '/' '-'`). The old `asset_name:` input was
  just a label, so an embedded `/` (possible when this
  `workflow_dispatch`-only workflow is run against a branch ref
  instead of a tag) was harmless; the new step does a literal `cp` to
  a path built from that string, so an unsanitized `/` was read as a
  directory separator and crashed the copy. No-op for the intended
  tag-dispatch case.
- The renamed binary is now copied into a new `release_assets/`
  directory instead of alongside the build output in `build/`. The
  `Build` step runs inside a root Docker container that leaves `build/`
  root-owned on the runner host; the old workflow only ever *read* from
  `build/`, but the new `cp` step needs to *write* into it, which the
  non-root `runner` user can't do.

## Verification

Verified with four real
`workflow_dispatch` runs against scratch tags on this repo (each
behavior change above was found and fixed via one such run). Final run
([`33489172268`](https://github.com/bitcraze/crazyflie-firmware/actions/runs/33489172268),
tag `test-release-action-v4`) passed every check:

Run: [`33489172268`](https://github.com/bitcraze/crazyflie-firmware/actions/runs/33489172268)
(scratch tag `test-release-action-v4`)
Draft release: https://github.com/bitcraze/crazyflie-firmware/releases/tag/untagged-04c7082a2df3c3ea4bf5

| Test | Result |
| --- | --- |
| No `Node.js 20 is deprecated` annotation on any of the 6 jobs | Pass |
| Release created, tag matches, only one release object | Pass |
| Release stays `draft: true` / `prerelease: true` throughout (`published_at: null`) | Pass |
| Exactly 5 assets, one per platform (`cf2`, `bolt`, `tag`, `flapper`, `cf21bl`) | Pass |
| Assets correctly named `<platform>-test-release-action-v4.bin` | Pass |
| Assets non-empty, plausible size (297,540–306,656 bytes) | Pass |
| No `Save/Load Release URL File` plumbing steps in any job | Pass |
| Both jobs request only `contents: write` | Pass |
| Idempotency: re-running a matrix job updates its asset in place (no duplicate) | Pass |

The scratch tag/release used for the final verification run should be
deleted before or after merge.