### PR TITLE
Fix thrust limits in RPYT commander

### DIFF
--- a/docs/functional-areas/crtp/crtp_commander.md
+++ b/docs/functional-areas/crtp/crtp_commander.md
@@ -39,12 +39,9 @@ cycle, which is not linear in thrust and dependent on battery voltage.
   is disabled, non-zero thrust is ignored until a packet with thrust 0
   has been received. This prevents the motors from starting on a stale
   or unintended set-point.
-* **Lower bound.** Thrust values below `MIN_THRUST` (7000) are treated as
-  zero. The value is `THRUST_MIN / THRUST_MAX * UINT16_MAX` from
-  `platform_defaults_cf2.h` and marks the point below which the measured
-  thrust curves are too noisy to be useful. When
-  `CONFIG_ENABLE_THRUST_BAT_COMPENSATED` is enabled (default), the same limit is
-  applied again per motor in the battery compensation.
+* **Lower bound.** Thrust values below `MIN_THRUST` are treated as zero. 
+  If `CONFIG_ENABLE_THRUST_BAT_COMPENSATED` is enabled (default), the limit 
+  is computed by `THRUST_MIN / THRUST_MAX * UINT16_MAX`.
 * **Upper bound.** There is no clipping in the commander. The per-motor
   output is capped to the PWM range in the power distribution.
 
@@ -63,16 +60,7 @@ interpreted.
 
 ## Example
 
-Using the python library, send thrust 0 once to unlock, then stream
-set-points:
-
-```python
-cf.commander.send_setpoint(0, 0, 0, 0)
-for _ in range(100):
-    cf.commander.send_setpoint(0.0, 0.0, 0.0, 30000)
-    time.sleep(0.01)
-cf.commander.send_setpoint(0, 0, 0, 0)
-```
+**[ramp.py](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/scripts/cflib/motors/ramp)**: Sends low-level roll/pitch/yaw/thrust set-points directly using the Commander class, ramping thrust up and down.
 
 Set-points must be sent continuously, see the watchdog timeouts in the
 [commander framework](/docs/functional-areas/sensor-to-control/commanders_setpoints.md).

--- a/docs/functional-areas/crtp/crtp_commander.md
+++ b/docs/functional-areas/crtp/crtp_commander.md
@@ -6,7 +6,8 @@ page_id: crtp_commander
 The commander port is used to send control set-points for the
 roll/pitch/yaw/thrust regulators from the host to the Crazyflie. As soon
 as the communication link has been established these packets can be sent
-and the values are valid until the next packet is received.
+and the values are valid until the next packet is received. The packets
+are decoded in `src/modules/src/crtp_commander_rpyt.c`.
 
 ## Communication protocol
 
@@ -17,7 +18,61 @@ and the values are valid until the next packet is received.
 
 |  Name    | Byte  |  Size  | Type       | Comment|
 |  --------| -------| ------| -----------| ----------------------|
-|  ROLL    | 0-3    | 4     | float      | The pitch set-point|
-|  PITCH   | 4-7    | 4     | float      | The roll set-point|
-|  YAW     | 8-11   | 4     | float      | The yaw set-point|
-|  THRUST  | 12-13  | 2     | uint16\_t  | The thrust set-point|
+|  ROLL    | 0-3    | 4     | float      | Roll set-point, degrees (angle mode) or degrees/s (rate mode)|
+|  PITCH   | 4-7    | 4     | float      | Pitch set-point, degrees (angle mode) or degrees/s (rate mode)|
+|  YAW     | 8-11   | 4     | float      | Yaw set-point, degrees/s (rate mode, default) or degrees (angle mode)|
+|  THRUST  | 12-13  | 2     | uint16\_t  | Thrust set-point, 0 - 65535|
+
+In rate mode the yaw value is negated on reception, so a positive value
+rotates the Crazyflie clockwise seen from above.
+
+## Thrust
+
+The thrust field is passed to the controller as a 16 bit value. With
+`CONFIG_ENABLE_THRUST_BAT_COMPENSATED` enabled it is linear in force: a
+motor commanded with value `t` produces `t / UINT16_MAX * THRUST_MAX`
+newtons (see `platform_defaults_cf2.h`), independent of battery voltage.
+Without battery compensation the value is used directly as PWM duty
+cycle, which is not linear in thrust and dependent on battery voltage.
+
+* **Thrust lock.** After connecting, and whenever the commander priority
+  is disabled, non-zero thrust is ignored until a packet with thrust 0
+  has been received. This prevents the motors from starting on a stale
+  or unintended set-point.
+* **Lower bound.** Thrust values below `MIN_THRUST` (7000) are treated as
+  zero. The value is `THRUST_MIN / THRUST_MAX * UINT16_MAX` from
+  `platform_defaults_cf2.h` and marks the point below which the measured
+  thrust curves are too noisy to be useful. When
+  `CONFIG_ENABLE_THRUST_BAT_COMPENSATED` is enabled (default), the same limit is
+  applied again per motor in the battery compensation.
+* **Upper bound.** There is no clipping in the commander. The per-motor
+  output is capped to the PWM range in the power distribution.
+
+## Flight modes
+
+The `flightmode` parameter group changes how the four fields are
+interpreted.
+
+| Parameter | Effect |
+| --------- | ------ |
+| `stabModeRoll`, `stabModePitch`, `stabModeYaw` | 0: rate control, 1: angle control. Defaults are angle for roll/pitch and rate for yaw. |
+| `althold` | Thrust becomes a vertical velocity set-point centred at 32767; roll/pitch/yaw unchanged. |
+| `poshold` | Roll and pitch become Y and X velocity set-points (value / 30 m/s); thrust as above. |
+| `posSet` | Roll, pitch and thrust become absolute Y, X (m) and Z (thrust / 1000 m) positions, yaw becomes an absolute angle. |
+| `yawMode` | Frame used for roll/pitch in yaw rate mode: 1 plus-mode, 2 x-mode (default). |
+
+## Example
+
+Using the python library, send thrust 0 once to unlock, then stream
+set-points:
+
+```python
+cf.commander.send_setpoint(0, 0, 0, 0)
+for _ in range(100):
+    cf.commander.send_setpoint(0.0, 0.0, 0.0, 30000)
+    time.sleep(0.01)
+cf.commander.send_setpoint(0, 0, 0, 0)
+```
+
+Set-points must be sent continuously, see the watchdog timeouts in the
+[commander framework](/docs/functional-areas/sensor-to-control/commanders_setpoints.md).

--- a/src/modules/src/crtp_commander_rpyt.c
+++ b/src/modules/src/crtp_commander_rpyt.c
@@ -34,12 +34,14 @@
 #include "FreeRTOS.h"
 #include "num.h"
 #include "position_controller.h"
+#include "platform_defaults.h"
 
-// Thrust below this is treated as zero. 7000 = THRUST_MIN / THRUST_MAX * UINT16_MAX
-// (platform_defaults_cf2.h); below it the measured thrust curves are too noisy.
-// With CONFIG_ENABLE_THRUST_BAT_COMPENSATED, motorsCompensateBatteryVoltage()
-// clips per motor at THRUST_MIN anyway. Literal so it also works without it.
-#define MIN_THRUST  7000
+// Thrust below MIN_THRUST is treated as zero
+#ifdef CONFIG_ENABLE_THRUST_BAT_COMPENSATED
+  #define MIN_THRUST ((uint16_t)(THRUST_MIN / THRUST_MAX * UINT16_MAX))
+#else
+  #define MIN_THRUST 1000
+#endif
 
 /**
  * CRTP commander rpyt packet format

--- a/src/modules/src/crtp_commander_rpyt.c
+++ b/src/modules/src/crtp_commander_rpyt.c
@@ -35,8 +35,13 @@
 #include "num.h"
 #include "position_controller.h"
 
-#define MIN_THRUST  1000
-#define MAX_THRUST  60000
+// Lower bound below which the thrust setpoint is treated as zero. The 7000 is
+// THRUST_MIN / THRUST_MAX * UINT16_MAX (see platform_defaults_cf2.h), i.e. the
+// point below which the measured thrust curves become too noisy to trust the
+// battery compensation fit. Kept as a literal so it also applies when
+// CONFIG_ENABLE_THRUST_BAT_COMPENSATED is off and THRUST_MIN is undefined.
+#define MIN_THRUST  7000
+#define MAX_THRUST  UINT16_MAX  // Full PWM range
 
 /**
  * CRTP commander rpyt packet format

--- a/src/modules/src/crtp_commander_rpyt.c
+++ b/src/modules/src/crtp_commander_rpyt.c
@@ -35,13 +35,11 @@
 #include "num.h"
 #include "position_controller.h"
 
-// Lower bound below which the thrust setpoint is treated as zero. The 7000 is
-// THRUST_MIN / THRUST_MAX * UINT16_MAX (see platform_defaults_cf2.h), i.e. the
-// point below which the measured thrust curves become too noisy to trust the
-// battery compensation fit. Kept as a literal so it also applies when
-// CONFIG_ENABLE_THRUST_BAT_COMPENSATED is off and THRUST_MIN is undefined.
+// Thrust below this is treated as zero. 7000 = THRUST_MIN / THRUST_MAX * UINT16_MAX
+// (platform_defaults_cf2.h); below it the measured thrust curves are too noisy.
+// With CONFIG_ENABLE_THRUST_BAT_COMPENSATED, motorsCompensateBatteryVoltage()
+// clips per motor at THRUST_MIN anyway. Literal so it also works without it.
 #define MIN_THRUST  7000
-#define MAX_THRUST  UINT16_MAX  // Full PWM range
 
 /**
  * CRTP commander rpyt packet format
@@ -140,7 +138,7 @@ void crtpCommanderRpytDecodeSetpoint(setpoint_t *setpoint, CRTPPacket *pk)
   if (thrustLocked || (rawThrust < MIN_THRUST)) {
     setpoint->thrust = 0;
   } else {
-    setpoint->thrust = fminf(rawThrust, MAX_THRUST);
+    setpoint->thrust = rawThrust;
   }
 
   if (altHoldMode) {


### PR DESCRIPTION
The RPYT commander uses some arbitrary upper thrust limit. The user expects the thrust to be linear between PWM_MIN and PWM_MAX (7000, 65535), so there shouldn't be an upper limit. The lower limit was 1000 before, fixed it to 7000. I've fixed the commander accordingly and added some documentation.