### PR TITLE
Reject TDoA candidates whose remote packet is older than one 32 bit time stamp wrap

### DIFF
--- a/src/modules/src/tdoaEngineInstance.c
+++ b/src/modules/src/tdoaEngineInstance.c
@@ -67,6 +67,12 @@ STATS_CNT_RATE_LOG_ADD(stFound, &tdoaEngineState.stats.suitableDataFound)
 STATS_CNT_RATE_LOG_ADD(stGeometry, &tdoaEngineState.stats.geometryRejected)
 
 /**
+ * @brief Rate of measurement anchor pair candidates that were rejected because the remote
+ * anchor's packet is older than one 32 bit time stamp wrap (67 ms) [1/s]
+ */
+STATS_CNT_RATE_LOG_ADD(stRxWrap, &tdoaEngineState.stats.remoteRxWrapRejected)
+
+/**
  * @brief Rate of packets where the time stamp is used to update the clock correction factor for an anchor [1/s]
  */
 STATS_CNT_RATE_LOG_ADD(stCc, &tdoaEngineState.stats.clockCorrectionCount)

--- a/src/utils/interface/tdoa/tdoaEngine.h
+++ b/src/utils/interface/tdoa/tdoaEngine.h
@@ -48,4 +48,10 @@ static inline uint64_t tdoaEngineTruncateToAnchorTimeStamp(uint64_t fullTimeStam
   return fullTimeStamp & TDOA_ENGINE_TRUNCATE_TO_ANCHOR_TS_BITMAP;
 }
 
+// The tag (DW1000) keeps 40 bit time stamps
+#define TDOA_ENGINE_TRUNCATE_TO_TAG_TS_BITMAP 0xFFFFFFFFFF
+static inline uint64_t tdoaEngineTruncateToTagTimeStamp(uint64_t fullTimeStamp) {
+  return fullTimeStamp & TDOA_ENGINE_TRUNCATE_TO_TAG_TS_BITMAP;
+}
+
 #endif // __TDOA_ENGINE_H__

--- a/src/utils/interface/tdoa/tdoaStats.h
+++ b/src/utils/interface/tdoa/tdoaStats.h
@@ -12,6 +12,7 @@ typedef struct {
   statsCntRateLogger_t timeIsGood;
   statsCntRateLogger_t suitableDataFound;
   statsCntRateLogger_t geometryRejected; // Rate for measurement pairs that were rejected due to bad geometry
+  statsCntRateLogger_t remoteRxWrapRejected; // Rate for measurement pairs that were rejected because the remote anchor packet is older than one 32 bit time stamp wrap
 
   // Anchor ids to use for stats
   uint8_t anchorId; // The id of the anchor to log

--- a/src/utils/src/tdoa/tdoaEngine.c
+++ b/src/utils/src/tdoa/tdoaEngine.c
@@ -136,6 +136,22 @@ static double calcDistanceDiff(const tdoaAnchorContext_t* otherAnchorCtx, const 
   return SPEED_OF_LIGHT * tdoa / locodeckTsFreq;
 }
 
+// Anchors only put 32 bit time stamps on air, so the anchor side gap (txAn - rxAr_by_An) in calcTDoA()
+// is only valid if the anchor transmitted less than one 32 bit wrap (67 ms) after it received the
+// remote anchor's packet. If the remote packet is older than that (the remote anchor went silent,
+// for instance due to packet collisions), the truncated gaps on the tag and anchor side no longer
+// cancel once the anchor side is scaled by the clock correction. The resulting error is
+// 2^32 * (clockCorrection - 1) ticks, that is about 20 m per ppm of clock offset.
+//
+// The tag has 40 bit time stamps, so the tag side gap is unambiguous and can be used to detect
+// the condition. The margin accounts for the difference in flight times seen by the tag and the anchor.
+#define TDOA_ENGINE_REMOTE_RX_MAX_AGE_MARGIN 0x00100000
+static bool isRemoteRxTimeWithinAnchorTsRange(const tdoaAnchorContext_t* otherAnchorCtx, const int64_t rxAn_by_T_in_cl_T) {
+  const int64_t rxAr_by_T_in_cl_T = tdoaStorageGetRxTime(otherAnchorCtx);
+  const uint64_t tagSideGap = tdoaEngineTruncateToTagTimeStamp(rxAn_by_T_in_cl_T - rxAr_by_T_in_cl_T);
+  return tagSideGap < (TDOA_ENGINE_TRUNCATE_TO_ANCHOR_TS_BITMAP - TDOA_ENGINE_REMOTE_RX_MAX_AGE_MARGIN);
+}
+
 static float sq(float a) { return a * a; }
 
 static float distanceBetweenAnchorsSquared(const point_t* a, const point_t* b) {
@@ -197,6 +213,11 @@ TESTABLE_STATIC bool matchRandomAnchor(tdoaEngineState_t* engineState,
     if (!doExcludeId || (excludedId != candidateAnchorId)) {
       if (tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
         if (engineState->matching.seqNr[index] == tdoaStorageGetSeqNr(otherAnchorCtx) && tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
+          if (!isRemoteRxTimeWithinAnchorTsRange(otherAnchorCtx, rxAn_by_T_in_cl_T)) {
+            STATS_CNT_RATE_EVENT(&engineState->stats.remoteRxWrapRejected);
+            continue;
+          }
+
           const double candidateDistanceDiff = calcDistanceDiff(otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, locodeckTsFreq);
           if (!isGeometryGoodEnough(anchorCtx, otherAnchorCtx, candidateDistanceDiff)) {
             STATS_CNT_RATE_EVENT(&engineState->stats.geometryRejected);
@@ -238,6 +259,11 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState,
             uint32_t updateTime = tdoaStorageGetLastUpdateTime(otherAnchorCtx);
             if (updateTime > youngestUpdateTime) {
               if (engineState->matching.seqNr[index] == tdoaStorageGetSeqNr(otherAnchorCtx)) {
+                if (!isRemoteRxTimeWithinAnchorTsRange(otherAnchorCtx, rxAn_by_T_in_cl_T)) {
+                  STATS_CNT_RATE_EVENT(&engineState->stats.remoteRxWrapRejected);
+                  continue;
+                }
+
                 youngestUpdateTime = updateTime;
                 bestId = candidateAnchorId;
               }

--- a/src/utils/src/tdoa/tdoaStats.c
+++ b/src/utils/src/tdoa/tdoaStats.c
@@ -49,6 +49,7 @@ void tdoaStatsInit(tdoaStats_t* tdoaStats, uint32_t now_ms) {
   STATS_CNT_RATE_INIT(&tdoaStats->timeIsGood, STATS_INTERVAL);
   STATS_CNT_RATE_INIT(&tdoaStats->suitableDataFound, STATS_INTERVAL);
   STATS_CNT_RATE_INIT(&tdoaStats->geometryRejected, STATS_INTERVAL);
+  STATS_CNT_RATE_INIT(&tdoaStats->remoteRxWrapRejected, STATS_INTERVAL);
 }
 
 void tdoaStatsUpdate(tdoaStats_t* tdoaStats, uint32_t now_ms) {

--- a/test/utils/src/tdoa/test_tdoaEngine.c
+++ b/test/utils/src/tdoa/test_tdoaEngine.c
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * test_tdoaEngine.c - Unit tests for the anchor pair distance ratio filter in matchRandomAnchor()
+ * test_tdoaEngine.c - Unit tests for the candidate filters in matchRandomAnchor()
  */
 
 // File under test
@@ -60,6 +60,7 @@ static tdoaAnchorContext_t ownAnchorCtx;
 
 static void noopSendTdoaToEstimator(tdoaMeasurement_t* tdoaMeasurement);
 static void fixtureRegisterCandidate(const uint8_t candidateId, const int64_t tof, const bool withPosition);
+static void fixtureRegisterCandidateWithRxTime(const uint8_t candidateId, const int64_t tof, const bool withPosition, const int64_t rxTime);
 
 void setUp(void) {
   tdoaEngineInit(&engineState, NOW_MS, noopSendTdoaToEstimator, LOCODECK_TS_FREQ_FOR_TEST, TdoaEngineMatchingAlgorithmRandom);
@@ -148,6 +149,86 @@ void testThatFalseIsReturnedWhenAllCandidatesFail() {
 }
 
 
+void testThatACandidateReceivedMoreThanOneAnchorTsWrapAgoIsRejected() {
+  // Fixture
+  // The candidate was received by the tag at 0, this packet arrives one full 32 bit wrap + RX_TIMESTAMP later.
+  // Truncated to 32 bits the gap looks like RX_TIMESTAMP, and distanceDiff would be 100 - 95 = 5 and pass the
+  // geometry check. The 40 bit tag time stamps reveal the wrap.
+  const int64_t rxAn_by_T = 0x100000000 + RX_TIMESTAMP;
+  fixtureRegisterCandidateWithRxTime(CANDIDATE_A_ID, 95, true, 0);
+
+  tdoaAnchorContext_t otherAnchorCtx;
+  double distanceDiff = 0.0;
+
+  // Test
+  bool actual = matchRandomAnchor(&engineState, &otherAnchorCtx, &ownAnchorCtx, false, 0, 0, rxAn_by_T, LOCODECK_TS_FREQ_FOR_TEST, &distanceDiff);
+
+  // Assert
+  TEST_ASSERT_FALSE(actual);
+  TEST_ASSERT_NULL(otherAnchorCtx.anchorInfo);
+}
+
+
+void testThatACandidateReceivedJustLessThanOneAnchorTsWrapAgoIsAccepted() {
+  // Fixture
+  // Gap of 0xFFE00000 ticks, below the (2^32 - margin) limit. tof chosen so that distanceDiff = 5.
+  const int64_t rxAn_by_T = 0xFFE00000;
+  fixtureRegisterCandidateWithRxTime(CANDIDATE_A_ID, 0xFFE00000 - 5, true, 0);
+
+  tdoaAnchorContext_t otherAnchorCtx;
+  double distanceDiff = 0.0;
+
+  // Test
+  bool actual = matchRandomAnchor(&engineState, &otherAnchorCtx, &ownAnchorCtx, false, 0, 0, rxAn_by_T, LOCODECK_TS_FREQ_FOR_TEST, &distanceDiff);
+
+  // Assert
+  TEST_ASSERT_TRUE(actual);
+  TEST_ASSERT_EQUAL_UINT8(CANDIDATE_A_ID, tdoaStorageGetId(&otherAnchorCtx));
+  TEST_ASSERT_EQUAL_FLOAT(5.0f, (float)distanceDiff);
+}
+
+
+void testThatTheTagSideGapIsEvaluatedModulo40Bits() {
+  // Fixture
+  // The candidate was received just before the 40 bit tag counter wrapped, this packet just after.
+  // The true gap is 0x200 ticks, distanceDiff = 0x200 - 507 = 5.
+  const int64_t rxAn_by_T = 0x100;
+  fixtureRegisterCandidateWithRxTime(CANDIDATE_A_ID, 507, true, 0xFFFFFFFF00);
+
+  tdoaAnchorContext_t otherAnchorCtx;
+  double distanceDiff = 0.0;
+
+  // Test
+  bool actual = matchRandomAnchor(&engineState, &otherAnchorCtx, &ownAnchorCtx, false, 0, 0, rxAn_by_T, LOCODECK_TS_FREQ_FOR_TEST, &distanceDiff);
+
+  // Assert
+  TEST_ASSERT_TRUE(actual);
+  TEST_ASSERT_EQUAL_UINT8(CANDIDATE_A_ID, tdoaStorageGetId(&otherAnchorCtx));
+  TEST_ASSERT_EQUAL_FLOAT(5.0f, (float)distanceDiff);
+}
+
+
+void testThatAWrappedCandidateIsSkippedInFavorOfTheNextCandidate() {
+  // Fixture
+  const int64_t rxAn_by_T = 0x100000000 + RX_TIMESTAMP;
+  // Registered first, tried second: received RX_TIMESTAMP ticks before this packet, distanceDiff = 5 - passes
+  fixtureRegisterCandidateWithRxTime(CANDIDATE_B_ID, 95, true, 0x100000000);
+  // Registered second, tried first: received one wrap + RX_TIMESTAMP ticks before this packet - rejected
+  fixtureRegisterCandidateWithRxTime(CANDIDATE_A_ID, 95, true, 0);
+
+  tdoaAnchorContext_t otherAnchorCtx;
+  double distanceDiff = 0.0;
+
+  // Test
+  bool actual = matchRandomAnchor(&engineState, &otherAnchorCtx, &ownAnchorCtx, false, 0, 0, rxAn_by_T, LOCODECK_TS_FREQ_FOR_TEST, &distanceDiff);
+
+  // Assert
+  TEST_ASSERT_TRUE(actual);
+  TEST_ASSERT_EQUAL_UINT8(CANDIDATE_B_ID, tdoaStorageGetId(&otherAnchorCtx));
+  TEST_ASSERT_EQUAL_FLOAT(5.0f, (float)distanceDiff);
+}
+
+
 // Helpers ///////////////
 
 static void noopSendTdoaToEstimator(tdoaMeasurement_t* tdoaMeasurement) {
@@ -158,11 +239,16 @@ static void noopSendTdoaToEstimator(tdoaMeasurement_t* tdoaMeasurement) {
 // and time of flight, so it passes the pre-existing matching checks in matchRandomAnchor().
 // The candidate is placed at (ANCHOR_TO_ANCHOR_DISTANCE, 0, 0), ownAnchorCtx is at the origin.
 static void fixtureRegisterCandidate(const uint8_t candidateId, const int64_t tof, const bool withPosition) {
+  fixtureRegisterCandidateWithRxTime(candidateId, tof, withPosition, 0);
+}
+
+// As fixtureRegisterCandidate(), but with an explicit time stamp for when the tag received the candidate's packet
+static void fixtureRegisterCandidateWithRxTime(const uint8_t candidateId, const int64_t tof, const bool withPosition, const int64_t rxTime) {
   const uint8_t seqNr = candidateId;
 
   tdoaAnchorContext_t candidateCtx;
   tdoaStorageGetCreateAnchorCtx(engineState.anchorInfoArray, candidateId, NOW_MS, &candidateCtx);
-  tdoaStorageSetRxTxData(&candidateCtx, 0, 0, seqNr);
+  tdoaStorageSetRxTxData(&candidateCtx, rxTime, 0, seqNr);
   if (withPosition) {
     tdoaStorageSetAnchorPosition(&candidateCtx, ANCHOR_TO_ANCHOR_DISTANCE, 0.0f, 0.0f);
   }


### PR DESCRIPTION
## Problem

TDoA3 logs from a 16 anchor system showed gross distance difference outliers of 25 to 100 m in about 8% of candidates. For each transmitting anchor the error was always the same step (for instance −93.5 m for anchor 6 and −41.5 m for anchor 2),  sometimes twice that step, and it only appeared when the remote anchor's packet was 67 ms or more old.

## Cause

A TDoA candidate pairs the packet just received from the transmitting anchor (An) with an earlier packet from a remote anchor (Ar). `calcTDoA()` computes two differences:
- `(txAn - rxAr_by_An)`: how long An waited between receiving Ar's packet and transmitting its own, in An's clock. Both time stamps are in An's packet.
- `(rxAn_by_T - rxAr_by_T)`: how long it was between the tag receiving Ar's packet and receiving An's packet, in the tag's clock.

It adds the Ar→An time of flight to the first difference, converts the result to tag ticks by multiplying it with the clock correction (the two clocks run a few ppm apart), and subtracts it from the second. What remains is how much longer An's packet took to reach the tag than Ar's packet, which is the TDoA.

Anchors only put 32 bit time stamps on air, so both differences are truncated to 32 bits and wrap every 2^32 ticks (67 ms). A candidate is only used if An and the tag hold the same latest packet from Ar (matching sequence numbers). That shared packet gets older with every packet from Ar that both miss, for instance due to packet collisions. Depending on the anchors' transmit rate, a single packet missed by both can be enough to make it more than 67 ms old, and both differences then come out 2^32 ticks too small.

If it were not for the clock correction, the two errors would cancel. But (txAn - rxAr_by_An) is multiplied by the clock correction before it is subtracted, so its error becomes 2^32 · clockCorrection ticks instead of 2^32. The two errors then differ by 2^32 · (clockCorrection − 1) ticks, and that is what ends up in the TDoA.

Light travels about 4.69 mm per tick (the tick rate is 499.2 MHz · 128), so one ppm of clock offset gives an error of about 20 m. This matches what the logs show. The step is fixed per transmitting anchor because its clock offset is, two missed wraps give twice the step, and the observed steps correspond to ordinary clock offsets of 0.6 to 4.6 ppm.

The existing checks do not catch this:
- The sequence number check passes, since An and the tag really do hold the same packet.
- The 30 ms remote data validity looks like it should reject old packets, but it limits how old An's report is, not how old Ar's packet is. If An keeps reporting the same packet from Ar, the entry stays valid even when that packet is more than 67 ms old.
- The clock correction check only verifies that An's clock correction is reliable, based on An's own consecutive packets. In this failure the clock correction is correct, and the check never looks at how old Ar's packet is.
- The (new) geometry check and the outlier filter's physical bound remove the largest errors. But a 12 to 25 m error from an anchor with a small clock offset on a 30 m anchor pair stays below the geometry limit (0.85 × 30 m = 25.5 m), and passes when the outlier filter is open.

## Fix

The tag keeps 40 bit time stamps, so `(rxAn_by_T - rxAr_by_T)` only wraps every 17.2 s and can be used to detect this. A candidate is skipped, the same way a candidate with bad geometry is skipped, when this difference is one 32 bit wrap minus a margin or more. In practice: when the tag received An's packet 67.2 ms or more after the Ar packet it would be paired with.

The margin is needed because if An's clock runs faster than the tag's, An's count can reach one wrap slightly before the tag's does. The margin, 2^20 ticks (16 µs), is well above the difference caused by clock offset, 1.34 µs at the 20 ppm clock offset limit in `clockCorrectionEngine.c`.

The check is applied in both `matchRandomAnchor()` and `matchYoungestAnchor()`. The rejection rate is logged as `tdoaEngine.stRxWrap`, next to `stGeometry`.

## Verification
- Unit tests for the check: a difference of one wrap is rejected, a difference just below the limit is accepted, the difference is still correct when the tag's 40 bit counter rolls over between the two receptions, and a wrapped candidate is skipped in favor of the next one.
- On a Crazyflie at rest in a Loco system, `stRxWrap` fires at about 2 per second out of 148 received packets per second, with the position estimate steady.
- In the logged flight, every candidate with an error of 25 to 100 m had a remote packet older than one wrap, so the check removes that whole band. Wrap errors can also be smaller (about 12 m for the anchor with the smallest clock offset) and are removed too, but below 25 m there are also outliers with other causes, which this PR does not address.