### PR TITLE
Decrease CCMRAM usage for CF2 sensor buffers

### DIFF
--- a/src/hal/src/sensors_bmi088_bmp3xx.c
+++ b/src/hal/src/sensors_bmi088_bmp3xx.c
@@ -125,7 +125,7 @@ static volatile uint64_t imuIntTimestamp;
 
 static Axis3i16 gyroRaw;
 static Axis3i16 accelRaw;
-NO_DMA_CCM_SAFE_ZERO_INIT static BiasObj gyroBiasRunning;
+static BiasObj gyroBiasRunning;
 static Axis3f gyroBias;
 #if defined(SENSORS_GYRO_BIAS_CALCULATE_STDDEV) && defined (GYRO_BIAS_LIGHT_WEIGHT)
 static Axis3f gyroBiasStdDev;

--- a/src/hal/src/sensors_mpu9250_lps25h.c
+++ b/src/hal/src/sensors_mpu9250_lps25h.c
@@ -119,7 +119,7 @@ static volatile uint64_t imuIntTimestamp;
 
 static Axis3i16 gyroRaw;
 static Axis3i16 accelRaw;
-NO_DMA_CCM_SAFE_ZERO_INIT static BiasObj gyroBiasRunning;
+static BiasObj gyroBiasRunning;
 static Axis3f  gyroBias;
 #if defined(SENSORS_GYRO_BIAS_CALCULATE_STDDEV) && defined (GYRO_BIAS_LIGHT_WEIGHT)
 static Axis3f  gyroBiasStdDev;


### PR DESCRIPTION
This PR should alleviate the current high pressure we have on the CCM memory usage. It does a small step in the right direction by moving calibration buffers to the sram.

This brings the CCM usage bellow 90% which was my target for the exercise. More work may need to be done in the future to manage the memory: Crazyflie has a lot of drivers that cannot all be enabled at the same time so careful use of dynamic memory could be a better strategy in the future.

## Summary

- move the MPU9250/LPS25H and BMI088/BMP3xx gyro bias buffers from CCMRAM to normal SRAM
- keep both buffers statically allocated and preserve the existing calibration behavior
- leave runtime buffer sharing as a possible follow-up if further SRAM optimization is needed

Fixes #1676.

## Memory usage

The default CF2 build changes from:

- CCM: 64,888 bytes used (99%), 648 free
- RAM: 92,724 bytes used (71%), 38,348 free

to:

- CCM: 55,584 bytes used (85%), 9,952 free
- RAM: 102,028 bytes used (78%), 29,044 free

This provides more than the targeted 10% CCM headroom. The FreeRTOS heap remains a statically reserved 30,000-byte pool and is not reduced by this change.

The CF21BL build uses 55,120 bytes of CCM (84%), with 10,416 bytes free.

## Verification

- `make cf2_defconfig && make -j8`
- `make cf21bl_defconfig && make -j8`