### PR TITLE
Do not configure unused AI-deck IO2 and IO3 pins

### DIFF
--- a/src/deck/drivers/src/aideck.c
+++ b/src/deck/drivers/src/aideck.c
@@ -314,9 +314,6 @@ static void aideckInit(DeckInfo *info)
   if (isInit)
     return;
 
-  pinMode(DECK_GPIO_IO2, OUTPUT);
-  pinMode(DECK_GPIO_IO3, OUTPUT);
-
   bootloaderSync = xEventGroupCreate();
 
   // Pull reset for GAP8/ESP32


### PR DESCRIPTION
## Abstract

The AI-deck driver configured IO2 and IO3 as outputs even though these pins are not connected or used by the AI-deck. This could overwrite another deck driver configuration, such as the Loco deck alternative IRQ and reset pins, depending on initialization order.

Remove the unused configuration so IO2 and IO3 remain available to other decks. This matches the AI-deck schematic and its declared GPIO usage of IO1 and IO4.

Fixes #1655.

## Testing

- `make cf2_defconfig`
- `make -j8`