### PR TITLE
Make unit tests possible to run locally

### DIFF
--- a/docs/building-and-flashing/build.md
+++ b/docs/building-and-flashing/build.md
@@ -225,52 +225,5 @@ $ make flash
 
 ## Unit testing
 
-### Running all unit tests
-
-With the environment set up locally
-
-```
-$ make unit
-```
-
-with the docker builder image and the toolbelt
-
-```
-$ tb make unit
-```
-
-### Running one unit test
-
-When working with one specific file it is often convenient to run only one unit test
-
-```
-$ make unit FILES=test/utils/src/test_num.c
-```
-
-or with the toolbelt
-
-```
-$ tb make unit FILES=test/utils/src/test_num.c
-```
-
-### Running unit tests with specific build settings
-
-Defines are managed by make and are passed on to the unit test code. Use the
-normal ways of configuring make when running tests. For instance to run test
-for Crazyflie 1
-
-```
-$ make unit LPS_TDOA_ENABLE=1
-```
-
-### Dependencies
-
-Frameworks for unit testing and mocking are pulled in as git submodules.
-
-The testing framework uses ruby and rake to generate and run code.
-
-To minimize the need for installations and configuration, use the docker builder
-image (bitcraze/builder) that contains all tools needed. All scripts in the
-tools/build directory are intended to be run in the image. The
-[toolbelt](https://github.com/bitcraze/toolbelt) makes it
-easy to run the tool scripts.
+See the [unit testing](../development/unit_testing) page for how to run and
+configure unit tests locally or with the toolbelt.

--- a/docs/development/unit_testing.md
+++ b/docs/development/unit_testing.md
@@ -27,6 +27,8 @@ with the docker builder image and the toolbelt
 
         tb make unit
 
+Note that a bare `rake` run will fail even though `make unit` succeeds.
+
 ## Running one unit test
 
 When working with one specific file it is often convenient to run only one unit test

--- a/tools/test/gcc.yml
+++ b/tools/test/gcc.yml
@@ -3,10 +3,10 @@ kconfig:
   config_file: 'build/.config'
 compiler:
   path: gcc
-  source_path:     &source_path 'src/'
-  unit_tests_path: &unit_tests_path 'test/**/'
-  mocks_path:      &mocks_path 'generated/test/mocks/'
-  build_path:      &build_path 'generated/test/build/'
+  source_path:     'src/'
+  unit_tests_path: 'test/**/'
+  mocks_path:      'generated/test/mocks/'
+  build_path:      'generated/test/build/'
   options:
     - '-c'
     - '-Wall'
@@ -23,9 +23,9 @@ compiler:
   includes:
     prefix: '-I'
     items:
-      - *source_path
-      - *unit_tests_path
-      - *mocks_path
+      - 'src/'
+      - 'test/**/'
+      - 'generated/test/mocks/'
       - 'build/include/generated'
       - 'src/config'
       - 'src/deck/drivers/interface/'
@@ -87,7 +87,7 @@ compiler:
   object_files:
     prefix: '-o'
     extension: '.o'
-    destination: *build_path
+    destination: 'generated/test/build/'
   libs:
     TEST_SUPPORT:
       files:
@@ -116,12 +116,12 @@ linker:
   includes:
     prefix: '-I'
   object_files:
-    path: *build_path
+    path: 'generated/test/build/'
     extension: '.o'
   bin_files:
     prefix: '-o'
     extension: '.exe'
-    destination: *build_path
+    destination: 'generated/test/build/'
 
 unsupported:
   - out_of_memory
@@ -140,5 +140,5 @@ env:
     - :ignore
     - :array
     - :callback
-  :mock_path: *mocks_path
+  :mock_path: 'generated/test/mocks/'
   :mock_prefix: mock_


### PR DESCRIPTION
### Summary

Fixes #1649 — the documented local unit test workflow (`make unit`) crashed on any
current Ruby (3.1+) with `Psych::AliasesNotEnabled`, before running the full suite.

### Root cause

`tools/test/gcc.yml` (CMock's config file) used YAML anchors/aliases to keep four
path settings DRY. The vendored `cmock` submodule (pinned to a 2017 commit, `cb1ad78`)
loads this file with a plain `YAML.load_file`, which predates CMock's own fix for
Ruby 3.1's Psych 4 defaulting to a restricted loader that rejects alias nodes.

CI never saw this: the pinned `bitcraze/builder` image ships Ruby 3.0.2 (Psych 3,
aliases allowed by default), so only developers running the documented workflow
locally with a modern system Ruby hit the crash.

### Fix

`tools/test/gcc.yml` — replaced the four YAML anchors/aliases with the literal path
strings inline at every usage site. No other files changed, no submodule pins bumped.
Verified the parsed config is byte-identical before/after; only the alias mechanism
is gone.

Also fixed two documentation gaps found while checking related docs:
- `docs/development/unit_testing.md`: added a note against running bare `rake`
  directly — it fails separately on an unrelated stale `STM32F072xB` define (real,
  pre-existing, out of scope for this fix).
- `docs/building-and-flashing/build.md`: had a stale, drifted duplicate of the
  unit-testing section (missing the AddressSanitizer/`vm.mmap_rnd_bits` note).
  Deduplicated to a pointer at `unit_testing.md` instead of syncing two copies.

### Out of scope (tracked separately)

The fix introduced in this PR is a quick-fix. The real fixes would be these listed below:

- `vendor/cmock` submodule is ~9 years stale (2017 pin vs. current `v2.7.0`) —
  filed as a follow-up: [Update `vendor/cmock` submodule](https://github.com/bitcraze/crazyflie-firmware/issues/1704).
- `bitcraze/builder` image ships EOL Ruby 3.0.2, which is why CI never caught this —
  [issue](https://github.com/bitcraze/docker-builder/issues/21) created in `bitcraze/docker-builder` repo

### Verification

- Local, clean tree, Ruby 3.2.3: `make unit UNIT_TEST_STYLE=min` — 44 test files,
  522 tests, 0 failures, 0 ignored, exit 0. No `Psych::AliasesNotEnabled`.
- Scope check: only `tools/test/gcc.yml` changed; no other in-repo consumer of the
  removed anchors.
- Config-equivalence check: parsed YAML structure identical pre/post-fix under both
  loaders that read this file (Unity's and CMock's).
- CI-parity check: reproduced CI's `basic_build` step locally against the
  `bitcraze/builder` image (Ruby 3.0.2) — green pre- and post-fix, confirming the
  change is a no-op for CI.
- Real CI on this PR (run
  [33757385884](https://github.com/bitcraze/crazyflie-firmware/actions/runs/33757385884)):
  all jobs green — `basic_build` (cf2, bolt, tag, flapper, cf21bl), `features`
  (bosch, loco_tdma, loco_tdoa2, loco_tdoa3, loco_tdoa3_all, bigquad, app_api),
  `kbuild-targets` (allyesconfig, allnoconfig), `apps`, `read_targets_from_file`.
